### PR TITLE
Extract lazy Ask coordination into LazyAskHandler (ISSUE-CORE-504)

### DIFF
--- a/doeff/handlers.py
+++ b/doeff/handlers.py
@@ -3,7 +3,7 @@
 These are user-space handler sentinels. The VM only dispatches to handlers and
 does not own handler semantics.
 
-Provides: state, reader, writer, result_safe, scheduler, await_handler.
+Provides: state, reader, writer, result_safe, scheduler, lazy_ask, await_handler.
 Default Await behavior for run()/async_run() comes from Python handlers in
 doeff.effects.future via default handler presets.
 """
@@ -16,6 +16,7 @@ _HANDLER_SENTINELS = {
     "writer",
     "result_safe",
     "scheduler",
+    "lazy_ask",
     "await_handler",
 }
 
@@ -32,4 +33,4 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["state", "reader", "writer", "result_safe", "scheduler", "await_handler"]
+__all__ = ["state", "reader", "writer", "result_safe", "scheduler", "lazy_ask", "await_handler"]

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -130,7 +130,7 @@ async def _call_async_run_fn(run_fn: Any, program: Any, kwargs: dict[str, Any]) 
 
 def _core_handler_sentinels(vm: Any) -> list[Any]:
     """Return the shared core handler sentinel stack from doeff_vm."""
-    required = ("state", "reader", "writer", "result_safe", "scheduler")
+    required = ("state", "reader", "writer", "result_safe", "scheduler", "lazy_ask")
     if all(hasattr(vm, name) for name in required):
         return [getattr(vm, name) for name in required]
     missing = [name for name in required if not hasattr(vm, name)]
@@ -284,6 +284,7 @@ def __getattr__(name: str) -> Any:
         "reader",
         "writer",
         "result_safe",
+        "lazy_ask",
         "await_handler",
     }:
         vm = _vm()
@@ -318,5 +319,6 @@ __all__ = [
     "reader",
     "writer",
     "result_safe",
+    "lazy_ask",
     "await_handler",
 ]

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -92,6 +92,7 @@ reader = _ext.reader
 writer = _ext.writer
 result_safe = _ext.result_safe
 scheduler = _ext.scheduler
+lazy_ask = _ext.lazy_ask
 await_handler = _ext.await_handler
 CreateContinuation = _ext.CreateContinuation
 GetContinuation = _ext.GetContinuation
@@ -197,6 +198,7 @@ __all__ = [
     "reader",
     "run",
     "scheduler",
+    "lazy_ask",
     "state",
     "result_safe",
     "await_handler",

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -12,16 +12,16 @@
 pub mod arena;
 pub mod capture;
 pub mod continuation;
-mod effect;
 pub mod dispatch;
 pub mod do_ctrl;
 pub mod driver;
+mod effect;
 pub mod error;
 pub mod frame;
 mod handler;
 pub mod ids;
-pub mod python_call;
 pub mod py_shared;
+pub mod python_call;
 pub mod pyvm;
 pub mod rust_store;
 pub mod scheduler;
@@ -34,8 +34,7 @@ pub mod yielded;
 // Re-exports for convenience
 pub use arena::SegmentArena;
 pub use capture::{
-    CaptureEvent, DelegationEntry, DispatchAction, FrameId, HandlerAction, HandlerKind,
-    TraceEntry,
+    CaptureEvent, DelegationEntry, DispatchAction, FrameId, HandlerAction, HandlerKind, TraceEntry,
 };
 pub use continuation::Continuation;
 pub use dispatch::DispatchContext;
@@ -45,14 +44,15 @@ pub use effect::{Effect, PyAsk, PyGet, PyModify, PyPut, PyTell};
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{
-    Handler, HandlerEntry, ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
+    Handler, HandlerEntry, LazyAskHandlerFactory, ReaderHandlerFactory, StateHandlerFactory,
+    WriterHandlerFactory,
 };
 pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
-pub use pyvm::{DoExprTag, PyStdlib, PyVM};
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
+pub use pyvm::{DoExprTag, PyStdlib, PyVM};
 pub use rust_store::RustStore;
 pub use segment::{Segment, SegmentKind};
 pub use step::PyException;
-pub use yielded::Yielded;
 pub use value::Value;
 pub use vm::{Callback, VM};
+pub use yielded::Yielded;

--- a/packages/doeff-vm/src/rust_store.rs
+++ b/packages/doeff-vm/src/rust_store.rs
@@ -5,24 +5,10 @@ use std::collections::HashMap;
 use crate::value::Value;
 
 #[derive(Debug, Clone)]
-struct LazyCacheEntry {
-    source_id: usize,
-    value: Value,
-}
-
-#[derive(Debug, Clone)]
-struct LazySemaphoreEntry {
-    source_id: usize,
-    semaphore: Value,
-}
-
-#[derive(Debug, Clone)]
 pub struct RustStore {
     pub state: HashMap<String, Value>,
     pub env: HashMap<String, Value>,
     pub log: Vec<Value>,
-    lazy_cache: HashMap<String, LazyCacheEntry>,
-    lazy_semaphores: HashMap<String, LazySemaphoreEntry>,
 }
 
 impl RustStore {
@@ -31,8 +17,6 @@ impl RustStore {
             state: HashMap::new(),
             env: HashMap::new(),
             log: Vec::new(),
-            lazy_cache: HashMap::new(),
-            lazy_semaphores: HashMap::new(),
         }
     }
 
@@ -96,31 +80,6 @@ impl RustStore {
 
     pub fn clear_logs(&mut self) -> Vec<Value> {
         std::mem::take(&mut self.log)
-    }
-
-    pub fn lazy_cache_get(&self, key: &str, source_id: usize) -> Option<Value> {
-        let entry = self.lazy_cache.get(key)?;
-        if entry.source_id == source_id {
-            return Some(entry.value.clone());
-        }
-        None
-    }
-
-    pub fn lazy_cache_put(&mut self, key: String, source_id: usize, value: Value) {
-        self.lazy_cache.insert(key, LazyCacheEntry { source_id, value });
-    }
-
-    pub fn lazy_semaphore_get(&self, key: &str, source_id: usize) -> Option<Value> {
-        let entry = self.lazy_semaphores.get(key)?;
-        if entry.source_id == source_id {
-            return Some(entry.semaphore.clone());
-        }
-        None
-    }
-
-    pub fn lazy_semaphore_put(&mut self, key: String, source_id: usize, semaphore: Value) {
-        self.lazy_semaphores
-            .insert(key, LazySemaphoreEntry { source_id, semaphore });
     }
 }
 

--- a/tests/core/test_handlers_exports.py
+++ b/tests/core/test_handlers_exports.py
@@ -16,3 +16,15 @@ def test_result_safe_resolves_to_doeff_vm_sentinel(monkeypatch: pytest.MonkeyPat
     assert hasattr(doeff_vm, "result_safe")
     monkeypatch.delitem(handlers.__dict__, "result_safe", raising=False)
     assert handlers.result_safe is doeff_vm.result_safe
+
+
+def test_lazy_ask_is_part_of_handlers_module_contract() -> None:
+    assert "lazy_ask" in handlers.__all__
+    assert "lazy_ask" in handlers._HANDLER_SENTINELS
+    assert "lazy_ask" in (handlers.__doc__ or "")
+
+
+def test_lazy_ask_resolves_to_doeff_vm_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert hasattr(doeff_vm, "lazy_ask")
+    monkeypatch.delitem(handlers.__dict__, "lazy_ask", raising=False)
+    assert handlers.lazy_ask is doeff_vm.lazy_ask

--- a/tests/core/test_rust_vm_api_strict.py
+++ b/tests/core/test_rust_vm_api_strict.py
@@ -26,6 +26,7 @@ def test_default_handlers_are_module_sentinels_only(monkeypatch: pytest.MonkeyPa
         "writer": object(),
         "result_safe": object(),
         "scheduler": object(),
+        "lazy_ask": object(),
     }
     fake_vm = SimpleNamespace(**sentinels)
     monkeypatch.setattr(rust_vm_module, "_vm", lambda: fake_vm)
@@ -38,6 +39,7 @@ def test_default_handlers_are_module_sentinels_only(monkeypatch: pytest.MonkeyPa
         sentinels["writer"],
         sentinels["result_safe"],
         sentinels["scheduler"],
+        sentinels["lazy_ask"],
         sync_await_handler,
     ]
 
@@ -53,6 +55,7 @@ def test_default_async_handlers_use_async_await_handler(
         "writer": object(),
         "result_safe": object(),
         "scheduler": object(),
+        "lazy_ask": object(),
     }
     fake_vm = SimpleNamespace(**sentinels)
     monkeypatch.setattr(rust_vm_module, "_vm", lambda: fake_vm)
@@ -65,6 +68,7 @@ def test_default_async_handlers_use_async_await_handler(
         sentinels["writer"],
         sentinels["result_safe"],
         sentinels["scheduler"],
+        sentinels["lazy_ask"],
         async_await_handler,
     ]
 

--- a/tests/core/test_sa002_spec_gaps.py
+++ b/tests/core/test_sa002_spec_gaps.py
@@ -77,7 +77,7 @@ def test_SA_002_G05_default_handlers_and_presets_contract() -> None:
 
     handlers = default_handlers()
     names = [str(getattr(h, "name", repr(h))).lower() for h in handlers]
-    assert len(handlers) == 6, "default_handlers() must include core runtime handlers"
+    assert len(handlers) == 7, "default_handlers() must include core runtime handlers"
     assert any("state" in n for n in names)
     assert any("reader" in n for n in names)
     assert any("writer" in n for n in names)

--- a/tests/public_api/test_kpc_macro_runtime_contract.py
+++ b/tests/public_api/test_kpc_macro_runtime_contract.py
@@ -25,7 +25,7 @@ class TestNoLegacyKpcExports:
 class TestDefaultAndPresetsRemainUsable:
     def test_default_handlers_contains_core_runtime_handlers(self) -> None:
         handlers = default_handlers()
-        assert len(handlers) == 6
+        assert len(handlers) == 7
 
     def test_sync_preset_uses_runtime_handler_sentinels(self) -> None:
         names = [str(getattr(h, "name", repr(h))).lower() for h in presets.sync_preset]


### PR DESCRIPTION
## Summary

Implements ISSUE-CORE-504 by extracting lazy `Ask` coordination out of `ReaderHandler` into a dedicated `LazyAskHandler`.

### What changed

- Added `LazyAskHandlerFactory` and `LazyAskHandlerProgram` in `packages/doeff-vm/src/handler.rs`.
  - Intercepts `Ask`
  - Maintains run-scoped lazy cache + semaphore state in handler-owned state
  - Coordinates `CreateSemaphore` / `AcquireSemaphore` / `ReleaseSemaphore`
  - Evaluates lazy values via `DoCtrl::Eval`
- Simplified `ReaderHandler` to pure env lookup (`Ask(key) -> env[key] -> Resume`).
- Removed lazy cache/semaphore storage from `RustStore` (`packages/doeff-vm/src/rust_store.rs`).
- Exported `lazy_ask` sentinel from `doeff_vm` (`packages/doeff-vm/src/pyvm.rs` and `packages/doeff-vm/doeff_vm/__init__.py`).
- Added `lazy_ask` into default handler presets (`doeff/rust_vm.py`).
- Updated handler exports (`doeff/handlers.py`).
- Updated and expanded lazy ask contract tests (`tests/effects/test_lazy_ask_semaphore.py`) and sentinel/default-handler contract tests.

## Acceptance Criteria Evidence

- AC-1 LazyAsk intercepts `Ask` and delegates raw lookup path to outer reader chain
  - Implemented in `packages/doeff-vm/src/handler.rs` (`LazyAskHandlerProgram`, `LazyAskPhase::AwaitDelegate*`).
- AC-2 LazyAsk caches evaluated lazy values
  - `uv run pytest tests/effects/test_lazy_ask_semaphore.py -v`
  - `test_lazy_ask_caches` passed.
- AC-3 Concurrent lazy Ask single evaluation via semaphore coordination
  - Same command above
  - `test_concurrent_lazy_ask_single_evaluation` passed.
- AC-4 Non-lazy Ask passthrough unchanged
  - Same command above
  - `test_non_lazy_ask_passthrough` passed.
- AC-5 Reader has zero semaphore/cache logic (pure lookup)
  - Reader code now only `store.ask` + `Resume` and `resume()` is `unreachable!`.
  - `test_reader_no_semaphore_dependency` passed.
- AC-6 Reader/Scheduler ordering independence
  - `test_ordering_independence` passed.
- AC-7 Lazy detection logic removed from ReaderHandler
  - Reader section in `packages/doeff-vm/src/handler.rs` has no semaphore/cache phase logic.
- AC-8 `lazy_cache` / `lazy_semaphores` removed from RustStore
  - `rg -n "lazy_cache|lazy_semaphores|lazy_cache_get|lazy_cache_put|lazy_semaphore_get|lazy_semaphore_put" packages/doeff-vm/src/rust_store.rs`
  - No matches.
- AC-9 `lazy_ask` sentinel exported from doeff_vm
  - `rg -n "lazy_ask" packages/doeff-vm/src/pyvm.rs packages/doeff-vm/doeff_vm/__init__.py`
- AC-10 defaults include `lazy_ask`
  - `doeff/rust_vm.py` `_core_handler_sentinels` now requires `("state", "reader", "writer", "result_safe", "scheduler", "lazy_ask")`.
- AC-11 Existing lazy Ask behavior regression coverage
  - `uv run pytest tests/effects/test_lazy_ask_semaphore.py -v` passed (10 passed).
- AC-12 Rust VM tests pass
  - `cargo test --manifest-path packages/doeff-vm/Cargo.toml` passed.
- AC-13 Python test suite passes
  - `uv run pytest tests/ -q` => `481 passed, 6 skipped`.

## Validation Commands Run

- `cargo test --manifest-path packages/doeff-vm/Cargo.toml`
- `uv sync --group dev --reinstall-package doeff-vm --reinstall-package doeff`
- `uv run pytest tests/effects/test_lazy_ask_semaphore.py -v`
- `uv run pytest tests/core/test_rust_vm_api_strict.py tests/core/test_handlers_exports.py tests/public_api/test_kpc_macro_runtime_contract.py tests/core/test_sa002_spec_gaps.py -q`
- `uv run pytest tests/ -q`

Refs: ISSUE-CORE-504
