### PR TITLE
docs: clarify ListenResult BoundedLog type and Await/Wait boundary

### DIFF
--- a/docs/13-api-reference.md
+++ b/docs/13-api-reference.md
@@ -292,7 +292,10 @@ value, logs = result
 
 **Signature:** `Listen(sub_program: ProgramLike)`
 
-**Returns:** `ListenResult(value, log)`
+**Returns:** `ListenResult(value: T, log: BoundedLog)`
+
+`ListenResult.log` uses bounded retention semantics: when capacity is exceeded, oldest
+entries are evicted.
 
 ---
 
@@ -321,6 +324,9 @@ value = yield Await(async_call())
 ```
 
 **Signature:** `Await(awaitable: Awaitable[Any])`
+
+`Await` bridges Python `asyncio` awaitables into doeff. For doeff-native `Task`/`Future`
+handles, use `Wait` instead.
 
 ---
 


### PR DESCRIPTION
## Summary
- update API reference `Listen` return signature to `ListenResult(value: T, log: BoundedLog)`
- add bounded retention note for `ListenResult.log`
- add explicit boundary note under `Await` directing doeff-native `Task`/`Future` usage to `Wait`

## Issue
- DA5-001

## Acceptance Criteria Evidence
1. Listen API entry shows type detail
   - Command: `rg -n 'BoundedLog' docs/13-api-reference.md`
   - Output: `295:**Returns:** ListenResult(value: T, log: BoundedLog)`
2. Await section distinguishes Await vs Wait boundary
   - Command: `rg -n 'asyncio.*awaitable|Python.*awaitable|doeff-native' docs/13-api-reference.md`
   - Output: `328:Await bridges Python asyncio awaitables into doeff. For doeff-native Task/Future...`

## Validation
- Command: `uv run pytest`
- Result: `495 passed, 6 skipped in 17.73s`