### PR TITLE
Add Semaphore effects documentation (DA2-008)

### DIFF
--- a/docs/17-semaphore-effects.md
+++ b/docs/17-semaphore-effects.md
@@ -1,0 +1,141 @@
+# 17. Semaphore Effects
+
+Semaphores provide cooperative concurrency control in doeff. They let you cap concurrent work,
+protect critical sections, and coordinate access to finite resources without blocking OS threads.
+
+## Table of Contents
+
+- [Overview / Motivation](#overview--motivation)
+- [Effect Definitions](#effect-definitions)
+- [Usage Patterns](#usage-patterns)
+- [FIFO Fairness](#fifo-fairness)
+- [Scheduler Integration](#scheduler-integration)
+
+## Overview / Motivation
+
+Semaphore effects are useful when many tasks run concurrently and only a limited number should
+enter a section at once.
+
+- **Bounded concurrency**: allow at most `N` concurrent workers.
+- **Mutual exclusion**: use one permit (`N = 1`) as a mutex.
+- **Resource pooling**: model fixed-size pools (DB connections, API slots, GPU workers).
+
+Because semaphores are effects, waiting is cooperative: blocked tasks yield to the scheduler and
+other runnable tasks continue.
+
+## Effect Definitions
+
+Import surface:
+
+```python
+from doeff import AcquireSemaphore, CreateSemaphore, ReleaseSemaphore, Semaphore
+```
+
+### `CreateSemaphore(permits: int)`
+
+Creates and returns a `Semaphore` handle with `permits` available permits.
+
+- `permits` must be an integer `>= 1`.
+- `CreateSemaphore(0)` raises `ValueError`.
+
+```python
+from doeff import CreateSemaphore, do
+
+@do
+def setup():
+    sem = yield CreateSemaphore(3)
+    return sem
+```
+
+### `AcquireSemaphore(sem)`
+
+Acquires one permit from `sem`.
+
+- If a permit is available and there are no earlier waiters, acquisition continues immediately.
+- If no permit is available, the task is cooperatively parked and resumed later.
+
+```python
+from doeff import AcquireSemaphore, do
+
+@do
+def enter(sem):
+    yield AcquireSemaphore(sem)
+```
+
+### `ReleaseSemaphore(sem)`
+
+Releases one permit back to `sem`.
+
+- If waiters exist, the released permit is handed to the oldest waiter (FIFO).
+- Releasing more times than acquired raises `RuntimeError`.
+
+```python
+from doeff import ReleaseSemaphore, do
+
+@do
+def leave(sem):
+    yield ReleaseSemaphore(sem)
+```
+
+## Usage Patterns
+
+### Mutex: `Semaphore(1)` for exclusive access
+
+```python
+from doeff import AcquireSemaphore, CreateSemaphore, ReleaseSemaphore, do
+
+@do
+def with_mutex(sem, update):
+    yield AcquireSemaphore(sem)
+    try:
+        return (yield update())
+    finally:
+        yield ReleaseSemaphore(sem)
+
+@do
+def program():
+    sem = yield CreateSemaphore(1)
+    return (yield with_mutex(sem, critical_update))
+```
+
+Use `try/finally` so permits are released even when work fails.
+
+### Connection pool: `Semaphore(N)` for bounded parallelism
+
+```python
+from doeff import AcquireSemaphore, CreateSemaphore, Gather, ReleaseSemaphore, Spawn, Wait, do
+
+@do
+def pooled_call(sem, call):
+    yield AcquireSemaphore(sem)
+    try:
+        return (yield call())
+    finally:
+        yield ReleaseSemaphore(sem)
+
+@do
+def run_batch(calls):
+    sem = yield CreateSemaphore(8)  # at most 8 concurrent calls
+    tasks = [yield Spawn(pooled_call(sem, call)) for call in calls]
+    return (yield Gather(*[Wait(t) for t in tasks]))
+```
+
+## FIFO Fairness
+
+Semaphore waiters are served in FIFO order.
+
+- A task that waits earlier is resumed earlier.
+- New acquirers do not bypass queued waiters.
+- This prevents starvation under sustained contention.
+
+## Scheduler Integration
+
+Semaphore effects are integrated with the scheduler's cooperative suspension model.
+
+1. `AcquireSemaphore` tries to take a permit.
+2. If unavailable, the scheduler parks the task and records it in the semaphore wait queue.
+3. The parked task yields execution; other runnable tasks continue.
+4. `ReleaseSemaphore` resumes the next waiter in FIFO order (or returns a permit to the semaphore
+   if no waiter exists).
+
+This design provides backpressure and fairness without thread blocking or busy waiting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,21 +24,22 @@ Welcome to the comprehensive documentation for doeff - an algebraic effects syst
 7. **[Cache System](07-cache-system.md)** - Cache effects with policies and handlers
 8. **[Graph Tracking](08-graph-tracking.md)** - Execution tracking and visualization
 9. **[Advanced Effects](09-advanced-effects.md)** - Gather, Atomic operations
+10. **[Semaphore Effects](17-semaphore-effects.md)** - Create, acquire, and release permits with FIFO fairness
 
 ### Integration & Advanced Topics
 
-10. **[Pinjected Integration](10-pinjected-integration.md)** - Dependency injection with pinjected
-11. **[Kleisli Arrows](11-kleisli-arrows.md)** - Composition and automatic unwrapping
-12. **[Patterns](12-patterns.md)** - Best practices and common patterns
-13. **[API Reference](13-api-reference.md)** - Complete API documentation
+11. **[Pinjected Integration](10-pinjected-integration.md)** - Dependency injection with pinjected
+12. **[Kleisli Arrows](11-kleisli-arrows.md)** - Composition and automatic unwrapping
+13. **[Patterns](12-patterns.md)** - Best practices and common patterns
+14. **[API Reference](13-api-reference.md)** - Complete API documentation
 
 ### CLI Tools
 
-14. **[CLI Auto-Discovery](14-cli-auto-discovery.md)** - Automatic interpreter and environment discovery
-15. **[CLI Script Execution](15-cli-script-execution.md)** - Execute Python scripts with program execution results
-16. **[Python run_program API](16-run-program-api.md)** - Use CLI-equivalent discovery from Python tests or scripts
-17. **[Effect Boundaries](17-effect-boundaries.md)** - Effect vs escape architecture and runner boundaries
-18. **[Agent Tutorial](19-agent-tutorial.md)** - Building an automated code review system
+15. **[CLI Auto-Discovery](14-cli-auto-discovery.md)** - Automatic interpreter and environment discovery
+16. **[CLI Script Execution](15-cli-script-execution.md)** - Execute Python scripts with program execution results
+17. **[Python run_program API](16-run-program-api.md)** - Use CLI-equivalent discovery from Python tests or scripts
+18. **[Effect Boundaries](17-effect-boundaries.md)** - Effect vs escape architecture and runner boundaries
+19. **[Agent Tutorial](19-agent-tutorial.md)** - Building an automated code review system
 
 ### Specialized Topics
 


### PR DESCRIPTION
## Summary
- add new chapter `docs/17-semaphore-effects.md` for SPEC-EFF-014 semaphore effects
- document motivation, effect definitions, usage patterns (mutex and connection pool), FIFO fairness, and cooperative parking scheduler integration
- add `Semaphore Effects` entry to `docs/index.md`

## Validation
- `test -f docs/17-semaphore-effects.md && echo "File exists"`
  - output: `File exists`
- `rg -n 'Semaphore' docs/index.md`
  - output: `27:10. **[Semaphore Effects](17-semaphore-effects.md)** - Create, acquire, and release permits with FIFO fairness`
- `uv run pytest tests/effects/test_semaphore.py`
  - output: `10 passed`
- `uv run pytest`
  - output: `481 passed, 6 skipped`

## Issue
- DA2-008
