### PR TITLE
Fix Result API docs in 05-error-handling

### DIFF
--- a/docs/05-error-handling.md
+++ b/docs/05-error-handling.md
@@ -6,6 +6,7 @@ This chapter covers error handling in doeff using `RunResult`, the `Safe` effect
 
 - [RunResult Overview](#runresult-overview)
 - [Ok/Err Result Values](#okerr-result-values)
+- [Result Methods](#result-methods)
 - [Pattern Matching](#pattern-matching)
 - [Safe Effect](#safe-effect)
 - [Captured Traceback on Err](#captured-traceback-on-err)
@@ -13,7 +14,7 @@ This chapter covers error handling in doeff using `RunResult`, the `Safe` effect
 
 ## RunResult Overview
 
-`run()` and `arun()` return a `RunResult[T]`.
+`run()` and `async_run()` return a `RunResult[T]`.
 
 ```python
 from doeff import Ask, Tell, default_handlers, do, run
@@ -48,7 +49,8 @@ Use the canonical import path:
 from doeff import Ok, Err
 ```
 
-`Ok` and `Err` values returned by doeff runtime surfaces (`RunResult.result`, `Safe(...)`, task completion payloads) are Rust-backed VM result objects.
+`Ok` and `Err` values returned by doeff runtime surfaces (`RunResult.result`, `Safe(...)`, task
+completion payloads) are a unified Rust-backed Result implementation.
 
 ### Fields
 
@@ -60,6 +62,14 @@ from doeff import Ok, Err
 
 - `bool(ok_value)` is `True`
 - `bool(err_value)` is `False`
+
+## Result Methods
+
+Use the Result API methods for transformations and fallbacks:
+
+- `value_or(default)`: get the success value or a fallback
+- `map(f)`: transform only the `Ok` value
+- `flat_map(f)`: chain functions that already return `Ok`/`Err`
 
 ## Pattern Matching
 


### PR DESCRIPTION
## Summary
- updated `docs/05-error-handling.md` to replace stale `arun()` reference with `async_run()`
- added a dedicated Result Methods section documenting `value_or()`, `map()`, and `flat_map()` as the current API names
- clarified that `Ok`/`Err` are unified Rust-backed result types across runtime surfaces
- retained executable examples and kept `Err.captured_traceback` coverage in the Err section

## Validation Evidence
- `rg -n "value_or|captured_traceback" docs/05-error-handling.md`
  - matches include both `value_or` and `captured_traceback`
- `uv run pytest tests/core/test_runtime_regressions_manual.py::test_rust_ok_err_pyclass_constructors tests/core/test_runtime_regressions_manual.py::test_safe_wraps_error_as_result_value`
  - result: `2 passed`
- doc example smoke check executed:
  - fallback example returns `fallback`
  - Err object exposes `captured_traceback`

## Issue
- DA2-006
