### PR TITLE
ISSUE-CORE-503: remove HashableAskEffect and add Rust-native hashable Reader/Local

### DIFF
--- a/doeff/effects/reader.py
+++ b/doeff/effects/reader.py
@@ -1,4 +1,4 @@
-"""Reader monad effects (Rust-backed core ask effect)."""
+"""Reader monad effects (Rust-backed Ask/Local effects)."""
 
 from __future__ import annotations
 
@@ -19,13 +19,6 @@ AskEffect = doeff_vm.PyAsk
 
 
 @dataclass(frozen=True)
-class HashableAskEffect(EffectBase):
-    """Reader lookup effect that preserves non-string hashable keys."""
-
-    key: EnvKey
-
-
-@dataclass(frozen=True)
 class LocalEffect(EffectBase):
     """Runs a sub-program against an updated environment and yields its value."""
 
@@ -39,89 +32,32 @@ class LocalEffect(EffectBase):
 
 def ask(key: EnvKey) -> Effect:
     ensure_hashable(key, name="key")
-    if isinstance(key, str):
-        return create_effect_with_trace(AskEffect(key))
-    return create_effect_with_trace(HashableAskEffect(key=key))
-
-
-def _build_local_overlay(env_update: Mapping[Any, object]) -> dict[Any, object]:
-    overlay: dict[Any, object] = {}
-    for key, value in env_update.items():
-        overlay[key] = value
-        if not isinstance(key, str):
-            overlay[str(key)] = value
-    return overlay
-
-
-def _is_lazy_program_value(value: object) -> bool:
-    do_expr = getattr(doeff_vm, "DoExpr", None)
-    if do_expr is not None and isinstance(value, do_expr):
-        return True
-
-    effect_base = getattr(doeff_vm, "EffectBase", None)
-    if effect_base is not None and isinstance(value, effect_base):
-        return True
-
-    if bool(getattr(value, "__doeff_do_expr_base__", False)):
-        return True
-
-    return bool(getattr(value, "__doeff_effect_base__", False))
-
-
-def _build_local_handler(overlay: dict[Any, object]):
-    lazy_cache: dict[Any, object] = {}
-
-    def handle_local_ask(effect, k):
-        key: Any | None = None
-        if isinstance(effect, AskEffect):
-            key = effect.key
-        elif isinstance(effect, HashableAskEffect):
-            key = effect.key
-
-        if key is not None and key in overlay:
-            if key in lazy_cache:
-                return (yield doeff_vm.Resume(k, lazy_cache[key]))
-
-            value = overlay[key]
-            if _is_lazy_program_value(value):
-                resolved = yield value
-                lazy_cache[key] = resolved
-                return (yield doeff_vm.Resume(k, resolved))
-
-            return (yield doeff_vm.Resume(k, value))
-
-        return (yield doeff_vm.Delegate())
-
-    return handle_local_ask
+    return create_effect_with_trace(AskEffect(key))
 
 
 def local(env_update: Mapping[Any, object], sub_program: ProgramLike):
     ensure_env_mapping(env_update, name="env_update")
     ensure_program_like(sub_program, name="sub_program")
-
-    overlay = _build_local_overlay(env_update)
-    return doeff_vm.WithHandler(_build_local_handler(overlay), sub_program)
+    return create_effect_with_trace(LocalEffect(env_update=env_update, sub_program=sub_program))
 
 
 def Ask(key: EnvKey) -> Effect:
     ensure_hashable(key, name="key")
-    if isinstance(key, str):
-        return create_effect_with_trace(AskEffect(key), skip_frames=3)
-    return create_effect_with_trace(HashableAskEffect(key=key), skip_frames=3)
+    return create_effect_with_trace(AskEffect(key), skip_frames=3)
 
 
 def Local(env_update: Mapping[Any, object], sub_program: ProgramLike) -> Effect:
     ensure_env_mapping(env_update, name="env_update")
     ensure_program_like(sub_program, name="sub_program")
-
-    overlay = _build_local_overlay(env_update)
-    return doeff_vm.WithHandler(_build_local_handler(overlay), sub_program)
+    return create_effect_with_trace(
+        LocalEffect(env_update=env_update, sub_program=sub_program),
+        skip_frames=3,
+    )
 
 
 __all__ = [
     "Ask",
     "AskEffect",
-    "HashableAskEffect",
     "Local",
     "LocalEffect",
     "ask",

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -61,7 +61,7 @@ def _run_call_kwargs(
     run_fn: Any,
     *,
     handlers: Sequence[Any],
-    env: dict[str, Any] | None,
+    env: dict[Any, Any] | None,
     store: dict[str, Any] | None,
     trace: bool,
 ) -> dict[str, Any]:
@@ -87,18 +87,12 @@ def _run_call_kwargs(
     return kwargs
 
 
-def _normalize_env(env: dict[Any, Any] | None) -> dict[str, Any] | None:
+def _normalize_env(env: dict[Any, Any] | None) -> dict[Any, Any] | None:
     if env is None:
         return None
     if not isinstance(env, dict):
         raise TypeError(f"env must be a dict, got {type(env).__name__}")
-    normalized: dict[str, Any] = {}
-    for key, value in env.items():
-        if isinstance(key, str):
-            normalized[key] = value
-        else:
-            normalized[str(key)] = value
-    return normalized
+    return dict(env)
 
 
 def _is_unexpected_trace_keyword(exc: TypeError) -> bool:

--- a/packages/doeff-pinjected/src/doeff_pinjected/bridge.py
+++ b/packages/doeff-pinjected/src/doeff_pinjected/bridge.py
@@ -83,39 +83,15 @@ def program_to_injected(prog: Program[T]) -> Injected[T]:
     """
 
     async def _runner(__resolver__: AsyncResolver) -> T:
-        use_local_passthrough = not _supports_program_intercept(prog)
-        original_build_local_handler = None
-
-        if use_local_passthrough:
-            import doeff_vm
-
-            from doeff.effects import reader as reader_effects
-
-            original_build_local_handler = reader_effects._build_local_handler
-
-            def _bridge_build_local_handler(_overlay: dict):
-                def handle_local_ask(_effect, _k):
-                    yield doeff_vm.Delegate()
-
-                return handle_local_ask
-
-            reader_effects._build_local_handler = _bridge_build_local_handler
-
         # Create wrapped program that handles dependency resolution
         wrapped_program = _program_with_dependency_interception(prog, __resolver__)
 
-        try:
-            # Run with env containing the resolver for use by ask effects
-            result = await async_run_with_handler_map(
-                wrapped_program,
-                production_handlers(resolver=__resolver__),
-                env={"__resolver__": __resolver__},
-            )
-        finally:
-            if use_local_passthrough and original_build_local_handler is not None:
-                from doeff.effects import reader as reader_effects
-
-                reader_effects._build_local_handler = original_build_local_handler
+        # Run with env containing the resolver for use by ask effects
+        result = await async_run_with_handler_map(
+            wrapped_program,
+            production_handlers(resolver=__resolver__),
+            env={"__resolver__": __resolver__},
+        )
 
         # Handle the result
         if result.is_err():
@@ -158,39 +134,15 @@ def program_to_injected_result(prog: Program[T]) -> Injected[RunResult[T]]:
     """
 
     async def _runner(__resolver__: AsyncResolver) -> RunResult[T]:
-        use_local_passthrough = not _supports_program_intercept(prog)
-        original_build_local_handler = None
-
-        if use_local_passthrough:
-            import doeff_vm
-
-            from doeff.effects import reader as reader_effects
-
-            original_build_local_handler = reader_effects._build_local_handler
-
-            def _bridge_build_local_handler(_overlay: dict):
-                def handle_local_ask(_effect, _k):
-                    yield doeff_vm.Delegate()
-
-                return handle_local_ask
-
-            reader_effects._build_local_handler = _bridge_build_local_handler
-
         # Create wrapped program that handles dependency resolution
         wrapped_program = _program_with_dependency_interception(prog, __resolver__)
 
-        try:
-            # Run with env containing the resolver for use by ask effects
-            result = await async_run_with_handler_map(
-                wrapped_program,
-                production_handlers(resolver=__resolver__),
-                env={"__resolver__": __resolver__},
-            )
-        finally:
-            if use_local_passthrough and original_build_local_handler is not None:
-                from doeff.effects import reader as reader_effects
-
-                reader_effects._build_local_handler = original_build_local_handler
+        # Run with env containing the resolver for use by ask effects
+        result = await async_run_with_handler_map(
+            wrapped_program,
+            production_handlers(resolver=__resolver__),
+            env={"__resolver__": __resolver__},
+        )
 
         # Return the full RunResult with both context and result
         return result

--- a/packages/doeff-vm/src/effect.rs
+++ b/packages/doeff-vm/src/effect.rs
@@ -38,7 +38,7 @@ pub struct PyModify {
 #[pyclass(frozen, name = "PyAsk", extends=PyEffectBase)]
 pub struct PyAsk {
     #[pyo3(get)]
-    pub key: String,
+    pub key: Py<PyAny>,
 }
 
 #[pyclass(frozen, name = "PyTell", extends=PyEffectBase)]
@@ -145,7 +145,7 @@ impl PyModify {
 #[pymethods]
 impl PyAsk {
     #[new]
-    fn new(key: String) -> PyClassInitializer<Self> {
+    fn new(key: Py<PyAny>) -> PyClassInitializer<Self> {
         PyClassInitializer::from(PyEffectBase {
             tag: DoExprTag::Effect as u8,
         })

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -12,16 +12,17 @@
 pub mod arena;
 pub mod capture;
 pub mod continuation;
-mod effect;
 pub mod dispatch;
 pub mod do_ctrl;
 pub mod driver;
+mod effect;
 pub mod error;
 pub mod frame;
 mod handler;
 pub mod ids;
-pub mod python_call;
+pub mod py_env_key;
 pub mod py_shared;
+pub mod python_call;
 pub mod pyvm;
 pub mod rust_store;
 pub mod scheduler;
@@ -34,8 +35,7 @@ pub mod yielded;
 // Re-exports for convenience
 pub use arena::SegmentArena;
 pub use capture::{
-    CaptureEvent, DelegationEntry, DispatchAction, FrameId, HandlerAction, HandlerKind,
-    TraceEntry,
+    CaptureEvent, DelegationEntry, DispatchAction, FrameId, HandlerAction, HandlerKind, TraceEntry,
 };
 pub use continuation::Continuation;
 pub use dispatch::DispatchContext;
@@ -48,11 +48,12 @@ pub use handler::{
     Handler, HandlerEntry, ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
 };
 pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
-pub use pyvm::{DoExprTag, PyStdlib, PyVM};
+pub use py_env_key::PyEnvKey;
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
+pub use pyvm::{DoExprTag, PyStdlib, PyVM};
 pub use rust_store::RustStore;
 pub use segment::{Segment, SegmentKind};
 pub use step::PyException;
-pub use yielded::Yielded;
 pub use value::Value;
 pub use vm::{Callback, VM};
+pub use yielded::Yielded;

--- a/packages/doeff-vm/src/py_env_key.rs
+++ b/packages/doeff-vm/src/py_env_key.rs
@@ -1,0 +1,74 @@
+//! Hash-preserving Python environment key wrapper.
+
+use std::hash::{Hash, Hasher};
+
+use pyo3::prelude::*;
+#[cfg(test)]
+use pyo3::types::PyString;
+
+use crate::py_shared::PyShared;
+
+/// HashMap key wrapper that preserves Python hash/eq semantics.
+///
+/// - `hash` is computed once from Python `hash(key)` at construction.
+/// - `Eq` uses Python `__eq__` for collision resolution.
+#[derive(Debug, Clone)]
+pub struct PyEnvKey {
+    object: PyShared,
+    hash: isize,
+    repr: String,
+}
+
+impl PyEnvKey {
+    pub fn from_bound(key: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let hash = key.hash()?;
+        let repr = key.repr()?.to_string_lossy().into_owned();
+        Ok(PyEnvKey {
+            object: PyShared::new(key.clone().unbind()),
+            hash,
+            repr,
+        })
+    }
+
+    pub fn from_object(key: Py<PyAny>) -> PyResult<Self> {
+        Python::attach(|py| Self::from_bound(key.bind(py)))
+    }
+
+    pub fn clone_object(&self, py: Python<'_>) -> Py<PyAny> {
+        self.object.clone_ref(py)
+    }
+
+    pub fn repr(&self) -> &str {
+        &self.repr
+    }
+
+    #[cfg(test)]
+    pub fn from_str(key: &str) -> Self {
+        Python::attach(|py| {
+            let py_key = PyString::new(py, key).into_any();
+            Self::from_bound(&py_key).expect("string keys are hashable")
+        })
+    }
+}
+
+impl Hash for PyEnvKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
+    }
+}
+
+impl PartialEq for PyEnvKey {
+    fn eq(&self, other: &Self) -> bool {
+        if self.hash != other.hash {
+            return false;
+        }
+
+        Python::attach(|py| {
+            let lhs = self.object.bind(py);
+            let rhs = other.object.bind(py);
+            lhs.eq(rhs).unwrap_or(false)
+        })
+    }
+}
+
+impl Eq for PyEnvKey {}

--- a/tests/misc/test_reader_hashable_keys.py
+++ b/tests/misc/test_reader_hashable_keys.py
@@ -5,6 +5,8 @@ from typing import Protocol
 import pytest
 
 from doeff import Local, ask, do
+from doeff.effects.reader import AskEffect
+from doeff.rust_vm import default_handlers, run as vm_run
 from doeff.types import EffectGenerator
 
 
@@ -32,3 +34,58 @@ async def test_reader_accepts_hashable_class_keys(interpreter) -> None:
 def test_ask_rejects_unhashable_keys() -> None:
     with pytest.raises(TypeError, match=r"key must be hashable"):
         ask([])  # type: ignore[arg-type]
+
+
+def test_ask_uses_single_effect_type_for_hashable_keys() -> None:
+    effect = ask(SomeFunc)
+    assert isinstance(effect, AskEffect)
+    assert effect.key is SomeFunc
+
+
+class ServiceA:
+    def __str__(self) -> str:
+        return "Service"
+
+    def __hash__(self) -> int:
+        return 1
+
+
+class ServiceB:
+    def __str__(self) -> str:
+        return "Service"
+
+    def __hash__(self) -> int:
+        return 2
+
+
+@pytest.mark.asyncio
+async def test_reader_distinguishes_same_str_different_hash_keys(interpreter) -> None:
+    key_a = ServiceA()
+    key_b = ServiceB()
+
+    @do
+    def program() -> EffectGenerator[tuple[str, str]]:
+        value_a = yield ask(key_a)
+        value_b = yield ask(key_b)
+        return (value_a, value_b)
+
+    result = await interpreter.run_async(Local({key_a: "A", key_b: "B"}, program()))
+
+    assert result.is_ok
+    assert result.value == ("A", "B")
+
+
+def test_run_env_preserves_hashable_keys() -> None:
+    @do
+    def program() -> EffectGenerator[str]:
+        func: SomeFunc = yield ask(SomeFunc)
+        return func()
+
+    result = vm_run(
+        program(),
+        handlers=default_handlers(),
+        env={SomeFunc: _impl},
+    )
+
+    assert result.is_ok()
+    assert result.value == "ok"


### PR DESCRIPTION
## Summary
- removed Python-side `HashableAskEffect` and unified `Ask` onto `PyAsk` for all hashable keys
- implemented Rust-native `LocalEffect` handling in `ReaderHandlerProgram` (scoped env apply/restore on success and error)
- migrated Rust reader env/lazy key storage from `String` to hash-preserving Python-object keys via new `PyEnvKey`
- updated Rust VM env seeding and `put_env`/`env_items` to preserve original hashable key objects
- removed `str()` coercion path in Python runtime env normalization and updated pinjected bridge compatibility path
- added regression coverage for single Ask effect type, same-`str()`/different-`hash()` key separation, and hashable env keys in `run(...)`

Related issue: ISSUE-CORE-503

## Acceptance Criteria Evidence
- [x] AC-1: `HashableAskEffect` class deleted
  - Evidence: `rg -n "HashableAskEffect" doeff packages tests` returned no matches.
- [x] AC-2: `Ask(key)` produces a single effect type for all hashable keys
  - Evidence: `uv run python` check printed `ask_effect_type= PyAsk` for protocol key.
- [x] AC-3: Non-string hashable keys are not coerced via `str()`
  - Evidence: Rust parser now reads `AskEffect.key` as `PyEnvKey` (`PyObject`-backed) and no reader `str()` coercion branch remains.
- [x] AC-4: Two objects with same `str()` but different `hash()` do not collide
  - Evidence: `uv run python` check printed `collision_result= ('A', 'B')` for `ServiceA/ServiceB` with identical `__str__`.
- [x] AC-5: Local effect handled in Rust (no Python WithHandler fallback)
  - Evidence: `doeff/effects/reader.py` now returns `LocalEffect`; Rust `ReaderHandlerProgram` has `AwaitLocalHandlers/AwaitLocalEval` handling.
- [x] AC-6: `env` storage supports hashable keys natively
  - Evidence: `RustStore.env` now uses `HashMap<PyEnvKey, Value>` and VM env seeding uses `PyEnvKey::from_bound`.
- [x] AC-7: All existing Ask/Local tests pass
  - Evidence: `uv run pytest tests/misc/test_reader_hashable_keys.py tests/effects/test_control_effects.py tests/effects/test_effect_combinations.py -q` → `73 passed`.
- [x] AC-8: `cargo test` passes
  - Evidence: `cargo test` in `packages/doeff-vm` → `139 passed`.
- [x] AC-9: `uv run pytest tests/ -q` passes
  - Evidence: `472 passed, 6 skipped in 12.98s`.

## Validation Commands Run
- `cargo test` (workdir: `packages/doeff-vm`)
- `uv run pytest tests/misc/test_reader_hashable_keys.py tests/effects/test_control_effects.py tests/effects/test_effect_combinations.py -q`
- `uv run pytest tests/ -q`
- `uv run python` one-off runtime verification for:
  - single Ask effect type output (`PyAsk`)
  - collision scenario (`('A', 'B')`)
  - hashable env key via `run(..., env={SomeFunc: _impl})`
