### PR TITLE
Extract lazy Ask coordination into LazyAskHandler

### DIFF
--- a/doeff/handlers.py
+++ b/doeff/handlers.py
@@ -3,7 +3,7 @@
 These are user-space handler sentinels. The VM only dispatches to handlers and
 does not own handler semantics.
 
-Provides: state, reader, writer, result_safe, scheduler, await_handler.
+Provides: state, reader, writer, result_safe, scheduler, lazy_ask, await_handler.
 Default Await behavior for run()/async_run() comes from Python handlers in
 doeff.effects.future via default handler presets.
 """
@@ -16,6 +16,7 @@ _HANDLER_SENTINELS = {
     "writer",
     "result_safe",
     "scheduler",
+    "lazy_ask",
     "await_handler",
 }
 
@@ -32,4 +33,4 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["state", "reader", "writer", "result_safe", "scheduler", "await_handler"]
+__all__ = ["state", "reader", "writer", "result_safe", "scheduler", "lazy_ask", "await_handler"]

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -130,7 +130,7 @@ async def _call_async_run_fn(run_fn: Any, program: Any, kwargs: dict[str, Any]) 
 
 def _core_handler_sentinels(vm: Any) -> list[Any]:
     """Return the shared core handler sentinel stack from doeff_vm."""
-    required = ("state", "reader", "writer", "result_safe", "scheduler")
+    required = ("state", "reader", "writer", "result_safe", "scheduler", "lazy_ask")
     if all(hasattr(vm, name) for name in required):
         return [getattr(vm, name) for name in required]
     missing = [name for name in required if not hasattr(vm, name)]
@@ -284,6 +284,7 @@ def __getattr__(name: str) -> Any:
         "reader",
         "writer",
         "result_safe",
+        "lazy_ask",
         "await_handler",
     }:
         vm = _vm()
@@ -318,5 +319,6 @@ __all__ = [
     "reader",
     "writer",
     "result_safe",
+    "lazy_ask",
     "await_handler",
 ]

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -92,6 +92,7 @@ reader = _ext.reader
 writer = _ext.writer
 result_safe = _ext.result_safe
 scheduler = _ext.scheduler
+lazy_ask = _ext.lazy_ask
 await_handler = _ext.await_handler
 CreateContinuation = _ext.CreateContinuation
 GetContinuation = _ext.GetContinuation
@@ -197,6 +198,7 @@ __all__ = [
     "reader",
     "run",
     "scheduler",
+    "lazy_ask",
     "state",
     "result_safe",
     "await_handler",

--- a/packages/doeff-vm/src/handler.rs
+++ b/packages/doeff-vm/src/handler.rs
@@ -4,6 +4,7 @@
 //! handler implementations. They are dispatched by the VM, not part of VM core
 //! stepping semantics.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
@@ -286,7 +287,7 @@ fn wrap_exception_as_result_err(error: PyException) -> Result<Value, PyException
     })
 }
 
-fn as_lazy_eval_expr(value: &Value) -> Option<PyShared> {
+fn lazy_ask_eval_expr(value: &Value) -> Option<PyShared> {
     let Value::Python(obj) = value else {
         return None;
     };
@@ -305,14 +306,14 @@ fn as_lazy_eval_expr(value: &Value) -> Option<PyShared> {
     })
 }
 
-fn lazy_source_id(value: &Value) -> Option<usize> {
+fn lazy_ask_source_id(value: &Value) -> Option<usize> {
     let Value::Python(obj) = value else {
         return None;
     };
     Python::attach(|py| Some(obj.bind(py).as_ptr() as usize))
 }
 
-fn reader_lazy_create_semaphore_effect() -> Result<DispatchEffect, PyException> {
+fn lazy_ask_create_semaphore_effect() -> Result<DispatchEffect, PyException> {
     Python::attach(|py| {
         let semaphore_module = py
             .import("doeff.effects.semaphore")
@@ -327,7 +328,7 @@ fn reader_lazy_create_semaphore_effect() -> Result<DispatchEffect, PyException> 
     })
 }
 
-fn reader_lazy_acquire_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect, PyException> {
+fn lazy_ask_acquire_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect, PyException> {
     let Value::Python(semaphore_obj) = semaphore else {
         return Err(PyException::type_error(format!(
             "CreateSemaphore returned non-semaphore value: {:?}",
@@ -349,7 +350,7 @@ fn reader_lazy_acquire_semaphore_effect(semaphore: &Value) -> Result<DispatchEff
     })
 }
 
-fn reader_lazy_release_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect, PyException> {
+fn lazy_ask_release_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect, PyException> {
     let Value::Python(semaphore_obj) = semaphore else {
         return Err(PyException::type_error(format!(
             "CreateSemaphore returned non-semaphore value: {:?}",
@@ -367,6 +368,19 @@ fn reader_lazy_release_semaphore_effect(semaphore: &Value) -> Result<DispatchEff
         let effect = release
             .call1((semaphore_obj.bind(py),))
             .map_err(|e| pyerr_to_exception(py, e))?;
+        Ok(dispatch_from_shared(PyShared::new(effect.unbind())))
+    })
+}
+
+fn lazy_ask_delegate_reader_effect(key: &str) -> Result<DispatchEffect, PyException> {
+    Python::attach(|py| {
+        let reader_module = py
+            .import("doeff.effects.reader")
+            .map_err(|e| pyerr_to_exception(py, e))?;
+        let ask = reader_module
+            .getattr("Ask")
+            .map_err(|e| pyerr_to_exception(py, e))?;
+        let effect = ask.call1((key,)).map_err(|e| pyerr_to_exception(py, e))?;
         Ok(dispatch_from_shared(PyShared::new(effect.unbind())))
     })
 }
@@ -695,6 +709,474 @@ impl RustHandlerProgram for StateHandlerProgram {
 }
 
 // ---------------------------------------------------------------------------
+// LazyAskHandlerFactory + LazyAskHandlerProgram
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct LazyCacheEntry {
+    source_id: usize,
+    value: Value,
+}
+
+#[derive(Debug, Clone)]
+struct LazySemaphoreEntry {
+    source_id: usize,
+    semaphore: Value,
+}
+
+#[derive(Debug, Default)]
+struct LazyAskState {
+    cache: HashMap<String, LazyCacheEntry>,
+    semaphores: HashMap<String, LazySemaphoreEntry>,
+}
+
+impl LazyAskState {
+    fn cache_get(&self, key: &str, source_id: usize) -> Option<Value> {
+        let entry = self.cache.get(key)?;
+        (entry.source_id == source_id).then(|| entry.value.clone())
+    }
+
+    fn cache_put(&mut self, key: String, source_id: usize, value: Value) {
+        self.cache.insert(key, LazyCacheEntry { source_id, value });
+    }
+
+    fn semaphore_get(&self, key: &str, source_id: usize) -> Option<Value> {
+        let entry = self.semaphores.get(key)?;
+        (entry.source_id == source_id).then(|| entry.semaphore.clone())
+    }
+
+    fn semaphore_put(&mut self, key: String, source_id: usize, semaphore: Value) {
+        self.semaphores.insert(
+            key,
+            LazySemaphoreEntry {
+                source_id,
+                semaphore,
+            },
+        );
+    }
+}
+
+#[derive(Clone)]
+pub struct LazyAskHandlerFactory {
+    default_state: Arc<Mutex<LazyAskState>>,
+    run_states: Arc<Mutex<HashMap<u64, Arc<Mutex<LazyAskState>>>>>,
+}
+
+impl std::fmt::Debug for LazyAskHandlerFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyAskHandlerFactory").finish()
+    }
+}
+
+impl LazyAskHandlerFactory {
+    pub fn new() -> Self {
+        LazyAskHandlerFactory {
+            default_state: Arc::new(Mutex::new(LazyAskState::default())),
+            run_states: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn state_for_run(&self, run_token: Option<u64>) -> Arc<Mutex<LazyAskState>> {
+        match run_token {
+            Some(token) => {
+                let mut states = self.run_states.lock().expect("LazyAsk lock poisoned");
+                states
+                    .entry(token)
+                    .or_insert_with(|| Arc::new(Mutex::new(LazyAskState::default())))
+                    .clone()
+            }
+            None => self.default_state.clone(),
+        }
+    }
+}
+
+impl Default for LazyAskHandlerFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RustProgramHandler for LazyAskHandlerFactory {
+    fn can_handle(&self, effect: &DispatchEffect) -> bool {
+        #[cfg(test)]
+        if matches!(effect, Effect::Ask { .. }) {
+            return true;
+        }
+
+        dispatch_ref_as_python(effect)
+            .is_some_and(|obj| parse_reader_python_effect(obj).ok().flatten().is_some())
+    }
+
+    fn create_program(&self) -> RustProgramRef {
+        Arc::new(Mutex::new(Box::new(LazyAskHandlerProgram::new(
+            self.state_for_run(None),
+        ))))
+    }
+
+    fn create_program_for_run(&self, run_token: Option<u64>) -> RustProgramRef {
+        Arc::new(Mutex::new(Box::new(LazyAskHandlerProgram::new(
+            self.state_for_run(run_token),
+        ))))
+    }
+
+    fn handler_name(&self) -> &'static str {
+        "LazyAskHandler"
+    }
+
+    fn on_run_end(&self, run_token: u64) {
+        let mut states = self.run_states.lock().expect("LazyAsk lock poisoned");
+        states.remove(&run_token);
+    }
+}
+
+#[derive(Debug)]
+enum LazyAskPhase {
+    Idle,
+    AwaitAcquire {
+        key: String,
+        continuation: Continuation,
+        source_id: usize,
+        semaphore: Option<Value>,
+    },
+    AwaitDelegate {
+        key: String,
+        continuation: Continuation,
+        source_id: usize,
+        semaphore: Value,
+    },
+    AwaitHandlers {
+        key: String,
+        continuation: Continuation,
+        source_id: usize,
+        semaphore: Value,
+        expr: PyShared,
+    },
+    AwaitEval {
+        key: String,
+        continuation: Continuation,
+        source_id: usize,
+        semaphore: Value,
+    },
+    AwaitReleaseSuccess {
+        continuation: Continuation,
+        value: Value,
+    },
+    AwaitReleaseError {
+        continuation: Continuation,
+        exception: PyException,
+    },
+}
+
+#[derive(Debug)]
+struct LazyAskHandlerProgram {
+    phase: LazyAskPhase,
+    state: Arc<Mutex<LazyAskState>>,
+}
+
+impl LazyAskHandlerProgram {
+    fn new(state: Arc<Mutex<LazyAskState>>) -> Self {
+        LazyAskHandlerProgram {
+            phase: LazyAskPhase::Idle,
+            state,
+        }
+    }
+
+    fn yield_perform(effect: Result<DispatchEffect, PyException>) -> RustProgramStep {
+        match effect {
+            Ok(effect) => RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Perform { effect })),
+            Err(exc) => RustProgramStep::Throw(exc),
+        }
+    }
+
+    fn transfer_throw(continuation: Continuation, exception: PyException) -> RustProgramStep {
+        RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::TransferThrow {
+            continuation,
+            exception,
+        }))
+    }
+
+    fn state_cache_get(&self, key: &str, source_id: usize) -> Option<Value> {
+        self.state
+            .lock()
+            .expect("LazyAsk lock poisoned")
+            .cache_get(key, source_id)
+    }
+
+    fn state_cache_put(&self, key: String, source_id: usize, value: Value) {
+        self.state
+            .lock()
+            .expect("LazyAsk lock poisoned")
+            .cache_put(key, source_id, value);
+    }
+
+    fn state_semaphore_get(&self, key: &str, source_id: usize) -> Option<Value> {
+        self.state
+            .lock()
+            .expect("LazyAsk lock poisoned")
+            .semaphore_get(key, source_id)
+    }
+
+    fn state_semaphore_put(&self, key: String, source_id: usize, semaphore: Value) {
+        self.state
+            .lock()
+            .expect("LazyAsk lock poisoned")
+            .semaphore_put(key, source_id, semaphore);
+    }
+
+    fn begin_acquire_phase(
+        &mut self,
+        key: String,
+        continuation: Continuation,
+        source_id: usize,
+        semaphore: Value,
+    ) -> RustProgramStep {
+        let effect = lazy_ask_acquire_semaphore_effect(&semaphore);
+        self.phase = LazyAskPhase::AwaitAcquire {
+            key,
+            continuation,
+            source_id,
+            semaphore: Some(semaphore),
+        };
+        Self::yield_perform(effect)
+    }
+
+    fn begin_release_success_phase(
+        &mut self,
+        continuation: Continuation,
+        value: Value,
+        semaphore: Value,
+    ) -> RustProgramStep {
+        let effect = lazy_ask_release_semaphore_effect(&semaphore);
+        self.phase = LazyAskPhase::AwaitReleaseSuccess {
+            continuation,
+            value,
+        };
+        Self::yield_perform(effect)
+    }
+
+    fn begin_release_error_phase(
+        &mut self,
+        continuation: Continuation,
+        exception: PyException,
+        semaphore: Value,
+    ) -> RustProgramStep {
+        let effect = lazy_ask_release_semaphore_effect(&semaphore);
+        self.phase = LazyAskPhase::AwaitReleaseError {
+            continuation,
+            exception,
+        };
+        Self::yield_perform(effect)
+    }
+
+    fn handle_ask(
+        &mut self,
+        key: String,
+        continuation: Continuation,
+        store: &mut RustStore,
+    ) -> RustProgramStep {
+        let Some(value) = store.ask(&key).cloned() else {
+            return RustProgramStep::Throw(missing_env_key_error(&key));
+        };
+
+        if lazy_ask_eval_expr(&value).is_none() {
+            return RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Resume {
+                continuation,
+                value,
+            }));
+        }
+
+        let source_id = lazy_ask_source_id(&value).unwrap_or_default();
+        if let Some(cached) = self.state_cache_get(&key, source_id) {
+            return RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Resume {
+                continuation,
+                value: cached,
+            }));
+        }
+
+        if let Some(semaphore) = self.state_semaphore_get(&key, source_id) {
+            return self.begin_acquire_phase(key, continuation, source_id, semaphore);
+        }
+
+        self.phase = LazyAskPhase::AwaitAcquire {
+            key,
+            continuation,
+            source_id,
+            semaphore: None,
+        };
+        Self::yield_perform(lazy_ask_create_semaphore_effect())
+    }
+}
+
+impl RustHandlerProgram for LazyAskHandlerProgram {
+    fn start(
+        &mut self,
+        _py: Python<'_>,
+        effect: DispatchEffect,
+        k: Continuation,
+        store: &mut RustStore,
+    ) -> RustProgramStep {
+        #[cfg(test)]
+        if let Effect::Ask { key } = effect.clone() {
+            return self.handle_ask(key, k, store);
+        }
+
+        if let Some(obj) = dispatch_into_python(effect.clone()) {
+            return match parse_reader_python_effect(&obj) {
+                Ok(Some(key)) => self.handle_ask(key, k, store),
+                Ok(None) => RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Delegate {
+                    effect: dispatch_from_shared(obj),
+                })),
+                Err(msg) => RustProgramStep::Throw(PyException::type_error(format!(
+                    "failed to parse lazy Ask effect: {msg}"
+                ))),
+            };
+        }
+
+        #[cfg(test)]
+        {
+            return RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Delegate { effect }));
+        }
+
+        #[cfg(not(test))]
+        unreachable!("runtime Effect is always Python")
+    }
+
+    fn resume(&mut self, value: Value, _store: &mut RustStore) -> RustProgramStep {
+        match std::mem::replace(&mut self.phase, LazyAskPhase::Idle) {
+            LazyAskPhase::AwaitAcquire {
+                key,
+                continuation,
+                source_id,
+                semaphore,
+            } => match semaphore {
+                None => {
+                    let semaphore = match value {
+                        Value::Python(_) => value,
+                        _ => {
+                            return RustProgramStep::Throw(PyException::type_error(
+                                "CreateSemaphore must return a semaphore handle".to_string(),
+                            ));
+                        }
+                    };
+                    self.state_semaphore_put(key.clone(), source_id, semaphore.clone());
+                    self.begin_acquire_phase(key, continuation, source_id, semaphore)
+                }
+                Some(semaphore) => {
+                    if let Some(cached) = self.state_cache_get(&key, source_id) {
+                        return self.begin_release_success_phase(continuation, cached, semaphore);
+                    }
+
+                    let effect = lazy_ask_delegate_reader_effect(&key);
+                    self.phase = LazyAskPhase::AwaitDelegate {
+                        key,
+                        continuation,
+                        source_id,
+                        semaphore,
+                    };
+                    Self::yield_perform(effect)
+                }
+            },
+            LazyAskPhase::AwaitDelegate {
+                key,
+                continuation,
+                source_id,
+                semaphore,
+            } => {
+                if let Some(expr) = lazy_ask_eval_expr(&value) {
+                    self.phase = LazyAskPhase::AwaitHandlers {
+                        key,
+                        continuation,
+                        source_id,
+                        semaphore,
+                        expr,
+                    };
+                    return RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::GetHandlers));
+                }
+                self.begin_release_success_phase(continuation, value, semaphore)
+            }
+            LazyAskPhase::AwaitHandlers {
+                key,
+                continuation,
+                source_id,
+                semaphore,
+                expr,
+            } => {
+                let handlers = match value {
+                    Value::Handlers(handlers) => handlers,
+                    _ => {
+                        return RustProgramStep::Throw(PyException::type_error(
+                            "lazy Ask expected handlers from GetHandlers".to_string(),
+                        ));
+                    }
+                };
+                self.phase = LazyAskPhase::AwaitEval {
+                    key,
+                    continuation,
+                    source_id,
+                    semaphore,
+                };
+                RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Eval {
+                    expr,
+                    handlers,
+                    metadata: None,
+                }))
+            }
+            LazyAskPhase::AwaitEval {
+                key,
+                continuation,
+                source_id,
+                semaphore,
+            } => {
+                self.state_cache_put(key, source_id, value.clone());
+                self.begin_release_success_phase(continuation, value, semaphore)
+            }
+            LazyAskPhase::AwaitReleaseSuccess {
+                continuation,
+                value,
+            } => RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Resume {
+                continuation,
+                value,
+            })),
+            LazyAskPhase::AwaitReleaseError {
+                continuation,
+                exception,
+            } => Self::transfer_throw(continuation, exception),
+            LazyAskPhase::Idle => RustProgramStep::Return(value),
+        }
+    }
+
+    fn throw(&mut self, exc: PyException, _store: &mut RustStore) -> RustProgramStep {
+        match std::mem::replace(&mut self.phase, LazyAskPhase::Idle) {
+            LazyAskPhase::AwaitAcquire { continuation, .. } => {
+                Self::transfer_throw(continuation, exc)
+            }
+            LazyAskPhase::AwaitDelegate {
+                continuation,
+                semaphore,
+                ..
+            } => self.begin_release_error_phase(continuation, exc, semaphore),
+            LazyAskPhase::AwaitHandlers {
+                continuation,
+                semaphore,
+                ..
+            } => self.begin_release_error_phase(continuation, exc, semaphore),
+            LazyAskPhase::AwaitEval {
+                continuation,
+                semaphore,
+                ..
+            } => self.begin_release_error_phase(continuation, exc, semaphore),
+            LazyAskPhase::AwaitReleaseSuccess { continuation, .. } => {
+                Self::transfer_throw(continuation, exc)
+            }
+            LazyAskPhase::AwaitReleaseError { continuation, .. } => {
+                Self::transfer_throw(continuation, exc)
+            }
+            LazyAskPhase::Idle => RustProgramStep::Throw(exc),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ReaderHandlerFactory + ReaderHandlerProgram
 // ---------------------------------------------------------------------------
 
@@ -722,119 +1204,14 @@ impl RustProgramHandler for ReaderHandlerFactory {
 }
 
 #[derive(Debug)]
-enum ReaderPhase {
-    Idle,
-    AwaitCreateSemaphore {
-        key: String,
-        continuation: Continuation,
-        expr: PyShared,
-        source_id: usize,
-    },
-    AwaitAcquireSemaphore {
-        key: String,
-        continuation: Continuation,
-        expr: PyShared,
-        source_id: usize,
-        semaphore: Value,
-    },
-    AwaitHandlers {
-        key: String,
-        continuation: Continuation,
-        expr: PyShared,
-        source_id: usize,
-        semaphore: Value,
-    },
-    AwaitEval {
-        key: String,
-        continuation: Continuation,
-        source_id: usize,
-        semaphore: Value,
-    },
-    AwaitReleaseSuccess {
-        continuation: Continuation,
-        value: Value,
-    },
-    AwaitReleaseError {
-        continuation: Continuation,
-        exception: PyException,
-    },
-}
-
-#[derive(Debug)]
-struct ReaderHandlerProgram {
-    phase: ReaderPhase,
-}
+struct ReaderHandlerProgram;
 
 impl ReaderHandlerProgram {
     fn new() -> Self {
-        ReaderHandlerProgram {
-            phase: ReaderPhase::Idle,
-        }
-    }
-
-    fn yield_perform(effect: Result<DispatchEffect, PyException>) -> RustProgramStep {
-        match effect {
-            Ok(effect) => RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Perform { effect })),
-            Err(exc) => RustProgramStep::Throw(exc),
-        }
-    }
-
-    fn transfer_throw(continuation: Continuation, exception: PyException) -> RustProgramStep {
-        RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::TransferThrow {
-            continuation,
-            exception,
-        }))
-    }
-
-    fn begin_acquire_phase(
-        &mut self,
-        key: String,
-        continuation: Continuation,
-        expr: PyShared,
-        source_id: usize,
-        semaphore: Value,
-    ) -> RustProgramStep {
-        let effect = reader_lazy_acquire_semaphore_effect(&semaphore);
-        self.phase = ReaderPhase::AwaitAcquireSemaphore {
-            key,
-            continuation,
-            expr,
-            source_id,
-            semaphore,
-        };
-        Self::yield_perform(effect)
-    }
-
-    fn begin_release_success_phase(
-        &mut self,
-        continuation: Continuation,
-        value: Value,
-        semaphore: Value,
-    ) -> RustProgramStep {
-        let effect = reader_lazy_release_semaphore_effect(&semaphore);
-        self.phase = ReaderPhase::AwaitReleaseSuccess {
-            continuation,
-            value,
-        };
-        Self::yield_perform(effect)
-    }
-
-    fn begin_release_error_phase(
-        &mut self,
-        continuation: Continuation,
-        exception: PyException,
-        semaphore: Value,
-    ) -> RustProgramStep {
-        let effect = reader_lazy_release_semaphore_effect(&semaphore);
-        self.phase = ReaderPhase::AwaitReleaseError {
-            continuation,
-            exception,
-        };
-        Self::yield_perform(effect)
+        ReaderHandlerProgram
     }
 
     fn handle_ask(
-        &mut self,
         key: String,
         continuation: Continuation,
         store: &mut RustStore,
@@ -842,31 +1219,6 @@ impl ReaderHandlerProgram {
         let Some(value) = store.ask(&key).cloned() else {
             return RustProgramStep::Throw(missing_env_key_error(&key));
         };
-
-        if let Some(expr) = as_lazy_eval_expr(&value) {
-            let source_id = lazy_source_id(&value).unwrap_or_default();
-
-            if let Some(cached) = store.lazy_cache_get(&key, source_id) {
-                store.env.insert(key, cached.clone());
-                return RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Resume {
-                    continuation,
-                    value: cached,
-                }));
-            }
-
-            if let Some(semaphore) = store.lazy_semaphore_get(&key, source_id) {
-                return self.begin_acquire_phase(key, continuation, expr, source_id, semaphore);
-            }
-
-            self.phase = ReaderPhase::AwaitCreateSemaphore {
-                key,
-                continuation,
-                expr,
-                source_id,
-            };
-            return Self::yield_perform(reader_lazy_create_semaphore_effect());
-        }
-
         RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Resume {
             continuation,
             value,
@@ -884,12 +1236,12 @@ impl RustHandlerProgram for ReaderHandlerProgram {
     ) -> RustProgramStep {
         #[cfg(test)]
         if let Effect::Ask { key } = effect.clone() {
-            return self.handle_ask(key, k, store);
+            return Self::handle_ask(key, k, store);
         }
 
         if let Some(obj) = dispatch_into_python(effect.clone()) {
             return match parse_reader_python_effect(&obj) {
-                Ok(Some(key)) => self.handle_ask(key, k, store),
+                Ok(Some(key)) => Self::handle_ask(key, k, store),
                 Ok(None) => RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Delegate {
                     effect: dispatch_from_shared(obj),
                 })),
@@ -908,125 +1260,12 @@ impl RustHandlerProgram for ReaderHandlerProgram {
         unreachable!("runtime Effect is always Python")
     }
 
-    fn resume(&mut self, value: Value, store: &mut RustStore) -> RustProgramStep {
-        match std::mem::replace(&mut self.phase, ReaderPhase::Idle) {
-            ReaderPhase::AwaitCreateSemaphore {
-                key,
-                continuation,
-                expr,
-                source_id,
-            } => {
-                let semaphore = match value {
-                    Value::Python(_) => value,
-                    _ => {
-                        return RustProgramStep::Throw(PyException::type_error(
-                            "CreateSemaphore must return a semaphore handle".to_string(),
-                        ));
-                    }
-                };
-                store.lazy_semaphore_put(key.clone(), source_id, semaphore.clone());
-                self.begin_acquire_phase(key, continuation, expr, source_id, semaphore)
-            }
-            ReaderPhase::AwaitAcquireSemaphore {
-                key,
-                continuation,
-                expr,
-                source_id,
-                semaphore,
-            } => {
-                if let Some(cached) = store.lazy_cache_get(&key, source_id) {
-                    store.env.insert(key, cached.clone());
-                    return self.begin_release_success_phase(continuation, cached, semaphore);
-                }
-
-                self.phase = ReaderPhase::AwaitHandlers {
-                    key,
-                    continuation,
-                    expr,
-                    source_id,
-                    semaphore,
-                };
-                RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::GetHandlers))
-            }
-            ReaderPhase::AwaitHandlers {
-                key,
-                continuation,
-                expr,
-                source_id,
-                semaphore,
-            } => {
-                let handlers = match value {
-                    Value::Handlers(handlers) => handlers,
-                    _ => {
-                        return RustProgramStep::Throw(PyException::type_error(
-                            "reader lazy Ask expected handlers from GetHandlers".to_string(),
-                        ));
-                    }
-                };
-
-                self.phase = ReaderPhase::AwaitEval {
-                    key,
-                    continuation,
-                    source_id,
-                    semaphore,
-                };
-                RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Eval {
-                    expr,
-                    handlers,
-                    metadata: None,
-                }))
-            }
-            ReaderPhase::AwaitEval {
-                key,
-                continuation,
-                source_id,
-                semaphore,
-            } => {
-                store.env.insert(key.clone(), value.clone());
-                store.lazy_cache_put(key.clone(), source_id, value.clone());
-                self.begin_release_success_phase(continuation, value, semaphore)
-            }
-            ReaderPhase::AwaitReleaseSuccess {
-                continuation,
-                value,
-            } => RustProgramStep::Yield(Yielded::DoCtrl(DoCtrl::Resume {
-                continuation,
-                value,
-            })),
-            ReaderPhase::AwaitReleaseError {
-                continuation,
-                exception,
-            } => Self::transfer_throw(continuation, exception),
-            ReaderPhase::Idle => RustProgramStep::Return(value),
-        }
+    fn resume(&mut self, _value: Value, _store: &mut RustStore) -> RustProgramStep {
+        unreachable!("ReaderHandler never yields mid-handling")
     }
 
     fn throw(&mut self, exc: PyException, _store: &mut RustStore) -> RustProgramStep {
-        match std::mem::replace(&mut self.phase, ReaderPhase::Idle) {
-            ReaderPhase::AwaitCreateSemaphore { continuation, .. } => {
-                Self::transfer_throw(continuation, exc)
-            }
-            ReaderPhase::AwaitAcquireSemaphore { continuation, .. } => {
-                Self::transfer_throw(continuation, exc)
-            }
-            ReaderPhase::AwaitHandlers {
-                continuation,
-                semaphore,
-                ..
-            } => self.begin_release_error_phase(continuation, exc, semaphore),
-            ReaderPhase::AwaitEval {
-                continuation,
-                semaphore,
-                ..
-            } => self.begin_release_error_phase(continuation, exc, semaphore),
-            ReaderPhase::AwaitReleaseSuccess { continuation, .. } => {
-                Self::transfer_throw(continuation, exc)
-            }
-            ReaderPhase::AwaitReleaseError { continuation, .. } => {
-                Self::transfer_throw(continuation, exc)
-            }
-            ReaderPhase::Idle => RustProgramStep::Throw(exc),
-        }
+        RustProgramStep::Throw(exc)
     }
 }
 
@@ -1547,6 +1786,20 @@ mod tests {
             }
             assert_eq!(store.get("key").unwrap().as_int(), Some(20)); // new value stored
         });
+    }
+
+    #[test]
+    fn test_lazy_ask_factory_can_handle() {
+        let f = LazyAskHandlerFactory::new();
+        assert!(f.can_handle(&Effect::Ask {
+            key: "x".to_string()
+        }));
+        assert!(!f.can_handle(&Effect::Get {
+            key: "x".to_string()
+        }));
+        assert!(!f.can_handle(&Effect::Tell {
+            message: Value::Unit
+        }));
     }
 
     #[test]

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -45,7 +45,8 @@ pub use effect::{Effect, PyAsk, PyGet, PyModify, PyPut, PyTell};
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{
-    Handler, HandlerEntry, ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
+    Handler, HandlerEntry, LazyAskHandlerFactory, ReaderHandlerFactory, StateHandlerFactory,
+    WriterHandlerFactory,
 };
 pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
 pub use pyvm::{DoExprTag, PyStdlib, PyVM};

--- a/packages/doeff-vm/src/rust_store.rs
+++ b/packages/doeff-vm/src/rust_store.rs
@@ -5,24 +5,10 @@ use std::collections::HashMap;
 use crate::value::Value;
 
 #[derive(Debug, Clone)]
-struct LazyCacheEntry {
-    source_id: usize,
-    value: Value,
-}
-
-#[derive(Debug, Clone)]
-struct LazySemaphoreEntry {
-    source_id: usize,
-    semaphore: Value,
-}
-
-#[derive(Debug, Clone)]
 pub struct RustStore {
     pub state: HashMap<String, Value>,
     pub env: HashMap<String, Value>,
     pub log: Vec<Value>,
-    lazy_cache: HashMap<String, LazyCacheEntry>,
-    lazy_semaphores: HashMap<String, LazySemaphoreEntry>,
 }
 
 impl RustStore {
@@ -31,8 +17,6 @@ impl RustStore {
             state: HashMap::new(),
             env: HashMap::new(),
             log: Vec::new(),
-            lazy_cache: HashMap::new(),
-            lazy_semaphores: HashMap::new(),
         }
     }
 
@@ -96,31 +80,6 @@ impl RustStore {
 
     pub fn clear_logs(&mut self) -> Vec<Value> {
         std::mem::take(&mut self.log)
-    }
-
-    pub fn lazy_cache_get(&self, key: &str, source_id: usize) -> Option<Value> {
-        let entry = self.lazy_cache.get(key)?;
-        if entry.source_id == source_id {
-            return Some(entry.value.clone());
-        }
-        None
-    }
-
-    pub fn lazy_cache_put(&mut self, key: String, source_id: usize, value: Value) {
-        self.lazy_cache.insert(key, LazyCacheEntry { source_id, value });
-    }
-
-    pub fn lazy_semaphore_get(&self, key: &str, source_id: usize) -> Option<Value> {
-        let entry = self.lazy_semaphores.get(key)?;
-        if entry.source_id == source_id {
-            return Some(entry.semaphore.clone());
-        }
-        None
-    }
-
-    pub fn lazy_semaphore_put(&mut self, key: String, source_id: usize, semaphore: Value) {
-        self.lazy_semaphores
-            .insert(key, LazySemaphoreEntry { source_id, semaphore });
     }
 }
 

--- a/tests/core/test_rust_vm_api_strict.py
+++ b/tests/core/test_rust_vm_api_strict.py
@@ -26,6 +26,7 @@ def test_default_handlers_are_module_sentinels_only(monkeypatch: pytest.MonkeyPa
         "writer": object(),
         "result_safe": object(),
         "scheduler": object(),
+        "lazy_ask": object(),
     }
     fake_vm = SimpleNamespace(**sentinels)
     monkeypatch.setattr(rust_vm_module, "_vm", lambda: fake_vm)
@@ -38,6 +39,7 @@ def test_default_handlers_are_module_sentinels_only(monkeypatch: pytest.MonkeyPa
         sentinels["writer"],
         sentinels["result_safe"],
         sentinels["scheduler"],
+        sentinels["lazy_ask"],
         sync_await_handler,
     ]
 
@@ -53,6 +55,7 @@ def test_default_async_handlers_use_async_await_handler(
         "writer": object(),
         "result_safe": object(),
         "scheduler": object(),
+        "lazy_ask": object(),
     }
     fake_vm = SimpleNamespace(**sentinels)
     monkeypatch.setattr(rust_vm_module, "_vm", lambda: fake_vm)
@@ -65,6 +68,7 @@ def test_default_async_handlers_use_async_await_handler(
         sentinels["writer"],
         sentinels["result_safe"],
         sentinels["scheduler"],
+        sentinels["lazy_ask"],
         async_await_handler,
     ]
 

--- a/tests/core/test_sa002_spec_gaps.py
+++ b/tests/core/test_sa002_spec_gaps.py
@@ -77,7 +77,7 @@ def test_SA_002_G05_default_handlers_and_presets_contract() -> None:
 
     handlers = default_handlers()
     names = [str(getattr(h, "name", repr(h))).lower() for h in handlers]
-    assert len(handlers) == 6, "default_handlers() must include core runtime handlers"
+    assert len(handlers) == 7, "default_handlers() must include core runtime handlers"
     assert any("state" in n for n in names)
     assert any("reader" in n for n in names)
     assert any("writer" in n for n in names)

--- a/tests/core/test_spec_gaps.py
+++ b/tests/core/test_spec_gaps.py
@@ -289,11 +289,15 @@ class TestG24HandlerResumeSemantics:
     """G24: Reader/Writer handlers resume() must be unreachable, not Return."""
 
     def test_reader_handler_resume_is_unreachable(self) -> None:
-        """ReaderHandlerProgram::resume should implement phased resume flow."""
+        """ReaderHandlerProgram::resume must be unreachable for one-shot lookup."""
         import pathlib
 
         handler_src = pathlib.Path(
-            "/Users/s22625/repos/doeff/packages/doeff-vm/src/handler.rs"
+            pathlib.Path(__file__).resolve().parents[2]
+            / "packages"
+            / "doeff-vm"
+            / "src"
+            / "handler.rs"
         ).read_text()
 
         # Find ReaderHandlerProgram's resume method
@@ -301,17 +305,21 @@ class TestG24HandlerResumeSemantics:
         reader_section = _extract_impl_resume(handler_src, "ReaderHandlerProgram")
         assert reader_section is not None, "Could not find ReaderHandlerProgram::resume"
 
-        assert "ReaderPhase::AwaitHandlers" in reader_section
-        assert "ReaderPhase::AwaitEval" in reader_section
-        assert "DoCtrl::Eval" in reader_section
-        assert "DoCtrl::Resume" in reader_section
+        assert "unreachable!" in reader_section, (
+            "ReaderHandlerProgram::resume should be unreachable for pure Ask lookup, "
+            f"but contains: {reader_section.strip()}"
+        )
 
     def test_writer_handler_resume_is_unreachable(self) -> None:
         """WriterHandlerProgram::resume must use unreachable!(), not Return."""
         import pathlib
 
         handler_src = pathlib.Path(
-            "/Users/s22625/repos/doeff/packages/doeff-vm/src/handler.rs"
+            pathlib.Path(__file__).resolve().parents[2]
+            / "packages"
+            / "doeff-vm"
+            / "src"
+            / "handler.rs"
         ).read_text()
 
         writer_section = _extract_impl_resume(handler_src, "WriterHandlerProgram")

--- a/tests/public_api/test_kpc_macro_runtime_contract.py
+++ b/tests/public_api/test_kpc_macro_runtime_contract.py
@@ -25,7 +25,7 @@ class TestNoLegacyKpcExports:
 class TestDefaultAndPresetsRemainUsable:
     def test_default_handlers_contains_core_runtime_handlers(self) -> None:
         handlers = default_handlers()
-        assert len(handlers) == 6
+        assert len(handlers) == 7
 
     def test_sync_preset_uses_runtime_handler_sentinels(self) -> None:
         names = [str(getattr(h, "name", repr(h))).lower() for h in presets.sync_preset]


### PR DESCRIPTION
## Summary

Extract lazy `Ask` coordination out of `ReaderHandler` into a dedicated `LazyAskHandler`, making lazy evaluation cache/semaphore behavior independent of `Reader`/`Scheduler` ordering.

### What changed

- Added `LazyAskHandlerFactory` and `LazyAskHandlerProgram` in `packages/doeff-vm/src/handler.rs`.
  - Handles `Ask` interception, lazy-value detection, cache lookup/update, semaphore coordination (`Create`/`Acquire`/`Release`), delegation to reader, and lazy eval.
  - Uses run-scoped internal state (`cache` + `semaphores`) to avoid cross-run leakage.
- Simplified `ReaderHandlerProgram` to pure env lookup (`Ask -> env[key] -> Resume`), no semaphore/cache/lazy eval paths.
- Removed lazy cache/semaphore state from `RustStore` in `packages/doeff-vm/src/rust_store.rs`.
- Registered new `lazy_ask` sentinel in Rust/Python VM exports:
  - `packages/doeff-vm/src/pyvm.rs`
  - `packages/doeff-vm/doeff_vm/__init__.py`
  - `packages/doeff-vm/src/lib.rs`
- Updated default handler presets to include `lazy_ask` (after `scheduler`):
  - `doeff/rust_vm.py`
  - `doeff/handlers.py`
- Updated and expanded tests to cover lazy ask behavior, reader purity, ordering independence, and updated core handler contracts:
  - `tests/effects/test_lazy_ask_semaphore.py`
  - `tests/core/test_rust_vm_api_strict.py`
  - `tests/core/test_sa002_spec_gaps.py`
  - `tests/public_api/test_kpc_macro_runtime_contract.py`
  - `tests/core/test_spec_gaps.py`

## Acceptance Criteria Evidence (ISSUE-CORE-504)

- AC-1: `LazyAskHandler` intercepts `Ask` and delegates raw lookup to Reader
  - Implemented in `packages/doeff-vm/src/handler.rs` (`LazyAskHandlerProgram::handle_ask` + `lazy_ask_delegate_reader_effect`).
  - Verified by passing tests in `tests/effects/test_lazy_ask_semaphore.py`.
- AC-2: Caches evaluated lazy values
  - `test_lazy_ask_caches` passes.
- AC-3: Concurrent lazy ask single evaluation with semaphore coordination
  - `test_concurrent_lazy_ask_single_evaluation` passes (`calls == 1`).
- AC-4: Non-lazy `Ask` passthrough
  - `test_non_lazy_ask_passthrough` passes.
- AC-5: Reader has zero semaphore/cache logic
  - `ReaderHandlerProgram::resume` is `unreachable!` and reader logic is pure lookup.
  - `test_reader_no_semaphore_dependency` passes with `handlers=[reader]` only.
- AC-6: Reader/Scheduler ordering independence
  - `test_ordering_independence` passes for multiple reader/scheduler orders (with `lazy_ask` innermost).
- AC-7: lazy detection removed from Reader
  - `as_lazy_eval_expr` usage removed from Reader flow; lazy logic moved to LazyAsk.
- AC-8: `RustStore` lazy cache/semaphore removed
  - `packages/doeff-vm/src/rust_store.rs` no longer has `lazy_cache`/`lazy_semaphores` fields or methods.
- AC-9: `lazy_ask` sentinel exported from `doeff_vm`
  - Added in `packages/doeff-vm/src/pyvm.rs` and re-exported in `packages/doeff-vm/doeff_vm/__init__.py`.
- AC-10: `default_handlers()` and `default_async_handlers()` include `lazy_ask`
  - Updated `doeff/rust_vm.py` required sentinel tuple.
- AC-11: Existing lazy ask tests no regression
  - `uv run pytest tests/effects/test_lazy_ask_semaphore.py -v` passes.
- AC-12: `cargo test` passes for doeff-vm
  - `cargo test --manifest-path packages/doeff-vm/Cargo.toml` passes (140 tests).
- AC-13: full pytest suite passes
  - `uv run pytest tests/ -q` passes (`479 passed, 6 skipped`).

## Validation Commands Run

- `cargo test --manifest-path packages/doeff-vm/Cargo.toml`
- `uv run pytest tests/effects/test_lazy_ask_semaphore.py -v`
- `uv run pytest tests/ -q`

All passed.

## Issue

Fixes ISSUE-CORE-504
