### PR TITLE
Fix invalid @do async def example in effect-combinations docs

### DIFF
--- a/docs/18-effect-combinations.md
+++ b/docs/18-effect-combinations.md
@@ -169,7 +169,7 @@ Use coordination primitives or isolated state partitioning instead.
 
 ```python
 @do
-async def test_law_8b_async():
+def test_law_8b_async():
     yield Put("counter", 0)
     results = yield Gather(increment(), increment(), increment())
     assert (yield Get("counter")) == 3


### PR DESCRIPTION
## Summary
- Fix the invalid `@do` example in `docs/18-effect-combinations.md` by changing `async def test_law_8b_async()` to `def test_law_8b_async()`.
- No surrounding prose or other examples were modified.

## Evidence for DA6-002 constraints
- Only file changed:
  - `git status --short` -> `M docs/18-effect-combinations.md`
- One-line diff only in target location:
  - `git diff -- docs/18-effect-combinations.md` shows only:
    - `-async def test_law_8b_async():`
    - `+def test_law_8b_async():`
- Line verification after change:
  - `nl -ba docs/18-effect-combinations.md | sed -n '166,178p'` shows line 172 as `def test_law_8b_async():`.

## Validation
- Ran full test suite:
  - `uv run pytest`
  - Result: `495 passed, 6 skipped in 17.45s`

## Issue
- Ref: `DA6-002`
