### PR TITLE
DA-MIG-001: migrate docs from arun to async_run

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -86,7 +86,7 @@ Let's break down what's happening:
 
 ### Programs are Lazy
 
-Programs don't execute until you call `run()` or `arun()`:
+Programs don't execute until you call `run()` or `async_run()`:
 
 ```python
 @do
@@ -162,7 +162,7 @@ result = run(
 
 ## Error Handling
 
-`run()` and `arun()` always return a `RuntimeResult`:
+`run()` and `async_run()` always return a `RuntimeResult`:
 
 ```python
 from doeff import run, default_handlers
@@ -314,7 +314,7 @@ from doeff import (
 
     # Execution functions
     run, async_run,
-    default_handlers(), default_handlers(),
+    default_handlers, default_async_handlers,
 )
 ```
 

--- a/docs/05-error-handling.md
+++ b/docs/05-error-handling.md
@@ -13,7 +13,7 @@ This chapter covers error handling in doeff using `RunResult`, the `Safe` effect
 
 ## RunResult Overview
 
-`run()` and `arun()` return a `RunResult[T]`.
+`run()` and `async_run()` return a `RunResult[T]`.
 
 ```python
 from doeff import Ask, Tell, default_handlers, do, run

--- a/docs/13-api-reference.md
+++ b/docs/13-api-reference.md
@@ -83,7 +83,7 @@ class ExecutionContext:
 
 ### RuntimeResult[T]
 
-Result of Program execution returned by `run()` and `arun()`.
+Result of Program execution returned by `run()` and `async_run()`.
 
 ```python
 class RuntimeResult[T](Protocol):
@@ -756,15 +756,15 @@ def run(
 Executes Programs asynchronously with real async I/O support.
 
 ```python
-from doeff import async_run, default_handlers
+from doeff import async_run, default_async_handlers
 
 # Run a program asynchronously
-result = await arun(my_program(), default_handlers())
+result = await async_run(my_program(), handlers=default_async_handlers())
 
 # With initial environment and store
-result = await arun(
+result = await async_run(
     my_program(),
-    default_handlers(),
+    handlers=default_async_handlers(),
     env={"key": "value"},
     store={"state": 0}
 )
@@ -773,7 +773,7 @@ result = await arun(
 **Signature:**
 
 ```python
-async def arun(
+async def async_run(
     program: Program[T],
     handlers: list[Handler],
     env: dict | None = None,
@@ -784,7 +784,7 @@ async def arun(
 **Parameters:**
 
 - **`program`** - Program to execute
-- **`handlers`** - List of effect handlers (use `default_handlers()` for defaults)
+- **`handlers`** - List of effect handlers (use `default_async_handlers()` for defaults)
 - **`env`** (optional) - Initial environment (Reader effects)
 - **`store`** (optional) - Initial store (State effects)
 
@@ -931,7 +931,7 @@ from doeff import do, Program
 
 # Execution
 from doeff import run, default_handlers
-from doeff import async_run, default_handlers
+from doeff import async_run, default_async_handlers
 
 # Basic Effects
 from doeff import Ask, Local, Get, Put, Modify, Log, Tell, Listen

--- a/docs/20-why-effects-over-di.md
+++ b/docs/20-why-effects-over-di.md
@@ -436,6 +436,7 @@ This program uses three independent effect domains:
 from doeff_sim.handlers import deterministic_sim_handler
 from doeff_events.handlers import event_handler
 from doeff_time.handlers import async_time_handler
+from doeff import async_run, default_async_handlers
 
 # Deterministic simulation (instant, reproducible)
 result = run(
@@ -451,7 +452,7 @@ result = run(
 )
 
 # Same program, real-time execution (wall-clock, asyncio)
-result = await arun(
+result = await async_run(
     WithHandler(
         WithHandler(
             trading_strategy(),
@@ -459,6 +460,7 @@ result = await arun(
         ),
         async_time_handler(),             # asyncio.sleep, time.time()
     ),
+    handlers=default_async_handlers(),
 )
 ```
 

--- a/docs/MARKERS.md
+++ b/docs/MARKERS.md
@@ -199,12 +199,14 @@ def simple_interpreter(program: Program):  # doeff: interpreter
 
 ### Async Interpreter
 ```python
+from doeff import async_run, default_async_handlers
+
 async def async_interpreter(  # doeff: interpreter
     program: Program,
     timeout: float = None
 ):
     """Execute program asynchronously with optional timeout."""
-    return await program.arun(timeout=timeout)
+    return await async_run(program, handlers=default_async_handlers())
 ```
 
 ### Transform Chain

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -226,10 +226,10 @@ No docs build system exists (no mkdocs.yml, no sphinx).
 | `09-advanced-effects.md` | LOW | 1 |
 | `13-api-reference.md` | LOW | 1 (`ExecutionContext` section) |
 
-- [ ] Rewrite all examples to use `run()` / `arun()` + `default_handlers()`
+- [ ] Rewrite all examples to use `run()` / `async_run()` + `default_handlers()` / `default_async_handlers()`
 
 ### M4.3 — Fix naming inconsistency
-- [ ] Standardize on `arun` (not `async_run`) across all docs
+- [ ] Standardize on `async_run` across all docs
 - [ ] `01-getting-started.md` and `02-core-concepts.md` reference `async_run`
 
 ### M4.4 — Write missing critical docs
@@ -239,7 +239,7 @@ Biggest structural gaps:
 - [ ] **Custom effects guide** — full lifecycle: define → handler → register → use
 - [ ] **Handler writing tutorial** — handler function signature and conventions
 - [ ] **Testing guide** — how to mock effects, test handlers, use `WithHandler` for test stubs
-- [ ] **Migration guide (standalone)** — comprehensive `ProgramInterpreter` → `run`/`arun` migration
+- [ ] **Migration guide (standalone)** — comprehensive `ProgramInterpreter` → `run`/`async_run` migration
 
 ### M4.5 — Clean up stale artifacts
 - [ ] Delete empty legacy runtime examples directory


### PR DESCRIPTION
## Summary
- replace remaining `arun` references in docs with `async_run`
- update async API reference signature/import/call examples to `async_run(..., handlers=default_async_handlers())`
- update marker async interpreter example to use `async_run(program, handlers=default_async_handlers())`
- update milestone tracking text to current naming

## Acceptance Criteria Evidence
- `rg '\barun\b' docs/ --glob '!revision-log.md' | wc -l` => `0`
- `uv run pytest` => `481 passed, 6 skipped in 18.75s`

## Issue
- DA-MIG-001
