### PR TITLE
Remove HashableAskEffect and add native hashable Reader keys

### DIFF
--- a/doeff/effects/reader.py
+++ b/doeff/effects/reader.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 from typing import Any
 
 import doeff_vm
@@ -12,116 +11,38 @@ from doeff.types import EnvKey
 
 from ._program_types import ProgramLike
 from ._validators import ensure_env_mapping, ensure_hashable, ensure_program_like
-from .base import Effect, EffectBase, create_effect_with_trace
+from .base import Effect, create_effect_with_trace
 
 
 AskEffect = doeff_vm.PyAsk
-
-
-@dataclass(frozen=True)
-class HashableAskEffect(EffectBase):
-    """Reader lookup effect that preserves non-string hashable keys."""
-
-    key: EnvKey
-
-
-@dataclass(frozen=True)
-class LocalEffect(EffectBase):
-    """Runs a sub-program against an updated environment and yields its value."""
-
-    env_update: Mapping[Any, object]
-    sub_program: ProgramLike
-
-    def __post_init__(self) -> None:
-        ensure_env_mapping(self.env_update, name="env_update")
-        ensure_program_like(self.sub_program, name="sub_program")
+LocalEffect = doeff_vm.PyLocal
 
 
 def ask(key: EnvKey) -> Effect:
     ensure_hashable(key, name="key")
-    if isinstance(key, str):
-        return create_effect_with_trace(AskEffect(key))
-    return create_effect_with_trace(HashableAskEffect(key=key))
-
-
-def _build_local_overlay(env_update: Mapping[Any, object]) -> dict[Any, object]:
-    overlay: dict[Any, object] = {}
-    for key, value in env_update.items():
-        overlay[key] = value
-        if not isinstance(key, str):
-            overlay[str(key)] = value
-    return overlay
-
-
-def _is_lazy_program_value(value: object) -> bool:
-    do_expr = getattr(doeff_vm, "DoExpr", None)
-    if do_expr is not None and isinstance(value, do_expr):
-        return True
-
-    effect_base = getattr(doeff_vm, "EffectBase", None)
-    if effect_base is not None and isinstance(value, effect_base):
-        return True
-
-    if bool(getattr(value, "__doeff_do_expr_base__", False)):
-        return True
-
-    return bool(getattr(value, "__doeff_effect_base__", False))
-
-
-def _build_local_handler(overlay: dict[Any, object]):
-    lazy_cache: dict[Any, object] = {}
-
-    def handle_local_ask(effect, k):
-        key: Any | None = None
-        if isinstance(effect, AskEffect):
-            key = effect.key
-        elif isinstance(effect, HashableAskEffect):
-            key = effect.key
-
-        if key is not None and key in overlay:
-            if key in lazy_cache:
-                return (yield doeff_vm.Resume(k, lazy_cache[key]))
-
-            value = overlay[key]
-            if _is_lazy_program_value(value):
-                resolved = yield value
-                lazy_cache[key] = resolved
-                return (yield doeff_vm.Resume(k, resolved))
-
-            return (yield doeff_vm.Resume(k, value))
-
-        return (yield doeff_vm.Delegate())
-
-    return handle_local_ask
+    return create_effect_with_trace(AskEffect(key))
 
 
 def local(env_update: Mapping[Any, object], sub_program: ProgramLike):
     ensure_env_mapping(env_update, name="env_update")
     ensure_program_like(sub_program, name="sub_program")
-
-    overlay = _build_local_overlay(env_update)
-    return doeff_vm.WithHandler(_build_local_handler(overlay), sub_program)
+    return create_effect_with_trace(LocalEffect(dict(env_update), sub_program))
 
 
 def Ask(key: EnvKey) -> Effect:
     ensure_hashable(key, name="key")
-    if isinstance(key, str):
-        return create_effect_with_trace(AskEffect(key), skip_frames=3)
-    return create_effect_with_trace(HashableAskEffect(key=key), skip_frames=3)
+    return create_effect_with_trace(AskEffect(key), skip_frames=3)
 
 
 def Local(env_update: Mapping[Any, object], sub_program: ProgramLike) -> Effect:
     ensure_env_mapping(env_update, name="env_update")
     ensure_program_like(sub_program, name="sub_program")
-
-    overlay = _build_local_overlay(env_update)
-    return doeff_vm.WithHandler(_build_local_handler(overlay), sub_program)
+    return create_effect_with_trace(LocalEffect(dict(env_update), sub_program), skip_frames=3)
 
 
 __all__ = [
     "Ask",
     "AskEffect",
-    "HashableAskEffect",
     "Local",
     "LocalEffect",
     "ask",

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -61,7 +61,7 @@ def _run_call_kwargs(
     run_fn: Any,
     *,
     handlers: Sequence[Any],
-    env: dict[str, Any] | None,
+    env: dict[Any, Any] | None,
     store: dict[str, Any] | None,
     trace: bool,
 ) -> dict[str, Any]:
@@ -87,18 +87,12 @@ def _run_call_kwargs(
     return kwargs
 
 
-def _normalize_env(env: dict[Any, Any] | None) -> dict[str, Any] | None:
+def _normalize_env(env: dict[Any, Any] | None) -> dict[Any, Any] | None:
     if env is None:
         return None
     if not isinstance(env, dict):
         raise TypeError(f"env must be a dict, got {type(env).__name__}")
-    normalized: dict[str, Any] = {}
-    for key, value in env.items():
-        if isinstance(key, str):
-            normalized[key] = value
-        else:
-            normalized[str(key)] = value
-    return normalized
+    return dict(env)
 
 
 def _is_unexpected_trace_keyword(exc: TypeError) -> bool:

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -104,6 +104,7 @@ PyGet = _ext.PyGet
 PyPut = _ext.PyPut
 PyModify = _ext.PyModify
 PyAsk = _ext.PyAsk
+PyLocal = _ext.PyLocal
 PyTell = _ext.PyTell
 SpawnEffect = _ext.SpawnEffect
 GatherEffect = _ext.GatherEffect
@@ -158,6 +159,7 @@ __all__ = [
     "DoThunkBase",
     "EffectBase",
     "PyAsk",
+    "PyLocal",
     "PyGet",
     "PySpawn",
     "PyGather",

--- a/packages/doeff-vm/src/effect.rs
+++ b/packages/doeff-vm/src/effect.rs
@@ -38,7 +38,15 @@ pub struct PyModify {
 #[pyclass(frozen, name = "PyAsk", extends=PyEffectBase)]
 pub struct PyAsk {
     #[pyo3(get)]
-    pub key: String,
+    pub key: Py<PyAny>,
+}
+
+#[pyclass(frozen, name = "PyLocal", extends=PyEffectBase)]
+pub struct PyLocal {
+    #[pyo3(get)]
+    pub env_update: Py<PyAny>,
+    #[pyo3(get)]
+    pub sub_program: Py<PyAny>,
 }
 
 #[pyclass(frozen, name = "PyTell", extends=PyEffectBase)]
@@ -145,11 +153,25 @@ impl PyModify {
 #[pymethods]
 impl PyAsk {
     #[new]
-    fn new(key: String) -> PyClassInitializer<Self> {
+    fn new(key: Py<PyAny>) -> PyClassInitializer<Self> {
         PyClassInitializer::from(PyEffectBase {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyAsk { key })
+    }
+}
+
+#[pymethods]
+impl PyLocal {
+    #[new]
+    fn new(env_update: Py<PyAny>, sub_program: Py<PyAny>) -> PyClassInitializer<Self> {
+        PyClassInitializer::from(PyEffectBase {
+            tag: DoExprTag::Effect as u8,
+        })
+        .add_subclass(PyLocal {
+            env_update,
+            sub_program,
+        })
     }
 }
 

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -20,6 +20,7 @@ pub mod error;
 pub mod frame;
 mod handler;
 pub mod ids;
+pub mod py_key;
 pub mod py_shared;
 pub mod python_call;
 pub mod pyvm;
@@ -48,6 +49,7 @@ pub use handler::{
     WriterHandlerFactory,
 };
 pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
+pub use py_key::HashedPyKey;
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
 pub use pyvm::{DoExprTag, PyStdlib, PyVM};
 pub use rust_store::RustStore;

--- a/packages/doeff-vm/src/py_key.rs
+++ b/packages/doeff-vm/src/py_key.rs
@@ -1,0 +1,102 @@
+//! Hashable Python key wrapper for Rust maps.
+
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+use pyo3::prelude::*;
+#[cfg(test)]
+use pyo3::types::PyString;
+
+#[derive(Clone)]
+enum HashedPyKeyInner {
+    Python(Py<PyAny>),
+    #[cfg(test)]
+    TestString(String),
+}
+
+/// Wrapper that preserves Python hash/equality behavior for dictionary keys.
+#[derive(Clone)]
+pub struct HashedPyKey {
+    hash: isize,
+    inner: HashedPyKeyInner,
+}
+
+impl HashedPyKey {
+    /// Build from a Python object by capturing its `hash(obj)` once.
+    pub fn from_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let hash = obj.hash()?;
+        Ok(Self {
+            hash,
+            inner: HashedPyKeyInner::Python(obj.clone().unbind()),
+        })
+    }
+
+    pub fn to_pyobject(&self, py: Python<'_>) -> Py<PyAny> {
+        match &self.inner {
+            HashedPyKeyInner::Python(obj) => obj.clone_ref(py),
+            #[cfg(test)]
+            HashedPyKeyInner::TestString(value) => PyString::new(py, value).into_any().unbind(),
+        }
+    }
+
+    pub fn display_for_error(&self) -> String {
+        Python::attach(|py| {
+            self.to_pyobject(py)
+                .bind(py)
+                .repr()
+                .and_then(|repr| repr.to_str().map(|s| s.to_owned()))
+                .unwrap_or_else(|_| "<unprintable env key>".to_string())
+        })
+    }
+
+    #[cfg(test)]
+    pub fn from_test_string(key: impl Into<String>) -> Self {
+        let value = key.into();
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        value.hash(&mut hasher);
+        let hash = (hasher.finish() & (isize::MAX as u64)) as isize;
+        Self {
+            hash,
+            inner: HashedPyKeyInner::TestString(value),
+        }
+    }
+}
+
+impl fmt::Debug for HashedPyKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashedPyKey")
+            .field("hash", &self.hash)
+            .field("repr", &self.display_for_error())
+            .finish()
+    }
+}
+
+impl PartialEq for HashedPyKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.inner, &other.inner) {
+            (HashedPyKeyInner::Python(lhs), HashedPyKeyInner::Python(rhs)) => {
+                if self.hash != other.hash {
+                    return false;
+                }
+                Python::attach(|py| lhs.bind(py).eq(rhs.bind(py)).unwrap_or(false))
+            }
+            #[cfg(test)]
+            (HashedPyKeyInner::TestString(lhs), HashedPyKeyInner::TestString(rhs)) => lhs == rhs,
+            #[cfg(test)]
+            (HashedPyKeyInner::Python(_), HashedPyKeyInner::TestString(_))
+            | (HashedPyKeyInner::TestString(_), HashedPyKeyInner::Python(_)) => false,
+        }
+    }
+}
+
+impl Eq for HashedPyKey {}
+
+impl Hash for HashedPyKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match &self.inner {
+            HashedPyKeyInner::Python(_) => self.hash.hash(state),
+            #[cfg(test)]
+            HashedPyKeyInner::TestString(value) => value.hash(state),
+        }
+    }
+}

--- a/tests/misc/test_reader_hashable_keys.py
+++ b/tests/misc/test_reader_hashable_keys.py
@@ -4,7 +4,9 @@ from typing import Protocol
 
 import pytest
 
-from doeff import Local, ask, do
+from doeff import Ask, Local, ask, do, run
+from doeff.effects.reader import AskEffect, LocalEffect
+from doeff.rust_vm import default_handlers
 from doeff.types import EffectGenerator
 
 
@@ -32,3 +34,51 @@ async def test_reader_accepts_hashable_class_keys(interpreter) -> None:
 def test_ask_rejects_unhashable_keys() -> None:
     with pytest.raises(TypeError, match=r"key must be hashable"):
         ask([])  # type: ignore[arg-type]
+
+
+def test_ask_uses_single_effect_type_for_hashable_keys() -> None:
+    assert isinstance(Ask("key"), AskEffect)
+    assert isinstance(Ask(42), AskEffect)
+    assert isinstance(Ask(("tuple", "key")), AskEffect)
+
+
+def test_reader_distinguishes_same_str_different_hash() -> None:
+    class ServiceA:
+        def __str__(self) -> str:
+            return "Service"
+
+        def __hash__(self) -> int:
+            return 1
+
+    class ServiceB:
+        def __str__(self) -> str:
+            return "Service"
+
+        def __hash__(self) -> int:
+            return 2
+
+    key_a = ServiceA()
+    key_b = ServiceB()
+
+    @do
+    def program() -> EffectGenerator[tuple[str, str]]:
+        value_a: str = yield ask(key_a)
+        value_b: str = yield ask(key_b)
+        return (value_a, value_b)
+
+    result = run(
+        program(),
+        handlers=default_handlers(),
+        env={key_a: "service-a", key_b: "service-b"},
+    )
+    assert result.is_ok()
+    assert result.value == ("service-a", "service-b")
+
+
+def test_local_builds_rust_local_effect() -> None:
+    @do
+    def sub_program() -> EffectGenerator[int]:
+        return 1
+
+    effect = Local({"key": "value"}, sub_program())
+    assert isinstance(effect, LocalEffect)


### PR DESCRIPTION
## Summary
- Delete `HashableAskEffect` and collapse Reader ask to a single effect path (`AskEffect`) for all hashable keys.
- Add Rust-native `PyLocal` effect and move Local semantics into `ReaderHandlerProgram` (scoped env overlay + restoration on success/throw).
- Introduce `HashedPyKey` (`packages/doeff-vm/src/py_key.rs`) to preserve Python hash/equality semantics across Rust env lookups.
- Migrate env + lazy Ask key storage from `String` to `HashedPyKey`:
  - `RustStore.env: HashMap<HashedPyKey, Value>`
  - lazy cache/semaphore maps in `LazyAskState` also keyed by `HashedPyKey`
- Remove Python-side `WithHandler` Local fallback and str-coercion env normalization.

## Acceptance Criteria Evidence
- AC-1 (`HashableAskEffect` deleted):
  - `rg -n "HashableAskEffect" doeff packages tests` → no matches
- AC-2 (`Ask(key)` single effect type):
  - `doeff/effects/reader.py` now aliases only `AskEffect = doeff_vm.PyAsk` and both `ask()`/`Ask()` construct `AskEffect` directly.
  - Verified by test: `uv run pytest tests/misc/test_reader_hashable_keys.py::test_ask_uses_single_effect_type_for_hashable_keys -q`
- AC-3 (no `str()` coercion for non-string hashables):
  - Reader parse path uses `HashedPyKey::from_bound(&key_obj)` (`packages/doeff-vm/src/handler.rs`).
  - Env seeding uses `HashedPyKey::from_bound(&key)` (`packages/doeff-vm/src/pyvm.rs`).
  - `_normalize_env` no longer applies `str(key)` (`doeff/rust_vm.py`).
- AC-4 (same `str()`, different `hash()` keys do not collide):
  - Added regression test `test_reader_distinguishes_same_str_different_hash` in `tests/misc/test_reader_hashable_keys.py`.
  - Verified by `uv run pytest tests/misc/test_reader_hashable_keys.py -q` → `5 passed`.
- AC-5 (Local handled in Rust; no Python WithHandler fallback):
  - `LocalEffect = doeff_vm.PyLocal` and `Local()`/`local()` now emit effects in `doeff/effects/reader.py`.
  - Rust handler parses and executes `ParsedReaderEffect::Local` in `packages/doeff-vm/src/handler.rs` (`begin_local`).
- AC-6 (env storage supports hashable keys natively):
  - `RustStore.env` migrated to `HashMap<HashedPyKey, Value>` in `packages/doeff-vm/src/rust_store.rs`.
- AC-7 (existing Ask/Local tests pass):
  - Covered by full suite below (`484 passed, 6 skipped`).
- AC-8 (`cargo test` passes):
  - `cd packages/doeff-vm && cargo test` → all tests passed.
- AC-9 (`uv run pytest tests/ -q` passes):
  - `uv run pytest tests/ -q` → `484 passed, 6 skipped`.

## Validation Run
- `cd packages/doeff-vm && cargo test`
- `uv run pytest tests/ -q`
- `uv run pytest tests/misc/test_reader_hashable_keys.py -q`

## Issue
- Ref: ISSUE-CORE-503
