### PR TITLE
Renumber semaphore doc to 21 and add cancel/leak lifecycle notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Welcome to the comprehensive documentation for doeff - an algebraic effects syst
 7. **[Cache System](07-cache-system.md)** - Cache effects with policies and handlers
 8. **[Graph Tracking](08-graph-tracking.md)** - Execution tracking and visualization
 9. **[Advanced Effects](09-advanced-effects.md)** - Gather, Atomic operations
-10. **[Semaphore Effects](17-semaphore-effects.md)** - Create, acquire, and release permits with FIFO fairness
+10. **[Semaphore Effects](21-semaphore-effects.md)** - Create, acquire, and release permits with FIFO fairness
 
 ### Integration & Advanced Topics
 


### PR DESCRIPTION
## Summary
- Renamed `docs/17-semaphore-effects.md` to `docs/21-semaphore-effects.md` to remove numbering collision.
- Updated `docs/index.md` table-of-contents link to `21-semaphore-effects.md`.
- Added explicit sections in semaphore docs for cancel interaction, permit leak warning, and no explicit destroy API.

## Acceptance Criteria Evidence
- `test -f docs/21-semaphore-effects.md && echo OK` -> `OK`
- `test ! -f docs/17-semaphore-effects.md && echo OK` -> `OK`
- `rg '17-semaphore' docs/` -> no matches (`EXIT:1`)

## Validation
- Ran `uv run pytest`.
- Result: **failed** with one existing failure unrelated to this docs-only change:
  - `tests/core/test_spec_gaps.py::TestG24HandlerResumeSemantics::test_reader_handler_resume_is_unreachable`

Reference: DA3-003
