### PR TITLE
Fix KPC and Intercept doc gaps (DA2-007)

### DIFF
--- a/docs/02-core-concepts.md
+++ b/docs/02-core-concepts.md
@@ -177,6 +177,19 @@ Handlers interpret effects with this shape:
 If a host handler returns an effect value, runtime normalizes it through `Perform(effect)`
 before continuing.
 
+## Intercept Transform Contract
+
+`Intercept(program, *transforms)` installs scoped transforms for yielded effects.
+Each transform is called with the current effect and may return:
+
+- `None`: pass through to the next transform (or to normal effect handling if none match)
+- `Effect`: replace the original effect with that effect
+- `Program`: replace the original effect by running that program
+
+Transforms are evaluated in declaration order, and the first non-`None` result wins.
+This contract defines interception as effect-to-effect/program rewriting at the
+`Perform(effect)` boundary, not as a separate control-node family.
+
 ## Composition
 
 IR-level composition primitives:

--- a/docs/revision-log.md
+++ b/docs/revision-log.md
@@ -3,6 +3,22 @@
 Historical and migration notes are collected here so the main documentation chapters stay focused on
 the current architecture and APIs.
 
+## DA2-007 (2026-02-17)
+
+Updates for KPC/Intercept documentation gaps:
+
+- Added Intercept transform contract coverage (`None` pass-through, `Effect` replacement,
+  `Program` replacement, first non-`None` wins).
+- Added explicit KPC non-effect invariant callout in Kleisli docs.
+- Added `@do` handler authoring contract details for handler signatures.
+- Added varargs auto-unwrap boundary notes for `*args`/`**kwargs`.
+
+KPC migration reminder (historical context):
+
+- The KPC handler is removed. Current architecture uses call-time macro expansion:
+  `KleisliProgram.__call__()` returns `Call` DoCtrl directly, and the VM evaluates
+  that DoExpr without any KPC-specific handler.
+
 ## DA-001 (2026-02-17)
 
 `docs/02-core-concepts.md` was rewritten to present only current architecture.


### PR DESCRIPTION
## Summary
- add Intercept transform contract subsection to `docs/02-core-concepts.md`
- add KPC non-effect invariant callout to `docs/11-kleisli-arrows.md`
- document `@do` handler authoring contract in `docs/11-kleisli-arrows.md`
- add varargs auto-unwrap boundary note in `docs/11-kleisli-arrows.md`
- add migration/history entry for DA2-007 in `docs/revision-log.md`

## Acceptance criteria evidence
- Gap 1 (KPC non-effect invariant): present in `docs/11-kleisli-arrows.md` under **KPC Non-Effect Invariant** (`PyEffectBase`, `Perform(KPC(...))`, and no KPC handler).
- Gap 2 (`@do` handler authoring contract): present in `docs/11-kleisli-arrows.md` under **`@do` Handler Authoring Contract** (inspectable signature, `(effect, k)`, Effect-family annotation).
- Gap 3 (Intercept transform contract): present in `docs/02-core-concepts.md` under **Intercept Transform Contract** (`None`/`Effect`/`Program`, first non-`None` wins).
- Gap 4 (removed KPC handler migration note): present as a migration pointer in `docs/11-kleisli-arrows.md`; detailed migration history moved to `docs/revision-log.md` (DA2-007 entry).
- Gap 5 (varargs auto-unwrap edges): present in `docs/11-kleisli-arrows.md` under **Varargs Auto-Unwrap at Composition Boundaries** (`var_positional`, `var_keyword`, partial boundary behavior).

## Validation commands and outputs
```bash
uv run pytest tests/public_api/test_types_001_kpc.py tests/public_api/test_types_001_handler_protocol.py tests/effects/test_control_effects.py
# 78 passed in 0.20s

uv run pytest tests/public_api/test_kpc_macro_expansion.py -q
# 7 passed in 0.02s
```

Varargs boundary behavior check:
```bash
uv run python - <<'PY'
# ...snippet omitted...
PY
# unannotated_varargs_arg_type= Perform
# program_annotated_varargs_arg_type= Pure
# program_annotated_varkw_arg_type= Pure
# partial_prefix_arg_type= Pure
# partial_vararg_arg_type= Pure
# partial_vararg_is_pure= True
# unannotated_vararg_is_perform= True
```

Documentation gap verification script:
```bash
uv run python - <<'PY'
# ...snippet omitted...
PY
# gap1_kpc_non_effect_invariant=True
# gap2_do_handler_authoring_contract=True
# gap3_intercept_transform_contract=True
# gap4_removed_kpc_handler_migration_note=True
# gap5_varargs_auto_unwrap_edges=True
```

Refs: DA2-007
