### PR TITLE
Fix stale API reference signatures for DA2-002

### DIFF
--- a/docs/13-api-reference.md
+++ b/docs/13-api-reference.md
@@ -1,166 +1,88 @@
 # API Reference
 
-Complete API reference for doeff.
+Complete API reference for doeff's current public surface.
 
 ## Core Types
 
 ### Program[T]
 
-The core abstraction representing a lazy, reusable computation.
+The core abstraction for lazy, reusable effectful computations.
 
 ```python
 class Program[T]:
     def map(self, f: Callable[[T], U]) -> Program[U]
     def flat_map(self, f: Callable[[T], Program[U]]) -> Program[U]
-    def intercept(self, transform: Callable[[Effect], Effect | Program]) -> Program[T]
+    def and_then_k(self, binder: Callable[[T], Program[U]]) -> Program[U]
+
+    @staticmethod
+    def pure(value: T) -> Program[T]
+
+    @staticmethod
+    def lift(value: Program[U] | U) -> Program[U]
 ```
 
-**Methods:**
-
-- **`map(f)`** - Transform the result value
-- **`flat_map(f)`** - Chain with another Program
-- **`intercept(transform)`** - Intercept and transform effects
-
-**Static Methods:**
-
-```python
-@staticmethod
-def pure(value: T) -> Program[T]
-```
-
-- **`Program.pure(value)`** - Create a Program that immediately returns a value
-
-**See:** [Core Concepts](02-core-concepts.md#program)
+**See:** [Core Concepts](02-core-concepts.md#program-model)
 
 ---
 
-### Effect
+### EffectBase / EffectValue[T]
 
-Protocol for algebraic effect operations.
+Effects are user-space operation payloads. They are data, not execution control nodes.
 
 ```python
-class Effect(Protocol):
-    def intercept(self, transform: Callable[[Effect], Effect | Program]) -> Effect | Program
+@dataclass(frozen=True, kw_only=True)
+class EffectBase:
+    created_at: EffectCreationContext | None = None
 ```
 
-All effects implement this protocol.
+At runtime, effect dispatch happens through `Perform(effect)`.
 
-**See:** [Core Concepts](02-core-concepts.md#effect-protocol)
+**See:** [Core Concepts](02-core-concepts.md#control-vs-effect-data)
 
 ---
 
-### Runtime Inputs (`run` / `async_run`)
+### RunResult[T]
 
-Runtime inputs are passed directly to `run()` and `async_run()` keyword arguments.
-
-```python
-result = run(
-    program,
-    handlers=default_handlers(),
-    env={"feature_flag": True},
-    state={"counter": 0},
-    store={"cache_key": "value"},
-)
-
-result = await async_run(
-    program,
-    handlers=default_async_handlers(),
-    env={"feature_flag": True},
-    state={"counter": 0},
-    store={"cache_key": "value"},
-)
-```
-
-**Common kwargs:**
-
-- **`env`** - Environment variables (Ask/Local effects)
-- **`state`** - Mutable state (Get/Put/Modify effects)
-- **`log`** - Writer entries (Tell/StructuredLog/slog effects)
-- **`graph`** - Execution graph (Step/Annotate effects)
-- **`memo`** - Within-execution cache (for internal use)
-- **`cache_handler`** - Persistent cache handler (CacheGet/CachePut)
-- **`atomic_state`** - Thread-safe state (AtomicGet/AtomicUpdate)
-- **`atomic_lock`** - Lock for atomic operations
-- **`handlers`** - Handler map, typically from `default_handlers()` or `default_async_handlers()`.
-
-**See:** [Core Concepts](02-core-concepts.md#execution-flow)
-
----
-
-### RuntimeResult[T]
-
-Result of Program execution returned by `run()` and `async_run()`.
+Result container returned by `run()` and `async_run()`.
 
 ```python
-class RuntimeResult[T](Protocol):
-    result: Result[T]      # Ok(value) or Err(error)
-    raw_store: dict        # Final store state
-    env: dict              # Final environment
-
-    # Stack traces for debugging
-    k_stack: KStackTrace
-    effect_stack: EffectStackTrace
-    python_stack: PythonStackTrace
+class RunResult[T](Protocol):
+    @property
+    def result(self) -> Result[T]: ...
 
     @property
-    def value(self) -> T        # Unwraps Ok or raises
+    def raw_store(self) -> dict[str, Any]: ...
 
     @property
-    def error(self) -> BaseException  # Get error or raises
+    def value(self) -> T: ...
 
-    def is_ok(self) -> bool     # True if result is Ok
-    def is_err(self) -> bool    # True if result is Err
-    def format(self, *, verbose: bool = False) -> str
+    @property
+    def error(self) -> BaseException: ...
+
+    def is_ok(self) -> bool: ...
+    def is_err(self) -> bool: ...
 ```
 
-**Core Properties:**
+**Core fields:**
 
 - **`result`** - `Ok(value)` or `Err(error)`
-- **`value`** - Unwraps Ok value (raises if Err)
-- **`error`** - Gets the exception (raises if Ok)
-- **`raw_store`** - Final store state dictionary
+- **`raw_store`** - Final store snapshot
+- **`value`** - Unwraps `Ok` value (raises on `Err`)
+- **`error`** - Unwraps `Err` error (raises on `Ok`)
 
-**Methods (NOT properties!):**
-
-- **`is_ok()`** - Returns True if result is Ok
-- **`is_err()`** - Returns True if result is Err
-- **`format(verbose=False)`** - Format result for display
-
-**Accessing logs and graph:**
-
-```python
-result = run(my_program(), default_handlers())
-logs = result.raw_store.get("__log__", [])
-graph = result.raw_store.get("__graph__")
-```
-
-**Stack traces (for debugging errors):**
-
-- **`k_stack`** - Continuation stack snapshot
-- **`effect_stack`** - Effect call tree
-- **`python_stack`** - Python source locations
-
-**See:** [Error Handling](05-error-handling.md#runtimeresult-protocol)
+**See:** [Error Handling](05-error-handling.md#runresult-overview)
 
 ---
 
 ### Result[T]
 
-Represents success (Ok) or failure (Err).
+Success/failure sum type used by `RunResult.result` and `Safe(...)`.
 
 ```python
-@dataclass
-class Ok[T]:
-    value: T
-
-@dataclass
-class Err:
-    error: Exception
-
-Result = Ok[T] | Err
+Result[T] = Ok[T] | Err
 ```
 
-**See:** [Error Handling](05-error-handling.md#result-type)
+**See:** [Error Handling](05-error-handling.md#ok-and-err)
 
 ---
 
@@ -168,28 +90,25 @@ Result = Ok[T] | Err
 
 ### @do
 
-Converts generator function to KleisliProgram.
+Converts a generator function into a `KleisliProgram`.
 
 ```python
 @do
 def my_program(x: int) -> Program[int]:
     value = yield Get("key")
     return value + x
-
-# Creates KleisliProgram with automatic Program unwrapping
 ```
 
-**Parameters:** Generator function that yields Effects or Programs
+**Returns:** `KleisliProgram[..., T]`
 
-**Returns:** KleisliProgram[T]
-
-**See:** [Core Concepts](02-core-concepts.md#do-decorator), [Kleisli Arrows](11-kleisli-arrows.md)
+**See:** [Core Concepts](02-core-concepts.md#generator-as-ast),
+[Kleisli Arrows](11-kleisli-arrows.md)
 
 ---
 
 ### @cache
 
-Caches Program result based on arguments.
+Caches Program results with policy fields.
 
 ```python
 @cache(ttl=60, lifecycle=CacheLifecycle.SESSION)
@@ -198,14 +117,13 @@ def expensive_computation(x: int):
     return x * 2
 ```
 
-**Parameters:**
+**Primary parameters:**
 
-- **`ttl`** (int, optional) - Time-to-live in seconds
-- **`lifecycle`** (CacheLifecycle, optional) - SESSION, PERSISTENT, TEMPORARY
-- **`storage`** (CacheStorage, optional) - MEMORY, DISK, DISTRIBUTED
-- **`**kwargs`** - Additional policy fields
-
-**Returns:** Decorated KleisliProgram with caching
+- **`ttl`** (`float | None`) - Time-to-live in seconds
+- **`lifecycle`** (`CacheLifecycle | str | None`) - Cache lifecycle hint
+- **`storage`** (`CacheStorage | str | None`) - Storage hint
+- **`metadata`** (`Mapping[str, Any] | None`) - Policy metadata
+- **`policy`** (`CachePolicy | Mapping[str, Any] | None`) - Full policy object
 
 **See:** [Cache System](07-cache-system.md), [cache.md](cache.md)
 
@@ -215,36 +133,28 @@ def expensive_computation(x: int):
 
 ### Ask(key)
 
-Request environment variable.
+Request an environment value.
 
 ```python
 config = yield Ask("database_url")
 ```
 
-**Parameters:** `key: str` - Environment variable name
-
-**Returns:** Value from environment
-
-**Raises:** `MissingEnvKeyError` if key not in environment
+**Signature:** `Ask(key: EnvKey)`
 
 **See:** [Basic Effects](03-basic-effects.md#reader-effects)
 
 ---
 
-### Local(env, program)
+### Local(env_update, sub_program)
 
-Run program with modified environment.
+Run a sub-program with environment overrides.
 
 ```python
 result = yield Local({"timeout": 30}, sub_program())
 ```
 
-**Parameters:**
-
-- **`env: dict[str, Any]`** - Environment overrides
-- **`program: Program[T]`** - Program to run
-
-**Returns:** Result of program with merged environment
+**Signature:**
+`Local(env_update: Mapping[Any, object], sub_program: ProgramLike)`
 
 **See:** [Basic Effects](03-basic-effects.md#local)
 
@@ -260,13 +170,7 @@ Read state value.
 count = yield Get("counter")
 ```
 
-**Parameters:** `key: str` - State key
-
-**Returns:** Value from store
-
-**Raises:** `KeyError` if key not found
-
-**See:** [Basic Effects](03-basic-effects.md#state-effects)
+**Signature:** `Get(key: str)`
 
 ---
 
@@ -278,33 +182,21 @@ Write state value.
 yield Put("counter", 42)
 ```
 
-**Parameters:**
-
-- **`key: str`** - State key
-- **`value: Any`** - Value to store
-
-**Returns:** None
-
-**See:** [Basic Effects](03-basic-effects.md#put)
+**Signature:** `Put(key: str, value: Any)`
 
 ---
 
 ### Modify(key, f)
 
-Update state value with function.
+Update state value using a transformation function.
 
 ```python
 yield Modify("counter", lambda x: x + 1)
 ```
 
-**Parameters:**
+**Signature:** `Modify(key: str, f: Callable[[Any], Any])`
 
-- **`key: str`** - State key
-- **`f: Callable[[T], T]`** - Transformation function
-
-**Returns:** The new (transformed) value
-
-**See:** [Basic Effects](03-basic-effects.md#modify)
+**See:** [Basic Effects](03-basic-effects.md#state-effects)
 
 ---
 
@@ -312,114 +204,126 @@ yield Modify("counter", lambda x: x + 1)
 
 ### Tell(message)
 
-Add a writer log entry.
+Append a log entry.
 
 ```python
 yield Tell("Processing started")
-yield Tell({"step": 1, "status": "complete"})
 ```
 
-**Parameters:** `message: object` - Message to append to the writer log
-
-**Returns:** None
-
-**See:** [Basic Effects](03-basic-effects.md#tell)
+**Signature:** `Tell(message: object)`
 
 ---
 
-### Listen(program)
+### Log(message)
 
-Capture logs from sub-program.
+Alias of `Tell(message)`.
+
+```python
+yield Tell("Step complete")
+```
+
+**Signature:** `Tell(message: object)`
+
+---
+
+### Listen(sub_program)
+
+Run a sub-program and capture emitted writer logs.
 
 ```python
 result = yield Listen(sub_program())
-value, logs = result  # Tuple unpacking
-# or
-value = result.value
-logs = result.log
+value, logs = result
 ```
 
-**Parameters:** `program: Program[T]` - Program to run
+**Signature:** `Listen(sub_program: ProgramLike)`
 
-**Returns:** ListenResult with `.value` and `.log` attributes
-
-**See:** [Basic Effects](03-basic-effects.md#listen)
+**Returns:** `ListenResult(value, log)`
 
 ---
 
-### StructuredLog(data)
+### StructuredLog(**entries)
 
-Add structured log entry.
+Append a structured log payload.
 
 ```python
-yield StructuredLog({"level": "info", "message": "Processing", "count": 42})
+yield StructuredLog(level="info", message="Processing", count=42)
 ```
 
-**Parameters:** `data: dict[str, Any]` - Structured log data
+**Signature:** `StructuredLog(**entries: object)`
 
-**Returns:** None
-
-**See:** [Basic Effects](03-basic-effects.md#structuredlog)
+**See:** [Basic Effects](03-basic-effects.md#writer-effects)
 
 ---
 
-## Async Effects
+## Async and Concurrency Effects
 
 ### Await(awaitable)
 
-Wait for async operation.
+Await a Python awaitable.
 
 ```python
-result = yield Await(async_function())
+value = yield Await(async_call())
 ```
 
-**Parameters:** `awaitable: Awaitable[T]` - Async operation
+**Signature:** `Await(awaitable: Awaitable[Any])`
 
-**Returns:** Result of awaitable
+---
 
-**See:** [Async Effects](04-async-effects.md#await)
+### Spawn(program, *, preferred_backend=None, **options)
+
+Spawn a Program in the background and return a `Task` handle.
+
+```python
+task = yield Spawn(worker())
+result = yield Wait(task)
+```
+
+**See:** [Advanced Effects](09-advanced-effects.md)
+
+---
+
+### Wait(future)
+
+Wait for a `Task`/`Future`/`Promise`-compatible value.
+
+```python
+result = yield Wait(task)
+```
+
+**Signature:** `Wait(future: Waitable[T])`
+
+---
+
+### Gather(*items)
+
+Resolve multiple waitables/programs and return results in input order.
+
+```python
+results = yield Gather(fetch_user(1), fetch_user(2), fetch_user(3))
+```
+
+**Signature:** `Gather(*items: Waitable[Any] | Program[Any])`
+
+**See:** [Advanced Effects](09-advanced-effects.md#gather-effects)
 
 ---
 
 ## Error Handling Effects
 
-### Safe(program)
+### Safe(sub_program)
 
-Wrap execution in a `Result` type for explicit error handling.
+Run a sub-program and capture errors as `Result`.
 
 ```python
 result = yield Safe(risky_operation())
 if result.is_ok():
     return result.value
-else:
-    return "fallback"
+return "fallback"
 ```
 
-**Parameters:**
-
-- **`program: Program[T]`** - Program that may fail
-
-**Returns:** `Result[T]` - Ok(value) on success, Err(error) on failure
+**Signature:** `Safe(sub_program: ProgramLike)`
 
 **See:** [Error Handling](05-error-handling.md#safe-effect)
-
----
-
-## IO Effects
-
-### IO(thunk)
-
-Execute side effect.
-
-```python
-timestamp = yield IO(lambda: time.time())
-```
-
-**Parameters:** `thunk: Callable[[], T]` - Function to execute
-
-**Returns:** Result of thunk
-
-**See:** [IO Effects](06-io-effects.md#io)
 
 ---
 
@@ -427,42 +331,28 @@ timestamp = yield IO(lambda: time.time())
 
 ### CacheGet(key)
 
-Retrieve cached value.
+Retrieve a cached value.
 
 ```python
 value = yield CacheGet("expensive_key")
 ```
 
-**Parameters:** `key: str` - Cache key
-
-**Returns:** Cached value
-
-**Raises:** KeyError if not in cache
-
-**See:** [Cache System](07-cache-system.md)
+**Signature:** `CacheGet(key: Any)`
 
 ---
 
-### CachePut(key, value, **policy)
+### CachePut(key, value, ttl=None, *, lifecycle=None, storage=None, metadata=None, policy=None)
 
-Store value in cache.
+Store a value in cache.
 
 ```python
 yield CachePut(
     "key",
     value,
     ttl=300,
-    lifecycle=CacheLifecycle.PERSISTENT
+    lifecycle=CacheLifecycle.PERSISTENT,
 )
 ```
-
-**Parameters:**
-
-- **`key: str`** - Cache key
-- **`value: Any`** - Value to cache
-- **`**policy`** - Policy fields (ttl, lifecycle, storage, metadata)
-
-**Returns:** None
 
 **See:** [Cache System](07-cache-system.md), [cache.md](cache.md)
 
@@ -470,38 +360,27 @@ yield CachePut(
 
 ## Graph Effects
 
-### Step(name, description)
+### Step(value, meta=None)
 
-Add named step to graph.
+Add a step node to the execution graph.
 
 ```python
-yield Step("initialize", "Setup phase")
+yield Step("initialize", {"phase": "setup"})
 ```
 
-**Parameters:**
-
-- **`name: str`** - Step name
-- **`description: str | dict`** (optional) - Step description or metadata
-
-**Returns:** None
-
-**See:** [Graph Tracking](08-graph-tracking.md#step)
+**Signature:** `Step(value: Any, meta: dict[str, Any] | None = None)`
 
 ---
 
-### Annotate(metadata)
+### Annotate(meta)
 
-Add metadata to current step.
+Add metadata to the latest graph step.
 
 ```python
 yield Annotate({"user_id": 123, "operation": "fetch"})
 ```
 
-**Parameters:** `metadata: dict[str, Any]` - Metadata dictionary
-
-**Returns:** None
-
-**See:** [Graph Tracking](08-graph-tracking.md#annotate)
+**Signature:** `Annotate(meta: dict[str, Any])`
 
 ---
 
@@ -513,101 +392,47 @@ Capture current graph state.
 graph = yield Snapshot()
 ```
 
-**Parameters:** None
-
-**Returns:** Current WGraph
-
-**See:** [Graph Tracking](08-graph-tracking.md#snapshot)
-
 ---
 
 ### CaptureGraph(program)
 
-Capture graph from sub-program.
+Run a sub-program and capture its graph output.
 
 ```python
-result, graph = yield CaptureGraph(sub_program())
+value, graph = yield CaptureGraph(sub_program())
 ```
 
-**Parameters:** `program: Program[T]` - Program to run
-
-**Returns:** Tuple of (result, graph)
+**Signature:** `CaptureGraph(program: ProgramLike)`
 
 **See:** [Graph Tracking](08-graph-tracking.md#capturegraph)
 
 ---
 
-## Advanced Effects
+## Atomic Effects
 
-### Spawn(program)
+### AtomicGet(key, *, default_factory=None)
 
-Spawn a Program in the background and return a Task handle.
-
-```python
-task = yield Spawn(worker())
-result = yield Wait(task)
-```
-
-**Parameters:**
-
-- **`program: Program[T]`** - Program to execute
-
-**Returns:** `Task[T]` - use `Wait(task)` to get result
-
-**See:** [Advanced Effects](09-advanced-effects.md)
-
-### Gather(*programs)
-
-Execute Programs in parallel.
-
-```python
-results = yield Gather(
-    fetch_user(1),
-    fetch_user(2),
-    fetch_user(3)
-)
-```
-
-**Parameters:** `*programs: Program[T]` - Programs to run in parallel
-
-**Returns:** `list[T]` - Results in order
-
-**See:** [Advanced Effects](09-advanced-effects.md#gather-effects)
-
----
-
-### AtomicGet(key)
-
-Thread-safe state read.
+Thread-safe shared-state read.
 
 ```python
 count = yield AtomicGet("counter")
 ```
 
-**Parameters:** `key: str` - State key
-
-**Returns:** Value from atomic state
-
-**See:** [Advanced Effects](09-advanced-effects.md#atomic-effects)
+**Signature:**
+`AtomicGet(key: str, *, default_factory: Callable[[], Any] | None = None)`
 
 ---
 
-### AtomicUpdate(key, f)
+### AtomicUpdate(key, updater, *, default_factory=None)
 
-Thread-safe state update.
+Thread-safe shared-state update.
 
 ```python
 new_value = yield AtomicUpdate("counter", lambda x: x + 1)
 ```
 
-**Parameters:**
-
-- **`key: str`** - State key
-- **`f: Callable[[T], T]`** - Update function
-
-**Returns:** Updated value
-
-**See:** [Advanced Effects](09-advanced-effects.md#atomicupdate)
+**Signature:**
+`AtomicUpdate(key: str, updater: Callable[[Any], Any], *, default_factory: Callable[[], Any] | None = None)`
 
 ---
 
@@ -615,7 +440,7 @@ new_value = yield AtomicUpdate("counter", lambda x: x + 1)
 
 ### program_to_injected(program)
 
-Convert Program to Injected.
+Convert `Program[T]` to `Injected[T]`.
 
 ```python
 from doeff_pinjected import program_to_injected
@@ -624,41 +449,28 @@ injected = program_to_injected(my_program())
 result = await resolver.provide(injected)
 ```
 
-**Parameters:** `program: Program[T]` - Program to convert
-
-**Returns:** `Injected[T]` - pinjected Injected value
-
-**Package:** doeff-pinjected
-
-**See:** [Pinjected Integration](10-pinjected-integration.md#program_to_injected)
+**Signature:** `program_to_injected(prog: Program[T]) -> Injected[T]`
 
 ---
 
 ### program_to_injected_result(program)
 
-Convert Program to Injected[RunResult].
+Convert `Program[T]` to `Injected[RunResult[T]]`.
 
 ```python
 from doeff_pinjected import program_to_injected_result
 
 injected = program_to_injected_result(my_program())
 result = await resolver.provide(injected)
-# result is RunResult[T] with state, log, graph
 ```
 
-**Parameters:** `program: Program[T]` - Program to convert
-
-**Returns:** `Injected[RunResult[T]]` - Injected returning full context
-
-**Package:** doeff-pinjected
-
-**See:** [Pinjected Integration](10-pinjected-integration.md#program_to_injected_result)
+**Signature:** `program_to_injected_result(prog: Program[T]) -> Injected[RunResult[T]]`
 
 ---
 
 ### program_to_iproxy(program)
 
-Convert Program to IProxy.
+Convert `Program[T]` to `IProxy[T]`.
 
 ```python
 from doeff_pinjected import program_to_iproxy
@@ -666,19 +478,13 @@ from doeff_pinjected import program_to_iproxy
 iproxy = program_to_iproxy(my_program())
 ```
 
-**Parameters:** `program: Program[T]` - Program to convert
-
-**Returns:** `IProxy[T]` - pinjected IProxy value
-
-**Package:** doeff-pinjected
-
-**See:** [Pinjected Integration](10-pinjected-integration.md#program_to_iproxy)
+**Signature:** `program_to_iproxy(prog: Program[T]) -> IProxy[T]`
 
 ---
 
 ### program_to_iproxy_result(program)
 
-Convert Program to IProxy[RunResult].
+Convert `Program[T]` to `IProxy[RunResult[T]]`.
 
 ```python
 from doeff_pinjected import program_to_iproxy_result
@@ -686,13 +492,7 @@ from doeff_pinjected import program_to_iproxy_result
 iproxy = program_to_iproxy_result(my_program())
 ```
 
-**Parameters:** `program: Program[T]` - Program to convert
-
-**Returns:** `IProxy[RunResult[T]]` - IProxy returning full context
-
-**Package:** doeff-pinjected
-
-**See:** [Pinjected Integration](10-pinjected-integration.md#program_to_iproxy_result)
+**Signature:** `program_to_iproxy_result(prog: Program[T]) -> IProxy[RunResult[T]]`
 
 ---
 
@@ -700,20 +500,16 @@ iproxy = program_to_iproxy_result(my_program())
 
 ### run
 
-Executes Programs synchronously with cooperative scheduling.
+Synchronously execute a Program/effect with explicit handler stack.
 
 ```python
-from doeff import run, default_handlers
+from doeff import default_handlers, run
 
-# Run a program synchronously
-result = run(my_program(), default_handlers())
-
-# With initial environment and store
 result = run(
     my_program(),
-    default_handlers(),
+    handlers=default_handlers(),
     env={"key": "value"},
-    store={"state": 0}
+    store={"state": 0},
 )
 ```
 
@@ -721,42 +517,30 @@ result = run(
 
 ```python
 def run(
-    program: Program[T],
-    handlers: list[Handler],
-    env: dict | None = None,
-    store: dict | None = None,
-) -> RuntimeResult[T]
+    program: DoExpr[T] | EffectValue[T],
+    handlers: Sequence[Any] = (),
+    env: dict[Any, Any] | None = None,
+    store: dict[str, Any] | None = None,
+    trace: bool = False,
+) -> RunResult[T]
 ```
 
-**Parameters:**
-
-- **`program`** - Program to execute
-- **`handlers`** - List of effect handlers (use `default_handlers()` for defaults)
-- **`env`** (optional) - Initial environment (Reader effects)
-- **`store`** (optional) - Initial store (State effects)
-
-**Returns:** RuntimeResult with result value
-
-**See:** [Core Concepts](02-core-concepts.md#execution-model)
+`env` and `store` are the execution inputs (Reader and State roots).
 
 ---
 
 ### async_run
 
-Executes Programs asynchronously with real async I/O support.
+Asynchronously execute a Program/effect with async-aware await handling.
 
 ```python
 from doeff import async_run, default_async_handlers
 
-# Run a program asynchronously
-result = await async_run(my_program(), handlers=default_async_handlers())
-
-# With initial environment and store
 result = await async_run(
     my_program(),
     handlers=default_async_handlers(),
     env={"key": "value"},
-    store={"state": 0}
+    store={"state": 0},
 )
 ```
 
@@ -764,29 +548,19 @@ result = await async_run(
 
 ```python
 async def async_run(
-    program: Program[T],
-    handlers: list[Handler],
-    env: dict | None = None,
-    store: dict | None = None,
-) -> RuntimeResult[T]
+    program: DoExpr[T] | EffectValue[T],
+    handlers: Sequence[Any] = (),
+    env: dict[Any, Any] | None = None,
+    store: dict[str, Any] | None = None,
+    trace: bool = False,
+) -> RunResult[T]
 ```
-
-**Parameters:**
-
-- **`program`** - Program to execute
-- **`handlers`** - List of effect handlers (use `default_async_handlers()` for defaults)
-- **`env`** (optional) - Initial environment (Reader effects)
-- **`store`** (optional) - Initial store (State effects)
-
-**Returns:** RuntimeResult with result value
-
-**See:** [Core Concepts](02-core-concepts.md#execution-model)
 
 ---
 
-### run_program(program, *, interpreter=None, envs=None, apply=None, transform=None, report=False, report_verbose=False, quiet=False, load_default_env=True)
+### run_program(...)
 
-Run a Program from Python with the same discovery defaults as `doeff run`.
+Run a Program from Python using CLI-equivalent discovery defaults.
 
 ```python
 from doeff import run_program
@@ -795,18 +569,22 @@ result = run_program("pkg.features.login_program", quiet=True, report=True)
 assert result.value == "ok"
 ```
 
-**Parameters:**
+**Signature:**
 
-- **`program`** (`str | Program`) - Program path (enables discovery) or Program instance.
-- **`interpreter`** (`str | AsyncioRuntime | callable | None`) - Override interpreter/runtime.
-- **`envs`** (`list[str | Program[dict] | Mapping] | None`) - Environments to merge.
-- **`apply`** (`str | KleisliProgram | callable | None`) - Kleisli applied before run.
-- **`transform`** (`list[str | callable] | None`) - Additional Program transformers.
-- **`report` / `report_verbose`** - Print RunResult report (string-path mode).
-- **`quiet`** - Suppress discovery stderr output.
-- **`load_default_env`** - Load `~/.doeff.py::__default_env__` when running with object inputs.
-
-**Returns:** ProgramRunResult with final value, RunResult, and discovery metadata
+```python
+def run_program(
+    program: str | Program[Any],
+    *,
+    interpreter: str | Callable[..., Any] | None = None,
+    envs: list[str | Program[dict[str, Any]] | Mapping[str, Any]] | None = None,
+    apply: str | KleisliProgram[..., Any] | Callable[[Program[Any]], Program[Any]] | None = None,
+    transform: list[str | Callable[[Program[Any]], Program[Any]]] | None = None,
+    report: bool = False,
+    report_verbose: bool = False,
+    quiet: bool = False,
+    load_default_env: bool = True,
+) -> ProgramRunResult
+```
 
 **See:** [Python run_program API](16-run-program-api.md)
 
@@ -814,7 +592,7 @@ assert result.value == "ok"
 
 ### ProgramRunResult
 
-Result container returned by `run_program()`.
+Dataclass returned by `run_program()`.
 
 ```python
 from doeff import ProgramRunResult
@@ -822,78 +600,44 @@ from doeff import ProgramRunResult
 
 **Fields:**
 
-- **`value`** - Final Program value (None on errors; inspect `run_result`).
-- **`run_result`** - Full RunResult with context/log/graph data.
-- **`interpreter_path`** - Resolved interpreter path or description of callable used.
-- **`env_sources`** - Environment sources applied (`<dict>`, `<Program[dict]>`, or paths).
-- **`applied_kleisli`** - Description of applied Kleisli (if any).
-- **`applied_transforms`** - Descriptions of applied transformers.
-
----
-
-## KleisliProgram
-
-Auto-unwrapping Program composition.
-
-```python
-from doeff import KleisliProgram
-
-@do
-def add(x: int, y: int):
-    return x + y
-
-# Automatic unwrapping
-prog_x = Program.pure(5)
-result = add(prog_x, 10)  # x unwrapped automatically
-```
-
-**Operators:**
-
-- **`>>`** (and_then_k) - Chain KleisliPrograms
-- **`<<`** (fmap) - Map pure function
-
-**See:** [Kleisli Arrows](11-kleisli-arrows.md)
+- **`value`** - Final Program value
+- **`run_result`** - `RunResult[Any] | None` (present when interpreter returns one)
+- **`interpreter_path`** - Resolved interpreter path or callable descriptor
+- **`env_sources`** - Applied environment sources
+- **`applied_kleisli`** - Applied Kleisli descriptor (if any)
+- **`applied_transforms`** - Applied transform descriptors
 
 ---
 
 ## Utilities
 
-### graph_to_html(graph)
+### graph_to_html(graph, *, title="doeff Graph Snapshot", mark_success=False)
 
-Generate HTML visualization of execution graph.
+Generate graph-visualization HTML as a Program.
 
 ```python
-from doeff import graph_to_html
+from doeff import default_handlers, graph_to_html, run
 
-html = await graph_to_html(result.graph)
+html = run(graph_to_html(graph), handlers=default_handlers()).value
 ```
 
-**Parameters:** `graph: WGraph` - Execution graph
-
-**Returns:** str - HTML visualization
-
-**See:** [Graph Tracking](08-graph-tracking.md#visualization)
+**Signature:**
+`graph_to_html(graph: WGraph, *, title: str = ..., mark_success: bool = False) -> Program[str]`
 
 ---
 
-### write_graph_html(graph, path)
+### write_graph_html(graph, output_path, *, title="doeff Graph Snapshot", mark_success=False)
 
-Write graph HTML to file.
+Write graph HTML to a file as a Program.
 
 ```python
-from doeff import write_graph_html
+from doeff import default_handlers, run, write_graph_html
 
-await write_graph_html(result.graph, "output.html")
+path = run(write_graph_html(graph, "output.html"), handlers=default_handlers()).value
 ```
 
-**Parameters:**
-
-- **`graph: WGraph`** - Execution graph
-- **`path: str`** - Output file path
-
-**Returns:** None
-
-**See:** [Graph Tracking](08-graph-tracking.md#export-to-html)
+**Signature:**
+`write_graph_html(graph: WGraph, output_path: str | Path, *, title: str = ..., mark_success: bool = False) -> Program[Path]`
 
 ---
 
@@ -904,48 +648,49 @@ await write_graph_html(result.graph, "output.html")
 | Category | Effects |
 |----------|---------|
 | **Reader** | Ask, Local |
-| **State** | Get, Put, Modify, AtomicGet, AtomicUpdate |
-| **Writer** | Tell, Listen, StructuredLog, slog |
-| **Async** | Await, Gather, Spawn, Wait |
+| **State** | Get, Put, Modify |
+| **Writer** | Tell, Log, Listen, StructuredLog |
+| **Async/Concurrency** | Await, Spawn, Wait, Gather |
 | **Error** | Safe |
-| **IO** | IO |
 | **Cache** | CacheGet, CachePut |
 | **Graph** | Step, Annotate, Snapshot, CaptureGraph |
-| **Advanced** | Spawn, Gather |
+| **Atomic** | AtomicGet, AtomicUpdate |
 
 ### Common Imports
 
 ```python
 # Core
-from doeff import do, Program
+from doeff import Program, EffectBase, do
 
 # Execution
-from doeff import run, default_handlers
-from doeff import async_run, default_async_handlers
+from doeff import run, async_run
+from doeff import default_handlers, default_async_handlers
 
-# Basic Effects
-from doeff import Ask, Local, Get, Put, Modify, Tell, Listen, StructuredLog, slog
+# Reader / State / Writer
+from doeff import Ask, Local, Get, Put, Modify, Tell, Log, Listen, StructuredLog
 
-# Async
-from doeff import Await, Gather, Spawn, Wait
+# Async / Concurrency
+from doeff import Await, Spawn, Wait, Gather
 
-# Error Handling
+# Error handling
 from doeff import Safe
-
-# IO
-from doeff import IO
 
 # Cache
 from doeff import CacheGet, CachePut, cache
 
 # Graph
-from doeff import Step, Annotate, Snapshot, CaptureGraph, graph_to_html
+from doeff import Step, Annotate, Snapshot, CaptureGraph, graph_to_html, write_graph_html
 
-# Advanced
-from doeff import Gather, AtomicGet, AtomicUpdate
+# Atomic
+from doeff import AtomicGet, AtomicUpdate
 
 # Pinjected (separate package)
-from doeff_pinjected import program_to_injected, program_to_injected_result
+from doeff_pinjected import (
+    program_to_injected,
+    program_to_injected_result,
+    program_to_iproxy,
+    program_to_iproxy_result,
+)
 ```
 
 ## Next Steps

--- a/docs/revision-log.md
+++ b/docs/revision-log.md
@@ -41,6 +41,17 @@ Current docs should describe the active model directly:
 - Main docs now use the canonical writer API: `Tell`, `StructuredLog`, `slog`, and `Listen`.
 - Inline references to deprecated protocol names were removed from core chapters.
 
+## DA2-002 (2026-02-17)
+
+`docs/13-api-reference.md` was realigned to current APIs:
+
+- removed stale `ExecutionContext` API section
+- replaced protocol-style effect documentation with the `EffectBase`/`EffectValue` model
+- updated stale signatures (`RunResult`, `run`/`async_run`, graph utilities, and effect constructors)
+
+Historical/deprecated protocol-era references are tracked in this revision log instead of inline
+API chapters.
+
 ## DA-011 (2026-02-17)
 
 `docs/program-architecture-overview.md` was fully rewritten to match:


### PR DESCRIPTION
## Summary
- rewrote `docs/13-api-reference.md` to match the current API surface
- removed the stale `ExecutionContext` API section and documented `env`/`store` on `run`/`async_run`
- replaced protocol-style effect documentation with the current `EffectBase`/`EffectValue` model
- audited and corrected stale signatures in the chapter (including `RunResult`, `async_run`, graph utilities, and effect constructors)
- added migration note `DA2-002` in `docs/revision-log.md`

## Acceptance Criteria Evidence

### 1) `ExecutionContext` section removed and replaced with current run API (`env`/`store`)
Updated execution reference in `docs/13-api-reference.md`:
- `run(..., env=..., store=...)`
- `async_run(..., env=..., store=...)`

### 2) Effect model updated from protocol-style to `EffectBase`/`EffectValue`
Updated core type section in `docs/13-api-reference.md`:
- `EffectBase / EffectValue[T]`
- explicit `Perform(effect)` dispatch note

### 3) Stale signatures audited and updated to current public API
Updated signatures across chapter sections including:
- `RunResult[T]`
- `async_run(...)` (no `arun` usage)
- `StructuredLog(**entries)`
- `Step(value, meta=None)`
- `AtomicUpdate(..., updater, ..., default_factory=...)`
- `graph_to_html(...) -> Program[str]`
- `write_graph_html(...) -> Program[Path]`
- `run_program(...)` and `ProgramRunResult.run_result: RunResult[Any] | None`

## Validation

```bash
rg 'ExecutionContext|class Effect.Protocol' docs/13-api-reference.md
# no matches

uv run pytest
# 481 passed, 6 skipped
```

Ref: DA2-002
