### PR TITLE
Migrate semaphore effects into Rust scheduler

### DIFF
--- a/doeff/effects/semaphore.py
+++ b/doeff/effects/semaphore.py
@@ -1,35 +1,17 @@
 from __future__ import annotations
 
-from collections import deque
-from dataclasses import dataclass, field
-from itertools import count
-from typing import Any
-
-import doeff_vm
+from dataclasses import dataclass
 
 from .base import Effect, EffectBase, create_effect_with_trace
-from .promise import CompletePromise, CreatePromise
-from .wait import Wait
-
-
-@dataclass(slots=True)
-class _SemaphoreWaiter:
-    promise: Any
-    cancelled: bool = False
-    granted: bool = False
-
-
-@dataclass(slots=True)
-class _SemaphoreState:
-    max_permits: int
-    available_permits: int
-    waiters: deque[_SemaphoreWaiter] = field(default_factory=deque)
 
 
 @dataclass(frozen=True, slots=True)
 class Semaphore:
     id: int
-    _state: _SemaphoreState = field(repr=False, compare=False, hash=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, int):
+            raise TypeError(f"id must be int, got {type(self.id).__name__}")
 
 
 @dataclass(frozen=True)
@@ -61,93 +43,6 @@ class ReleaseSemaphoreEffect(EffectBase):
             raise TypeError(f"semaphore must be Semaphore, got {type(self.semaphore).__name__}")
 
 
-_SEMAPHORE_ID_COUNTER = count(1)
-
-
-def _drop_cancelled_head_waiters(state: _SemaphoreState) -> None:
-    while state.waiters and state.waiters[0].cancelled:
-        state.waiters.popleft()
-
-
-def _remove_waiter(state: _SemaphoreState, target: _SemaphoreWaiter) -> bool:
-    try:
-        state.waiters.remove(target)
-        return True
-    except ValueError:
-        return False
-
-
-def _release_one(semaphore: Semaphore):
-    state = semaphore._state
-
-    while state.waiters:
-        waiter = state.waiters.popleft()
-        if waiter.cancelled:
-            continue
-        waiter.granted = True
-        yield CompletePromise(waiter.promise, None)
-        return
-
-    if state.available_permits >= state.max_permits:
-        raise RuntimeError("semaphore released too many times")
-
-    state.available_permits += 1
-
-
-def _handle_create_semaphore(effect: CreateSemaphoreEffect, k: Any):
-    sem = Semaphore(
-        id=next(_SEMAPHORE_ID_COUNTER),
-        _state=_SemaphoreState(
-            max_permits=effect.permits,
-            available_permits=effect.permits,
-        ),
-    )
-    return (yield doeff_vm.Resume(k, sem))
-
-
-def _handle_acquire_semaphore(effect: AcquireSemaphoreEffect, k: Any):
-    semaphore = effect.semaphore
-    state = semaphore._state
-
-    _drop_cancelled_head_waiters(state)
-    if state.available_permits > 0 and not state.waiters:
-        state.available_permits -= 1
-        return (yield doeff_vm.Resume(k, None))
-
-    waiter_promise = yield CreatePromise()
-    waiter = _SemaphoreWaiter(promise=waiter_promise)
-    state.waiters.append(waiter)
-
-    try:
-        _ = yield Wait(waiter_promise.future)
-    except BaseException:
-        waiter.cancelled = True
-        removed = _remove_waiter(state, waiter)
-        if not removed and waiter.granted:
-            yield from _release_one(semaphore)
-        raise
-
-    return (yield doeff_vm.Resume(k, None))
-
-
-def _handle_release_semaphore(effect: ReleaseSemaphoreEffect, k: Any):
-    yield from _release_one(effect.semaphore)
-    return (yield doeff_vm.Resume(k, None))
-
-
-def _with_semaphore_handlers(program: Any) -> Any:
-    from doeff.rust_vm import wrap_with_handler_map
-
-    return wrap_with_handler_map(
-        program,
-        {
-            CreateSemaphoreEffect: _handle_create_semaphore,
-            AcquireSemaphoreEffect: _handle_acquire_semaphore,
-            ReleaseSemaphoreEffect: _handle_release_semaphore,
-        },
-    )
-
-
 def create_semaphore(permits: int) -> CreateSemaphoreEffect:
     return create_effect_with_trace(CreateSemaphoreEffect(permits=permits))
 
@@ -160,22 +55,16 @@ def release_semaphore(semaphore: Semaphore) -> ReleaseSemaphoreEffect:
     return create_effect_with_trace(ReleaseSemaphoreEffect(semaphore=semaphore))
 
 
-def CreateSemaphore(permits: int) -> Effect:
-    return _with_semaphore_handlers(
-        create_effect_with_trace(CreateSemaphoreEffect(permits=permits), skip_frames=3)
-    )
+def CreateSemaphore(permits: int) -> Effect:  # noqa: N802
+    return create_effect_with_trace(CreateSemaphoreEffect(permits=permits), skip_frames=3)
 
 
-def AcquireSemaphore(semaphore: Semaphore) -> Effect:
-    return _with_semaphore_handlers(
-        create_effect_with_trace(AcquireSemaphoreEffect(semaphore=semaphore), skip_frames=3)
-    )
+def AcquireSemaphore(semaphore: Semaphore) -> Effect:  # noqa: N802
+    return create_effect_with_trace(AcquireSemaphoreEffect(semaphore=semaphore), skip_frames=3)
 
 
-def ReleaseSemaphore(semaphore: Semaphore) -> Effect:
-    return _with_semaphore_handlers(
-        create_effect_with_trace(ReleaseSemaphoreEffect(semaphore=semaphore), skip_frames=3)
-    )
+def ReleaseSemaphore(semaphore: Semaphore) -> Effect:  # noqa: N802
+    return create_effect_with_trace(ReleaseSemaphoreEffect(semaphore=semaphore), skip_frames=3)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Move semaphore effect dispatch/handling into Rust scheduler (`packages/doeff-vm/src/scheduler.rs`).
- Simplify `doeff/effects/semaphore.py` to thin effect constructors + `Semaphore(id)` handle type.
- Add cancellation interaction regression test in `tests/effects/test_semaphore.py`.

## Issue
- Ref: ISSUE-CORE-498

## Acceptance Criteria Evidence

### AC-1: `parse_scheduler_python_effect()` recognizes all 3 semaphore effects
- Added parser branches for `CreateSemaphoreEffect`, `AcquireSemaphoreEffect`, `ReleaseSemaphoreEffect` in `packages/doeff-vm/src/scheduler.rs`.
- Evidence (grep): parser branches at lines around 426, 438, 444.

### AC-2: Semaphore state managed in Rust scheduler
- Added `SemaphoreRuntimeState` and semaphore registry + waiter queue in `SchedulerState` (`packages/doeff-vm/src/scheduler.rs`).
- Added Rust methods `create_semaphore`, `acquire_semaphore`, `release_semaphore`, FIFO waiter handling, over-release check, and cancellation-aware waiter cleanup.

### AC-3: `semaphore.py` has no `wrap_with_handler_map`; uppercase constructors are thin wrappers
- `doeff/effects/semaphore.py` now only defines dataclasses and constructor helpers with `create_effect_with_trace(...)`.
- `wrap_with_handler_map` usage removed.

### AC-4: No module-level global counter
- Removed `_SEMAPHORE_ID_COUNTER` from Python.
- Added `next_semaphore` allocator in Rust scheduler state.

### AC-5: Cancel interaction test passes
- Added `test_cancelled_waiter_is_removed_and_order_is_preserved` in `tests/effects/test_semaphore.py`.
- Verified passing in semaphore test run.

### AC-6: Existing semaphore tests still pass
- Command: `uv run pytest tests/effects/test_semaphore.py -v`
- Result: `10 passed`.

### AC-7: Lint on changed files
- `uv run ruff check doeff/effects/semaphore.py tests/effects/test_semaphore.py` -> pass.
- `uv run pyright doeff/effects/semaphore.py tests/effects/test_semaphore.py` -> `0 errors`.
- `uv run semgrep --config .semgrep.yaml doeff/effects/semaphore.py tests/effects/test_semaphore.py packages/doeff-vm/src/scheduler.rs` -> `0 findings`.

## Validation Commands Run
- `uv run maturin develop --manifest-path packages/doeff-vm/Cargo.toml`
- `uv run pytest tests/effects/test_semaphore.py -v` (pass)
- `uv run pytest tests/ -q` (1 existing failure outside semaphore scope)
- `make lint` (repository-wide existing lint debt; non-targeted)
