### PR TITLE
Migration: replace Log() with Tell() in docs

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -40,21 +40,21 @@ uv add doeff
 Let's write a simple program that uses state management and logging:
 
 ```python
-from doeff import do, Program, Put, Get, Log
+from doeff import do, Program, Put, Get, Tell
 from doeff import run, default_handlers
 
 @do
 def counter_program():
     yield Put("counter", 0)
-    yield Log("Counter initialized")
+    yield Tell("Counter initialized")
 
     count = yield Get("counter")
-    yield Log(f"Current count: {count}")
+    yield Tell(f"Current count: {count}")
 
     yield Put("counter", count + 1)
     final_count = yield Get("counter")
 
-    yield Log(f"Final count: {final_count}")
+    yield Tell(f"Final count: {final_count}")
     return final_count
 
 def main():
@@ -78,7 +78,7 @@ Let's break down what's happening:
 3. **Effects** (algebraic effect operations):
    - `Put("counter", value)` - State effect: sets state (handled by the State handler)
    - `Get("counter")` - State effect: retrieves state
-   - `Log(message)` - Writer effect: writes to log (handled by the Writer handler)
+   - `Tell(message)` - Writer effect: appends to log (handled by the Writer handler)
 4. **`run`**: Executes programs with the provided effect handlers
 5. **Result**: Returns a `RuntimeResult` with `.value` for success or `.error` for failure
 
@@ -91,7 +91,7 @@ Programs don't execute until you call `run()` or `arun()`:
 ```python
 @do
 def my_program():
-    yield Log("This won't execute yet")
+    yield Tell("This won't execute yet")
     return 42
 
 # Just creates a Program, doesn't execute
@@ -109,7 +109,7 @@ Unlike Python generators, `@do` functions can be called multiple times:
 @do
 def get_timestamp():
     import time
-    yield Log("Getting timestamp")
+    yield Tell("Getting timestamp")
     return yield IO(lambda: time.time())
 
 # Each call creates a fresh Program
@@ -129,12 +129,12 @@ You can compose effectful programs together — a key advantage of algebraic eff
 @do
 def setup():
     yield Put("config", {"debug": True})
-    yield Log("Setup complete")
+    yield Tell("Setup complete")
 
 @do
 def work():
     config = yield Get("config")
-    yield Log(f"Working with config: {config}")
+    yield Tell(f"Working with config: {config}")
     return "done"
 
 @do
@@ -199,7 +199,7 @@ def complex_workflow():
     yield Put("connection", f"Connected to {db_url}")
 
     # Writer effect - log progress
-    yield Log("Processing data...")
+    yield Tell("Processing data...")
 
     # Async effect - await async operations
     data = yield Await(fetch_data_async())
@@ -216,10 +216,10 @@ def conditional_program():
     count = yield Get("count")
 
     if count > 10:
-        yield Log("Count is high")
+        yield Tell("Count is high")
         yield Put("status", "high")
     else:
-        yield Log("Count is low")
+        yield Tell("Count is low")
         yield Put("status", "low")
 
     return count
@@ -234,12 +234,12 @@ Make sure you're using `@do` decorator:
 ```python
 # Wrong - missing @do
 def my_program():
-    yield Log("test")
+    yield Tell("test")
 
 # Right - has @do
 @do
 def my_program():
-    yield Log("test")
+    yield Tell("test")
 ```
 
 ### "TypeError: Unknown yield type"
@@ -298,7 +298,7 @@ from doeff import (
     Ask, Local,
 
     # Writer effects
-    Log, Tell, Listen,
+    Tell, Listen,
 
     # Async effects
     Await, Gather,
@@ -321,12 +321,12 @@ from doeff import (
 ### Basic Program Template
 
 ```python
-from doeff import do, Log, run, default_handlers
+from doeff import do, Tell, run, default_handlers
 
 @do
 def my_program():
     # Your effects here
-    yield Log("Hello, doeff!")
+    yield Tell("Hello, doeff!")
     return "result"
 
 def main():

--- a/docs/06-io-effects.md
+++ b/docs/06-io-effects.md
@@ -35,13 +35,13 @@ def compute_something():
 @do
 def read_file(filename):
     content = yield IO(lambda: open(filename).read())
-    yield Log(f"Read {len(content)} bytes")
+    yield Tell(f"Read {len(content)} bytes")
     return content
 
 @do
 def write_file(filename, content):
     yield IO(lambda: open(filename, 'w').write(content))
-    yield Log(f"Wrote {len(content)} bytes to {filename}")
+    yield Tell(f"Wrote {len(content)} bytes to {filename}")
 ```
 
 ### Current Time
@@ -52,7 +52,7 @@ import time
 @do
 def get_timestamp():
     timestamp = yield IO(lambda: time.time())
-    yield Log(f"Timestamp: {timestamp}")
+    yield Tell(f"Timestamp: {timestamp}")
     return timestamp
 ```
 
@@ -64,7 +64,7 @@ import random
 @do
 def roll_dice():
     value = yield IO(lambda: random.randint(1, 6))
-    yield Log(f"Rolled: {value}")
+    yield Tell(f"Rolled: {value}")
     return value
 ```
 
@@ -96,7 +96,7 @@ def run_command(cmd):
     ))
 
     if result.returncode != 0:
-        yield Log(f"Command failed: {result.stderr}")
+        yield Tell(f"Command failed: {result.stderr}")
         raise Exception(f"Command failed with code {result.returncode}")
 
     return result.stdout
@@ -118,14 +118,14 @@ def with_console_output():
     return result
 ```
 
-For internal logging, prefer the `Log` effect which captures logs in the execution context:
+For internal logging, prefer the `Tell` effect which captures logs in the execution context:
 
 ```python
 @do
 def with_logging():
-    yield Log("Starting operation...")  # Captured in logs
+    yield Tell("Starting operation...")  # Captured in logs
     result = yield process_data()
-    yield Log(f"Completed with: {result}")  # Captured in logs
+    yield Tell(f"Completed with: {result}")  # Captured in logs
     return result
 ```
 
@@ -244,7 +244,7 @@ handlers = [mock_io_handler, *default_handlers()]
 result = run(my_program(), handlers)
 ```
 
-### Console Output vs Log
+### Console Output vs Writer Log
 
 **Use `IO(print)` for:**
 - User-facing output
@@ -252,7 +252,7 @@ result = run(my_program(), handlers)
 - Interactive prompts
 - Actual terminal output
 
-**Use `Log` for:**
+**Use `Tell` for:**
 - Debugging information
 - Audit trails
 - Internal program state
@@ -261,16 +261,16 @@ result = run(my_program(), handlers)
 ```python
 @do
 def good_separation():
-    # Log for internal tracking (captured in context)
-    yield Log("Starting operation...")
+    # Tell for internal tracking (captured in context)
+    yield Tell("Starting operation...")
 
     # print via IO for user visibility (goes to stdout)
     yield IO(lambda: print("Processing your request..."))
 
     result = yield do_work()
 
-    # Log the details (captured in context)
-    yield Log(f"Operation completed with result: {result}")
+    # Tell the details (captured in context)
+    yield Tell(f"Operation completed with result: {result}")
 
     # print the summary (goes to stdout)
     yield IO(lambda: print("Done!"))
@@ -283,13 +283,13 @@ def good_separation():
 | Effect | Purpose | Example |
 |--------|---------|---------|
 | `IO(action)` | Execute side-effectful callable | File I/O, system calls, time, console output |
-| `Log(msg)` | Internal logging (captured) | Debugging, audit trails |
+| `Tell(msg)` | Internal logging (captured) | Debugging, audit trails |
 
 **Key Points:**
 - IO isolates side effects for testability
 - Use IO for non-async side effects including console output
 - Use `IO(lambda: print(...))` for user-facing output
-- Use `Log` for internal tracking captured in execution context
+- Use `Tell` for internal tracking captured in execution context
 - Keep IO actions small and focused
 
 ## Next Steps

--- a/docs/07-cache-system.md
+++ b/docs/07-cache-system.md
@@ -19,7 +19,7 @@ from doeff import cache, do
 @cache(ttl=60, lifecycle=CacheLifecycle.SESSION)
 @do
 def expensive_computation(x: int):
-    yield Log("Computing (this should only happen once)...")
+    yield Tell("Computing (this should only happen once)...")
     # Expensive work here
     return x * 2
 
@@ -38,10 +38,10 @@ def with_manual_cache():
     try:
         # Try to get from cache
         value = yield CacheGet("my_key")
-        yield Log("Cache hit!")
+        yield Tell("Cache hit!")
     except KeyError:
         # Cache miss - compute and store
-        yield Log("Cache miss, computing...")
+        yield Tell("Cache miss, computing...")
         value = yield expensive_operation()
         
         yield CachePut(

--- a/docs/08-graph-tracking.md
+++ b/docs/08-graph-tracking.md
@@ -41,7 +41,7 @@ def with_snapshot():
 
     # Capture graph at this point
     graph = yield Snapshot()
-    yield Log(f"Graph has {len(graph.steps)} steps")
+    yield Tell(f"Graph has {len(graph.steps)} steps")
 
     yield Step("continue")
     return "done"

--- a/docs/10-pinjected-integration.md
+++ b/docs/10-pinjected-integration.md
@@ -96,7 +96,7 @@ from doeff_pinjected import program_to_injected_result
 @do
 def stateful_program():
     yield Put("status", "initialized")
-    yield Log("Starting computation")
+    yield Tell("Starting computation")
     config = yield Ask("config")
     yield Put("config_loaded", True)
     return config["value"]
@@ -161,7 +161,7 @@ result = await resolver.provide(injected)  # 3. Ask -> resolver.provide("databas
 ### Service Layer Pattern
 
 ```python
-from doeff import do, Ask, Log, Safe
+from doeff import do, Ask, Tell, Safe
 
 @do
 def user_service(user_id: int):
@@ -172,11 +172,11 @@ def user_service(user_id: int):
     cache_result = yield Safe(cache.get(f"user_{user_id}"))
     
     if cache_result.is_ok():
-        yield Log(f"Cache hit for user {user_id}")
+        yield Tell(f"Cache hit for user {user_id}")
         return cache_result.value
     
     # Fetch from database
-    yield Log(f"Fetching user {user_id} from database")
+    yield Tell(f"Fetching user {user_id} from database")
     user = yield db.query_user(user_id)
     
     # Update cache
@@ -197,12 +197,12 @@ def user_repository():
     
     @do
     def get_user(user_id: int):
-        yield Log(f"Repository: fetching user {user_id}")
+        yield Tell(f"Repository: fetching user {user_id}")
         return yield db.query("SELECT * FROM users WHERE id = ?", user_id)
     
     @do
     def save_user(user):
-        yield Log(f"Repository: saving user {user.id}")
+        yield Tell(f"Repository: saving user {user.id}")
         yield db.execute("INSERT OR REPLACE INTO users VALUES (?, ?)", user.id, user.name)
     
     return {"get": get_user, "save": save_user}
@@ -406,7 +406,7 @@ def good_design():
     cache = yield Ask("cache")        # External dependency
     
     value = yield Get("counter")      # Internal state
-    yield Log("Processing")           # Internal effect
+    yield Tell("Processing")           # Internal effect
 ```
 
 **DON'T:**

--- a/docs/13-api-reference.md
+++ b/docs/13-api-reference.md
@@ -70,7 +70,7 @@ class ExecutionContext:
 
 - **`env`** - Environment variables (Ask/Local effects)
 - **`state`** - Mutable state (Get/Put/Modify effects)
-- **`log`** - Log entries (Log/Tell effects)
+- **`log`** - Writer entries (Tell/StructuredLog/slog effects)
 - **`graph`** - Execution graph (Step/Annotate effects)
 - **`memo`** - Within-execution cache (for internal use)
 - **`cache_handler`** - Persistent cache handler (CacheGet/CachePut)
@@ -304,32 +304,16 @@ yield Modify("counter", lambda x: x + 1)
 
 ## Writer Effects
 
-### Log(message)
-
-Add log entry.
-
-```python
-yield Log("Processing data")
-```
-
-**Parameters:** `message: str` - Log message
-
-**Returns:** None
-
-**See:** [Basic Effects](03-basic-effects.md#writer-effects)
-
----
-
 ### Tell(message)
 
-Add a log entry. Alias: `Log(message)`.
+Add a writer log entry.
 
 ```python
 yield Tell("Processing started")
-yield Log("Step 1 complete")  # Log is alias for Tell
+yield Tell({"step": 1, "status": "complete"})
 ```
 
-**Parameters:** `message: object` - Message to log (string or any object)
+**Parameters:** `message: object` - Message to append to the writer log
 
 **Returns:** None
 
@@ -915,7 +899,7 @@ await write_graph_html(result.graph, "output.html")
 |----------|---------|
 | **Reader** | Ask, Local |
 | **State** | Get, Put, Modify, AtomicGet, AtomicUpdate |
-| **Writer** | Log, Tell, Listen, StructuredLog |
+| **Writer** | Tell, Listen, StructuredLog, slog |
 | **Async** | Await, Gather, Spawn, Wait |
 | **Error** | Safe |
 | **IO** | IO |
@@ -934,7 +918,7 @@ from doeff import run, default_handlers
 from doeff import async_run, default_handlers
 
 # Basic Effects
-from doeff import Ask, Local, Get, Put, Modify, Log, Tell, Listen
+from doeff import Ask, Local, Get, Put, Modify, Tell, Listen, StructuredLog, slog
 
 # Async
 from doeff import Await, Gather, Spawn, Wait

--- a/docs/14-cli-auto-discovery.md
+++ b/docs/14-cli-auto-discovery.md
@@ -211,7 +211,7 @@ def auth_interpreter(prog: Program):
 # myapp/features/auth/login.py
 @do
 def login_program():
-    yield Log("Logging in...")
+    yield Tell("Logging in...")
     return "success"
 ```
 
@@ -296,7 +296,7 @@ auth_env: Program[dict] = Program.pure({
 @do
 def login_program():
     config = yield Ask('timeout')
-    yield Log(f"Timeout: {config}")  # Will be 30!
+    yield Tell(f"Timeout: {config}")  # Will be 30!
     return "success"
 ```
 
@@ -507,7 +507,7 @@ base_env = Program.pure({'debug': True})
 @do
 def my_program():
     debug = yield Ask('debug')
-    yield Log(f"Debug mode: {debug}")
+    yield Tell(f"Debug mode: {debug}")
     return "done"
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,7 +159,7 @@ main()
 |----------|---------|---------|
 | **Reader** | Ask, Local | [03](03-basic-effects.md#reader-effects) |
 | **State** | Get, Put, Modify, AtomicGet, AtomicUpdate | [03](03-basic-effects.md#state-effects), [09](09-advanced-effects.md#atomic-effects) |
-| **Writer** | Log, Tell, Listen, StructuredLog | [03](03-basic-effects.md#writer-effects) |
+| **Writer** | Tell, Listen, StructuredLog, slog | [03](03-basic-effects.md#writer-effects) |
 | **Future** | Await, Gather | [04](04-async-effects.md) |
 | **Result** | Safe | [05](05-error-handling.md) |
 | **IO** | IO | [06](06-io-effects.md) |
@@ -176,7 +176,7 @@ main()
 def application():
     config = yield Ask("config")
     yield Put("status", "running")
-    yield Log(f"Started with config: {config}")
+    yield Tell(f"Started with config: {config}")
     result = yield do_work()
     return result
 ```
@@ -190,7 +190,7 @@ def robust_fetch(url):
     if result.is_ok():
         return result.value
     else:
-        yield Log(f"Fetch failed: {result.error}")
+        yield Tell(f"Fetch failed: {result.error}")
         return None
 ```
 

--- a/docs/positioning/domain-angles/batch-etl.md
+++ b/docs/positioning/domain-angles/batch-etl.md
@@ -16,7 +16,7 @@ Batch jobs processing millions of records face:
 ```python
 @do
 def process_batch(items: list[str]) -> Program[BatchResult]:
-    yield Log(f"Starting batch of {len(items)} items")
+    yield Tell(f"Starting batch of {len(items)} items")
     results = []
     for i, item in enumerate(items):
         yield Put("progress", i)

--- a/docs/positioning/domain-angles/ml-infrastructure.md
+++ b/docs/positioning/domain-angles/ml-infrastructure.md
@@ -258,12 +258,12 @@ def retry_handler(max_retries=3, backoff=1.0, transient_errors=None):
             except Exception as e:
                 if any(err in str(e).lower() for err in transient_errors):
                     if attempt < max_retries - 1:
-                        yield Log(f"Retry {attempt + 1}/{max_retries} for {effect.cmd}: {e}")
+                        yield Tell(f"Retry {attempt + 1}/{max_retries} for {effect.cmd}: {e}")
                         yield Delay(current_backoff)
                         current_backoff *= 2
                         attempt += 1
                     else:
-                        yield Log(f"Failed after {max_retries} attempts: {effect.cmd}")
+                        yield Tell(f"Failed after {max_retries} attempts: {effect.cmd}")
                         raise
                 else:
                     raise  # non-transient error, fail immediately
@@ -338,9 +338,9 @@ def execute_ai_platform(cmd: str) -> Program[str]:
 def logging_handler():
     def handler(effect, k):
         if isinstance(effect, SystemCall):
-            yield Log(f"Executing: {effect.cmd}")
+            yield Tell(f"Executing: {effect.cmd}")
             result = yield Delegate()
-            yield Log(f"Result: {result}")
+            yield Tell(f"Result: {result}")
             return result
         yield Delegate()
     return handler
@@ -605,7 +605,7 @@ def run_ml_job(
     Handlers decide HOW each step happens.
     """
     # 1. Build
-    yield Log(f"Building image for {project.name}")
+    yield Tell(f"Building image for {project.name}")
     image = yield BuildImage(schematic.builder)
 
     # 2. Push

--- a/docs/positioning/domain-angles/trading-backtesting.md
+++ b/docs/positioning/domain-angles/trading-backtesting.md
@@ -16,7 +16,7 @@ The key insight from [docs/20-why-effects-over-di.md](../20-why-effects-over-di.
 ## The Strategy: Pure Effects
 
 ```python
-from doeff import do, Program, Get, Put, Log, Tell, Safe
+from doeff import do, Program, Get, Put, Tell, Safe
 from doeff.effects import Await, Spawn, Gather
 
 @dataclass(frozen=True)
@@ -65,11 +65,11 @@ def mean_reversion_strategy(symbol: str, window: int = 20) -> Program[None]:
             position = portfolio.get(symbol, 0)
 
             if price < sma * 0.98 and position == 0:
-                yield Log(f"BUY signal: {price:.2f} < SMA {sma:.2f}")
+                yield Tell(f"BUY signal: {price:.2f} < SMA {sma:.2f}")
                 yield PlaceOrder(symbol, "buy", quantity=100, order_type="market")
 
             elif price > sma * 1.02 and position > 0:
-                yield Log(f"SELL signal: {price:.2f} > SMA {sma:.2f}")
+                yield Tell(f"SELL signal: {price:.2f} > SMA {sma:.2f}")
                 yield PlaceOrder(symbol, "sell", quantity=position, order_type="market")
 
         yield Delay(60.0)  # wait 1 minute between checks
@@ -151,7 +151,7 @@ def live_market_handler():
 
         elif isinstance(effect, PlaceOrder):
             # Log the order but don't execute
-            yield Log(f"[PAPER] Would {effect.side} {effect.quantity} {effect.symbol}")
+            yield Tell(f"[PAPER] Would {effect.side} {effect.quantity} {effect.symbol}")
             # Simulate fill at current price
             price = yield GetPrice(effect.symbol)
             return OrderResult(filled=True, price=price, paper=True)
@@ -193,7 +193,7 @@ def live_execution_handler(broker_client):
             return broker_client.get_quote(effect.symbol)
 
         elif isinstance(effect, PlaceOrder):
-            yield Log(f"[LIVE] {effect.side} {effect.quantity} {effect.symbol}")
+            yield Tell(f"[LIVE] {effect.side} {effect.quantity} {effect.symbol}")
             order = broker_client.place_order(
                 symbol=effect.symbol,
                 side=effect.side,

--- a/docs/positioning/langchain-critique.md
+++ b/docs/positioning/langchain-critique.md
@@ -165,7 +165,7 @@ LangChain:
                = tightly coupled, every layer adds latency and complexity
 
 doeff:
-  User Code:  yield LLMChat(...)  yield Parse(...)  yield Log(...)
+  User Code:  yield LLMChat(...)  yield Parse(...)  yield Tell(...)
                     |                    |                  |
                     v                    v                  v
   Handler Stack:  [openai_handler]  [parse_handler]  [log_handler]

--- a/docs/positioning/three-stage-pitch.md
+++ b/docs/positioning/three-stage-pitch.md
@@ -60,7 +60,7 @@ def process_order(order_id):
 ```python
 @do
 def process_order(order_id) -> Program[float]:
-    yield Log(f"Processing {order_id}")
+    yield Tell(f"Processing {order_id}")
     cached = yield Safe(CacheGet(f"order:{order_id}"))
     if cached.is_ok():
         return cached.value
@@ -73,7 +73,7 @@ def process_order(order_id) -> Program[float]:
 
     total = order.qty * price
     yield Safe(CachePut(f"order:{order_id}", total, ttl=300))
-    yield Log(f"Done: {total}")
+    yield Tell(f"Done: {total}")
     return total
 ```
 


### PR DESCRIPTION
## Summary
- Migrated documentation examples and references from deprecated `Log(...)` usage to canonical `Tell(...)` across the 14 files listed in DA-MIG-002.
- Updated API docs in `docs/13-api-reference.md` by replacing the `### Log(message)` section with `### Tell(message)` and removing deprecated alias wording.
- Updated writer effect listings/import examples to current API (`Tell`, `StructuredLog`, `slog`, `Listen`).
- Left `docs/revision-log.md` unchanged.

## Acceptance Criteria Evidence
- `rg 'yield Log\(' docs/ --glob '!revision-log.md' | wc -l` -> `0`
- `rg '### Log\(' docs/ | wc -l` -> `0`
- `rg 'from doeff import.*\bLog\b' docs/ | wc -l` -> `0`

## Validation
- `uv run pytest`
- Result: `481 passed, 6 skipped in 19.39s`

## Issue
- DA-MIG-002
