### PR TITLE
DA3-007: Expand docs for core concepts, Kleisli, and Intercept gaps

### DIFF
--- a/docs/02-core-concepts.md
+++ b/docs/02-core-concepts.md
@@ -109,6 +109,36 @@ program = fetch_user(Ask("active_user_id"))
 
 `program` above is a `DoExpr` (`Call`) that is evaluated by `run`/`async_run`.
 
+### Non-Generator `@do` Functions
+
+`@do` also supports non-generator functions that use plain `return` and never
+`yield`. In that case, call-time expansion still produces a valid `Call` node,
+and runtime evaluation returns the function result normally.
+
+### Metadata Preservation
+
+The decorator preserves normal function metadata so tooling still works:
+`__doc__`, `__name__`, `__qualname__`, `__module__`, `__annotations__`, and
+the inspectable signature. This metadata preservation is part of the public
+behavior contract for `@do`.
+
+### Method Decoration via `__get__`
+
+`KleisliProgram` implements descriptor binding (`__get__`), so `@do` works on
+instance methods the same way as regular Python methods. The bound instance is
+applied at call time before `Call(...)` construction.
+
+### Kleisli `>>` Composition
+
+Kleisli arrows support `>>` composition (alias of `and_then_k`) to chain
+`KleisliProgram` values directly. This is Kleisli-level composition, not VM
+instruction composition.
+
+```python
+fetch_user_posts = fetch_user >> fetch_posts
+program = fetch_user_posts(7)
+```
+
 ## Rust VM Execution Pipeline
 
 Runtime flow:

--- a/docs/09-advanced-effects.md
+++ b/docs/09-advanced-effects.md
@@ -307,6 +307,8 @@ def transform(effect: Effect) -> Effect | Program | None:
 - `Effect`: substitute with that effect (it is not re-transformed by the same `InterceptFrame`).
 - `Program`: replace the effect by executing that program under the current intercept scope.
 - First non-`None` transform wins.
+- If a transform raises an exception, that transform exception propagates and
+  Intercept evaluation fails for that step.
 
 ### Child Propagation
 

--- a/docs/11-kleisli-arrows.md
+++ b/docs/11-kleisli-arrows.md
@@ -7,6 +7,7 @@ pure call-time macro expansion and emits a `Call` DoCtrl directly.
 
 - [What `@do` Returns](#what-do-returns)
 - [Call-Time Macro Expansion](#call-time-macro-expansion)
+- [Why Call Is a Macro](#why-call-is-a-macro)
 - [KPC Non-Effect Invariant](#kpc-non-effect-invariant)
 - [Annotation-Aware Argument Classification](#annotation-aware-argument-classification)
 - [`@do` Handler Authoring Contract](#do-handler-authoring-contract)
@@ -67,6 +68,17 @@ def __call__(self, *args, **kwargs):
     }
     return Call(Pure(self.execution_kernel), do_expr_args, do_expr_kwargs, metadata)
 ```
+
+## Why Call Is a Macro
+
+`KleisliProgram.__call__` is intentionally a macro step to preserve phase separation:
+Python call-time expansion builds `DoExpr`, and VM runtime evaluation executes `DoExpr`.
+Treating call-construction as an effect introduces a recursion flaw where call dispatch
+must invoke effect handling before the call tree is fully constructed.
+
+The macro model avoids that cycle by constructing `Call(...)` immediately, then letting
+standard DoExpr evaluation proceed. Historical removed component matrix details are kept
+in `docs/revision-log.md` so this chapter stays focused on the current model.
 
 ## KPC Non-Effect Invariant
 

--- a/docs/revision-log.md
+++ b/docs/revision-log.md
@@ -3,6 +3,16 @@
 Historical and migration notes are collected here so the main documentation chapters stay focused on
 the current architecture and APIs.
 
+## DA3-007 (2026-02-17)
+
+Removed component matrix for the KPC transition (historical reference):
+
+| Removed component | Previous role | Current replacement |
+| --- | --- | --- |
+| `KPC` effect value type | Represented call intent as an effect payload | `Call` DoCtrl emitted directly by `KleisliProgram.__call__` |
+| KPC runtime handler | Interpreted `KPC(...)` through handler dispatch | Standard VM evaluation of `Call(...)` DoExpr |
+| KPC-specific dispatch path | Special-case effect-dispatch branch | Call-time macro expansion + regular DoExpr execution |
+
 ## DA2-007 (2026-02-17)
 
 Updates for KPC/Intercept documentation gaps:


### PR DESCRIPTION
## Summary
- add concise `@do` behavior notes to `docs/02-core-concepts.md` for non-generator returns, metadata preservation, method binding via `__get__`, and Kleisli `>>` composition
- add `Why Call Is a Macro` rationale in `docs/11-kleisli-arrows.md` covering recursion flaw and phase separation
- add Intercept transform exception propagation note in `docs/09-advanced-effects.md`
- move historical removed-component matrix content to `docs/revision-log.md` (policy-compliant)

## Acceptance Criteria Evidence
### 1) 02-core-concepts additions
Command: `rg 'non-generator|metadata.*preserv|>>.*compos' docs/02-core-concepts.md`
Output:
- `@do` also supports non-generator functions that use plain `return` and never
- `the inspectable signature. This metadata preservation is part of the public`
- `Kleisli arrows support `>>` composition (alias of `and_then_k`) to chain`

### 2) 11-kleisli rationale additions
Command: `rg 'recursion|phase.separation' docs/11-kleisli-arrows.md`
Output:
- ``KleisliProgram.__call__` is intentionally a macro step to preserve phase separation:`
- `Treating call-construction as an effect introduces a recursion flaw where call dispatch`

### 3) 09-advanced Intercept transform exception note
Command: `rg 'transform.*exception' docs/09-advanced-effects.md`
Output:
- `- If a transform raises an exception, that transform exception propagates and`

## Validation
- Ran: `uv run pytest`
- Result: `1 failed, 485 passed, 6 skipped`
- Failure observed in existing suite: `tests/core/test_spec_gaps.py::TestG24HandlerResumeSemantics::test_reader_handler_resume_is_unreachable`

## Issue
- DA3-007
