### PR TITLE
Rewrite program architecture overview to current DoExpr/VM model

### DIFF
--- a/docs/revision-log.md
+++ b/docs/revision-log.md
@@ -25,6 +25,21 @@ Current docs should describe the active model directly:
 - Main docs now use the canonical writer API: `Tell`, `StructuredLog`, `slog`, and `Listen`.
 - Inline references to deprecated protocol names were removed from core chapters.
 
+## DA-011 (2026-02-17)
+
+`docs/program-architecture-overview.md` was fully rewritten to match:
+
+- SPEC-TYPES-001 Rev 12
+- SPEC-008 Rev 14
+- SPEC-CORE-001
+
+Archived historical content from the old chapter includes:
+
+- old runtime naming and execution flow references
+- old inheritance-centric type modeling notes
+- old KPC dispatch framing that predated call-time macro expansion
+- old interpreter-loop wording that predated `run` / `async_run` + explicit `Perform` boundary
+
 ## Error Handling Migration Notes (Archived)
 
 The following migration guide was moved from `docs/05-error-handling.md`.


### PR DESCRIPTION
## Summary
- Completely rewrote `docs/program-architecture-overview.md` to the current model from SPEC-TYPES-001 Rev 12, SPEC-008 Rev 14, and SPEC-CORE-001.
- Removed old inline architecture/protocol references from the chapter and replaced them with current concepts:
  - explicit `Perform(effect)` boundary
  - binary yielded classification (`DoCtrlBase | EffectBase`)
  - `step : state -> Free[ExternalOp, step_outcome]`
  - opaque effect dispatch (`Py<PyAny>`) with handler-side downcast
  - KPC as call-time macro expansion to `Call`
  - `run` / `async_run` runner model
  - `PythonAsyncSyntaxEscape` as the async syntax escape boundary
- Added DA-011 archival note to `docs/revision-log.md` for historical context placement.

## Acceptance Criteria Evidence
### 1) Required architecture points covered in updated chapter
Command:
```bash
rg -n "Program Model|Generator as Lazy AST|DoCtrl Instruction Set|KPC Is Call-Time Macro Expansion|VM Step Semantics|Yield Classification and Dispatch|Handler Protocol|Escape Boundary: Async Only|Runners" docs/program-architecture-overview.md
```
Output:
- `docs/program-architecture-overview.md:9` Program Model
- `docs/program-architecture-overview.md:30` Generator as Lazy AST
- `docs/program-architecture-overview.md:47` DoCtrl Instruction Set
- `docs/program-architecture-overview.md:63` KPC Is Call-Time Macro Expansion
- `docs/program-architecture-overview.md:74` VM Step Semantics
- `docs/program-architecture-overview.md:88` Yield Classification and Dispatch
- `docs/program-architecture-overview.md:102` Handler Protocol
- `docs/program-architecture-overview.md:111` Escape Boundary: Async Only
- `docs/program-architecture-overview.md:122` Runners

### 2) Specific required semantics present
Command:
```bash
rg -n "Perform\(effect\)|step : state -> Free\[ExternalOp, step_outcome\]|DoCtrlBase|EffectBase|Py<PyAny>|PythonAsyncSyntaxEscape|run\(program|async_run\(program|Pure\(|Map\(|FlatMap\(|Call\(" docs/program-architecture-overview.md
```
Output includes:
- `docs/program-architecture-overview.md:79` `step : state -> Free[ExternalOp, step_outcome]`
- `docs/program-architecture-overview.md:92` `DoCtrlBase`
- `docs/program-architecture-overview.md:93` `EffectBase`
- `docs/program-architecture-overview.md:100` `Py<PyAny>` opaque effect dispatch
- `docs/program-architecture-overview.md:113` `PythonAsyncSyntaxEscape` only VM-level escape
- `docs/program-architecture-overview.md:126` `run(program, ...)`
- `docs/program-architecture-overview.md:127` `async_run(program, ...)`
- `docs/program-architecture-overview.md:51-56` `Pure` / `Call` / `Map` / `FlatMap` / `Perform` listed as DoCtrl

### 3) Legacy protocol references removed from updated chapter
Command:
```bash
rg -n "ProgramInterpreter|ExecutionContext|CESKRuntime|@dataclass class Program|ProgramBase|EffectBase\(ProgramBase\)|\bLog\b|KPC-as-effect|Migration from" docs/program-architecture-overview.md
```
Output:
- No matches

### 4) Historical placement in revision log
Command:
```bash
rg -n "DA-011|program-architecture-overview" docs/revision-log.md
```
Output:
- `docs/revision-log.md:28` `## DA-011 (2026-02-17)`
- `docs/revision-log.md:30` `docs/program-architecture-overview.md` rewrite note

## Validation
- Ran full suite:
  - `uv run pytest`
  - Result: `20 failed, 455 passed, 6 skipped in 23.65s`
- Failures are in lazy-ask/semaphore runtime tests (`tests/core/test_runtime_regressions_manual.py`, `tests/effects/test_lazy_ask_semaphore.py`) and are unrelated to this docs-only change.

## Issue
- References: `DA-011`
