### PR TITLE
docs: rewrite core concepts for DoExpr/Perform architecture

### DIFF
--- a/docs/revision-log.md
+++ b/docs/revision-log.md
@@ -1,0 +1,21 @@
+# Revision Log
+
+This file records historical and migration notes that are intentionally kept out of
+architecture chapters.
+
+## DA-001 (2026-02-17)
+
+`docs/02-core-concepts.md` was rewritten to present only current architecture.
+The following historical topics were moved out of the core chapter:
+
+- legacy `Program` dataclass wrapper representation
+- legacy inheritance discussions around `ProgramBase` / `EffectBase(ProgramBase)`
+- legacy writer-effect references that used `Log` examples
+- legacy KPC-as-effect discussion (superseded by call-time macro model)
+- legacy runtime naming references (`ProgramInterpreter`, `ExecutionContext`, `CESKRuntime`)
+
+Current docs should describe the active model directly:
+
+- `Program[T]` as `DoExpr[T]`
+- explicit `Perform(effect)` dispatch boundary
+- binary `classify_yielded` architecture and current `run` / `async_run` semantics


### PR DESCRIPTION
## Summary
- Completely rewrote `docs/02-core-concepts.md` to align with SPEC-TYPES-001 Rev 12 and SPEC-CORE-001.
- Replaced stale `Program` dataclass-wrapper model with current `Program[T]`/`DoExpr[T]` model.
- Added explicit `DoExpr`/`DoCtrl`/`EffectValue` separation and `Perform(effect)` boundary.
- Updated examples to use `Tell` (no `yield Log(...)` usage).
- Added Rust VM architecture details: binary `classify_yielded`, tag/GIL-minimized dispatch framing, free-monad generator interpretation, and `run` vs `async_run` loop semantics.

## Acceptance Criteria Evidence
Issue reference: DA-001

### 1) Program[T] stale dataclass wrapper removed
Command:
```bash
rg -n "@dataclass\\(frozen=True\\)|generator_func: Callable\\[\\[\\], Generator\\[Effect \\| Program" docs/02-core-concepts.md || echo 'pass: no stale dataclass wrapper'
```
Output:
```text
pass: no stale dataclass wrapper
```

### 2) DoExpr/DoCtrl/EffectValue + explicit Perform boundary present
Command:
```bash
rg -n "DoExpr vs DoCtrl vs EffectValue|DoExpr\\[T\\]|DoCtrl\\[T\\]|EffectValue\\[T\\]|Perform\\(effect\\)|yield expr  ≡" docs/02-core-concepts.md
```
Output (excerpt):
```text
48:## DoExpr vs DoCtrl vs EffectValue
52:- `DoExpr[T]`: control IR evaluated by VM
53:- `DoCtrl[T]`: concrete control nodes ...
54:- `EffectValue[T]`: user-space operation data ...
74:`Perform(effect)` is the control boundary for handler dispatch.
90:yield expr  ≡  Bind(expr, λresult. rest_of_program)
```

### 3) Removed Log effect usage in examples
Command:
```bash
rg -n "yield Tell\\(|Tell\\(" docs/02-core-concepts.md
rg -n "yield Log\\(|\\bLog\\(" docs/02-core-concepts.md || echo 'pass: no Log() effect examples'
```
Output:
```text
234:    yield Tell(f"counter updated: {current} -> {current + 1}")
pass: no Log() effect examples
```

### 4) Rust VM architecture + run/async_run semantics documented
Command:
```bash
rg -n "classify_yielded|DoCtrlBase|EffectBase|GIL|minimized|PythonAsyncSyntaxEscape|Conceptual sync runner|Conceptual async runner|free-monad" docs/02-core-concepts.md
```
Output (excerpt):
```text
143:2. `classify_yielded` performs binary classification:
144:   - `DoCtrlBase` -> evaluate as control
145:   - `EffectBase` -> dispatch through handler stack ...
151:- Tag-based dispatch ... GIL-minimized hot paths.
161:Conceptual sync runner:
176:Conceptual async runner:
189:        if out is PythonAsyncSyntaxEscape:
253:- The Rust VM interprets a lazy free-monad AST via binary yield classification.
```

## Validation
- `uv run pytest`
  - Result: `20 failed, 455 passed, 6 skipped`
  - Failing area: existing lazy-Ask/semaphore tests (`tests/core/test_runtime_regressions_manual.py`, `tests/effects/test_lazy_ask_semaphore.py`)
- Focused verification of concepts touched by docs:
  - `uv run pytest tests/core/test_doexpr_hierarchy.py tests/public_api/test_types_001_hierarchy.py tests/public_api/test_kpc_macro_expansion.py tests/core/test_rust_vm_api_strict.py`
  - Result: `33 passed`
