### PR TITLE
Align Task.cancel with SPEC-SCHED-001 effectful cancellation

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -13,6 +13,88 @@ rules:
   # EFFECT SYSTEM PATTERNS
   # ---------------------------------------------------------------------------
 
+  - id: doeff-no-python-side-cancel-state
+    patterns:
+      - pattern-either:
+          - pattern: _cancelled_task_ids
+          - pattern: _cancelled_task_ids.add(...)
+          - pattern: _cancelled_task_ids.discard(...)
+          - pattern: $X in _cancelled_task_ids
+    paths:
+      include:
+        - "**/doeff/**"
+      exclude:
+        - "**/tests/**"
+    message: |
+      BANNED: Python-side cancel state management.
+      Cancellation state belongs in the Rust scheduler (`cancel_requested: HashSet<TaskId>`).
+      Task.cancel() must yield a PyCancelEffect, not mutate Python globals.
+      See SPEC-SCHED-001 §Cancel, ISSUE-CORE-502.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: architecture
+      rationale: "Cancel state ownership — SPEC-SCHED-001, ISSUE-CORE-502"
+
+  - id: doeff-no-python-task-id-extraction
+    patterns:
+      - pattern-inside: |
+          class Task:
+              ...
+      - pattern: task_id_of(...)
+    paths:
+      include:
+        - "**/doeff/effects/spawn.py"
+    message: |
+      BANNED: Python code must not extract task_id from Rust handles for scheduler operations.
+      Task operations (cancel, is_done) should yield effects handled by the Rust scheduler.
+      The Python layer should not inspect or decode Rust-internal handle structures.
+      See SPEC-SCHED-001 §PyTask, ISSUE-CORE-502.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: architecture
+      rationale: "Layer boundary — Python must not inspect Rust handle internals"
+
+  - id: doeff-no-rust-poll-python-cancel-state
+    pattern-regex: 'getattr\("_cancelled_task_ids"\)'
+    paths:
+      include:
+        - "**/packages/doeff-vm/src/**"
+    message: |
+      BANNED: Rust scheduler must not poll Python for cancellation state.
+      The scheduler owns cancel_requested via PyCancelEffect handler.
+      Remove GIL round-trip polling of _cancelled_task_ids.
+      See SPEC-SCHED-001, ISSUE-CORE-502.
+    languages: [rust]
+    severity: ERROR
+    metadata:
+      category: architecture
+      rationale: "Scheduler state ownership — cancel state lives in Rust"
+
+  - id: doeff-cancel-must-be-effectful
+    patterns:
+      - pattern-inside: |
+          class Task:
+              ...
+      - pattern: |
+          def cancel(self):
+              ...
+              return Program.pure(...)
+    paths:
+      include:
+        - "**/doeff/effects/spawn.py"
+    message: |
+      BANNED: Task.cancel() must yield an effect, not return Program.pure().
+      Cancel is a scheduler operation — it must go through effect dispatch.
+      Use: return create_effect_with_trace(TaskCancelEffect(task=self), ...)
+      See SPEC-SCHED-001 §PyTask, ISSUE-CORE-502.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: architecture
+      rationale: "Cancel must be effectful per SPEC-SCHED-001"
+
   - id: doeff-no-direct-generator-in-do
     patterns:
       - pattern: |

--- a/doeff/effects/gather.py
+++ b/doeff/effects/gather.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import doeff_vm
 
 from .base import Effect, create_effect_with_trace
-from .spawn import TaskCancelledError, Waitable, is_task_cancelled, normalize_waitable
+from .spawn import Waitable, normalize_waitable
 
 if TYPE_CHECKING:
     from doeff.program import ProgramBase
@@ -44,10 +44,6 @@ def Gather(*items: "Waitable[Any] | ProgramBase[Any]") -> Any:
 
     @do
     def _program():
-        for item in validated:
-            if is_task_cancelled(item):
-                raise TaskCancelledError("Task was cancelled")
-
         return (
             yield create_effect_with_trace(
                 GatherEffect(items=validated),

--- a/doeff/effects/race.py
+++ b/doeff/effects/race.py
@@ -6,7 +6,7 @@ from typing import Any, Generic, TypeVar
 import doeff_vm
 
 from .base import Effect, create_effect_with_trace
-from .spawn import TaskCancelledError, Waitable, is_task_cancelled, normalize_waitable
+from .spawn import Waitable, normalize_waitable
 
 T = TypeVar("T")
 
@@ -45,10 +45,6 @@ def Race(*futures: Waitable[Any]):
 
     @do
     def _program():
-        for waitable in validated:
-            if is_task_cancelled(waitable):
-                raise TaskCancelledError("Task was cancelled")
-
         value = yield create_effect_with_trace(RaceEffect(validated), skip_frames=3)
         return RaceResult(first=validated[0], value=value, rest=tuple(validated[1:]))
 

--- a/doeff/effects/scheduler_internal.py
+++ b/doeff/effects/scheduler_internal.py
@@ -120,19 +120,6 @@ class _SchedulerCreateTaskHandle(EffectBase):
 
 
 @dataclass(frozen=True, kw_only=True)
-class _SchedulerCancelTask(EffectBase):
-    """Request cancellation of a task.
-
-    Attributes:
-        handle_id: The task's handle ID
-
-    Returns True if task was cancelled, False if already complete or not found.
-    """
-
-    handle_id: Any
-
-
-@dataclass(frozen=True, kw_only=True)
 class _SchedulerCreatePromise(EffectBase):
     """Create a new promise handle.
 
@@ -205,7 +192,6 @@ def async_external_wait_handler(effect: Any, k: Any):
 
 
 __all__ = [
-    "_SchedulerCancelTask",
     "_SchedulerCreatePromise",
     "_SchedulerCreateTaskHandle",
     "_SchedulerDequeueTask",

--- a/doeff/effects/wait.py
+++ b/doeff/effects/wait.py
@@ -5,7 +5,7 @@ from typing import Any, TypeVar
 
 from .base import Effect, EffectBase, create_effect_with_trace
 from .gather import gather
-from .spawn import TaskCancelledError, Waitable, is_task_cancelled, normalize_waitable
+from .spawn import Waitable, normalize_waitable
 
 T = TypeVar("T")
 
@@ -31,9 +31,6 @@ def Wait(future: Waitable[T]):
 
     @do
     def _program():
-        if is_task_cancelled(normalized):
-            raise TaskCancelledError("Task was cancelled")
-
         values = yield gather(normalized)
         return values[0]
 

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -112,6 +112,7 @@ CreatePromiseEffect = _ext.CreatePromiseEffect
 CompletePromiseEffect = _ext.CompletePromiseEffect
 FailPromiseEffect = _ext.FailPromiseEffect
 CreateExternalPromiseEffect = _ext.CreateExternalPromiseEffect
+PyCancelEffect = _ext.PyCancelEffect
 _SchedulerTaskCompleted = _ext._SchedulerTaskCompleted
 
 # R13-I: DoExprTag constants
@@ -143,6 +144,7 @@ PyCreatePromise = CreatePromiseEffect
 PyCompletePromise = CompletePromiseEffect
 PyFailPromise = FailPromiseEffect
 PyCreateExternalPromise = CreateExternalPromiseEffect
+TaskCancelEffect = PyCancelEffect
 PyTaskCompleted = _SchedulerTaskCompleted
 
 __all__ = [
@@ -166,6 +168,7 @@ __all__ = [
     "PyCompletePromise",
     "PyFailPromise",
     "PyCreateExternalPromise",
+    "PyCancelEffect",
     "PyTaskCompleted",
     "SpawnEffect",
     "GatherEffect",
@@ -174,6 +177,7 @@ __all__ = [
     "CompletePromiseEffect",
     "FailPromiseEffect",
     "CreateExternalPromiseEffect",
+    "TaskCancelEffect",
     "_SchedulerTaskCompleted",
     "PyModify",
     "PyPut",

--- a/packages/doeff-vm/src/effect.rs
+++ b/packages/doeff-vm/src/effect.rs
@@ -97,6 +97,12 @@ pub struct PyFailPromise {
 #[pyclass(frozen, name = "CreateExternalPromiseEffect", extends=PyEffectBase)]
 pub struct PyCreateExternalPromise;
 
+#[pyclass(frozen, name = "PyCancelEffect", extends=PyEffectBase)]
+pub struct PyCancelEffect {
+    #[pyo3(get)]
+    pub task: Py<PyAny>,
+}
+
 #[pyclass(frozen, name = "_SchedulerTaskCompleted", extends=PyEffectBase)]
 pub struct PyTaskCompleted {
     #[pyo3(get)]
@@ -312,6 +318,20 @@ impl PyCreateExternalPromise {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyCreateExternalPromise)
+    }
+}
+
+#[pymethods]
+impl PyCancelEffect {
+    #[classattr]
+    const __doeff_scheduler_cancel__: bool = true;
+
+    #[new]
+    fn new(task: Py<PyAny>) -> PyClassInitializer<Self> {
+        PyClassInitializer::from(PyEffectBase {
+            tag: DoExprTag::Effect as u8,
+        })
+        .add_subclass(PyCancelEffect { task })
     }
 }
 

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -40,7 +40,7 @@ pub use continuation::Continuation;
 pub use dispatch::DispatchContext;
 pub use do_ctrl::DoCtrl;
 pub use driver::{Mode, StepEvent};
-pub use effect::{Effect, PyAsk, PyGet, PyModify, PyPut, PyTell};
+pub use effect::{Effect, PyAsk, PyCancelEffect, PyGet, PyModify, PyPut, PyTell};
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -6,9 +6,9 @@ use pyo3::types::{PyDict, PyTuple};
 
 use crate::do_ctrl::{CallArg, DoCtrl};
 use crate::effect::{
-    dispatch_from_shared, dispatch_to_pyobject, PyAsk, PyCompletePromise, PyCreateExternalPromise,
-    PyCreatePromise, PyFailPromise, PyGather, PyGet, PyModify, PyPut, PyRace, PySpawn,
-    PyTaskCompleted, PyTell,
+    dispatch_from_shared, dispatch_to_pyobject, PyAsk, PyCancelEffect, PyCompletePromise,
+    PyCreateExternalPromise, PyCreatePromise, PyFailPromise, PyGather, PyGet, PyModify, PyPut,
+    PyRace, PySpawn, PyTaskCompleted, PyTell,
 };
 
 // ---------------------------------------------------------------------------
@@ -2874,6 +2874,7 @@ pub fn doeff_vm(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCompletePromise>()?;
     m.add_class::<PyFailPromise>()?;
     m.add_class::<PyCreateExternalPromise>()?;
+    m.add_class::<PyCancelEffect>()?;
     m.add_class::<PyTaskCompleted>()?;
     // G14: scheduler sentinel
     m.add(

--- a/tests/effects/test_cancel_effectful.py
+++ b/tests/effects/test_cancel_effectful.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from doeff import (
+    AcquireSemaphore,
+    CreateSemaphore,
+    Pure,
+    ReleaseSemaphore,
+    Safe,
+    Spawn,
+    Wait,
+    default_handlers,
+    do,
+    run,
+)
+from doeff.effects import TaskCancelledError
+from doeff.effects.spawn import Task
+from doeff.program import Program
+from doeff.types import EffectBase
+
+
+def test_cancel_yields_effect() -> None:
+    """Task.cancel() must yield an EffectBase, not Program.pure()."""
+    task = Task(backend="thread", _handle={"type": "Task", "task_id": 0})
+    result = task.cancel()
+
+    assert isinstance(result, EffectBase)
+    assert not isinstance(result, Program)
+
+
+def test_no_python_side_cancel_state() -> None:
+    """Cancellation state should live in Rust scheduler state, not Python globals."""
+    import doeff.effects.spawn as spawn_mod
+
+    assert not hasattr(spawn_mod, "_cancelled_task_ids")
+
+
+def test_cancel_pending_task() -> None:
+    """Cancelling a pending task should mark it cancelled immediately."""
+
+    @do
+    def program():
+        task = yield Spawn(Pure("never runs"))
+        _ = yield task.cancel()
+        return (yield Safe(Wait(task)))
+
+    result = run(program(), handlers=default_handlers())
+    assert result.is_ok()
+    assert result.value.is_err()
+    assert isinstance(result.value.error, TaskCancelledError)
+
+
+def test_cancel_running_task_cooperative() -> None:
+    """Cancelling a running task should fail Wait with TaskCancelledError."""
+
+    @do
+    def cooperative_spin():
+        for _ in range(10_000):
+            yield Pure(None)
+        return "finished"
+
+    @do
+    def program():
+        task = yield Spawn(cooperative_spin())
+        yield Pure(None)
+        _ = yield task.cancel()
+        return (yield Safe(Wait(task)))
+
+    result = run(program(), handlers=default_handlers())
+    assert result.is_ok()
+    assert result.value.is_err()
+    assert isinstance(result.value.error, TaskCancelledError)
+
+
+def test_cancel_cleans_semaphore_waiters() -> None:
+    """Cancelling a blocked semaphore waiter should remove it immediately."""
+
+    @do
+    def waiter(sem):
+        yield AcquireSemaphore(sem)
+        yield ReleaseSemaphore(sem)
+
+    @do
+    def program():
+        sem = yield CreateSemaphore(1)
+        yield AcquireSemaphore(sem)
+
+        blocked = yield Spawn(waiter(sem))
+        yield Pure(None)
+        _ = yield blocked.cancel()
+
+        yield ReleaseSemaphore(sem)
+        yield AcquireSemaphore(sem)
+        yield ReleaseSemaphore(sem)
+        return (yield Safe(Wait(blocked)))
+
+    result = run(program(), handlers=default_handlers())
+    assert result.is_ok()
+    assert result.value.is_err()
+    assert isinstance(result.value.error, TaskCancelledError)


### PR DESCRIPTION
## Summary
- implement `PyCancelEffect` in doeff-vm and register/export it through Python bindings
- route `Task.cancel()` through scheduler effect dispatch (`TaskCancelEffect` aliasing `PyCancelEffect`)
- move cancellation ownership fully into Rust scheduler (`cancel_requested: HashSet<TaskId>`)
- remove Python-side cancel globals/polling and delete dead `_SchedulerCancelTask`
- perform semaphore waiter cleanup at cancel time instead of per-operation polling
- add ISSUE-CORE-502 semgrep guardrails and new T1-T5 regression tests

## Acceptance Criteria Evidence
- AC-1 `Task.cancel()` yields an effect: `tests/effects/test_cancel_effectful.py::test_cancel_yields_effect` passes
- AC-2 Cancel effect handled by Rust scheduler: new parse+dispatch paths in `packages/doeff-vm/src/scheduler.rs` for `PyCancelEffect`/`TaskCancelEffect`; covered by cancel tests
- AC-3 State transitions per cancel semantics: scheduler now distinguishes running vs non-running cancellation (`request_task_cancellation`, `apply_running_task_cancellation_if_requested`)
- AC-4 Blocked-task semaphore cleanup on cancel: `remove_semaphore_waiters_for_task` + `test_cancel_cleans_semaphore_waiters`
- AC-5 Python `_cancelled_task_ids` removed: `tests/effects/test_cancel_effectful.py::test_no_python_side_cancel_state` passes
- AC-6 Rust GIL polling removed: `is_task_cancel_requested` deleted from `packages/doeff-vm/src/scheduler.rs`
- AC-7 Semgrep regression rules added: `.semgrep.yaml` rules `doeff-no-python-side-cancel-state`, `doeff-no-python-task-id-extraction`, `doeff-no-rust-poll-python-cancel-state`, `doeff-cancel-must-be-effectful`
- AC-8 T1-T5 pass: `uv run pytest tests/effects/test_cancel_effectful.py -q` -> `5 passed`
- AC-9 Existing cancel tests pass: `uv run pytest tests/effects/test_semaphore.py -v` includes `test_cancelled_waiter_is_removed_and_order_is_preserved` pass
- AC-10 Existing semaphore cancel interaction passes: same semaphore test command above
- AC-11 doeff-vm cargo tests pass: `cargo test --manifest-path packages/doeff-vm/Cargo.toml` -> `139 passed`
- AC-12 full tests pass: `uv run pytest tests/ -q` -> `486 passed, 6 skipped`

## Validation Commands
- `uv run pytest tests/effects/test_cancel_effectful.py -q`
- `cargo test --manifest-path packages/doeff-vm/Cargo.toml`
- `uv run pytest tests/effects/test_semaphore.py -v`
- `uv run pytest tests/ -q`
- `semgrep --config .semgrep.yaml doeff/effects/spawn.py packages/doeff-vm/src/scheduler.rs doeff/effects/scheduler_internal.py`
- `semgrep --config .semgrep.yaml doeff/effects/spawn.py packages/doeff-vm/src/scheduler.rs doeff/effects/scheduler_internal.py --json` (checked no matches for new ISSUE-CORE-502 rule IDs)

Ref: ISSUE-CORE-502
