### PR TITLE
Rename Safe to Try in effect doc files

### DIFF
--- a/docs/04-async-effects.md
+++ b/docs/04-async-effects.md
@@ -178,15 +178,15 @@ why long-running concurrent workloads must keep yielding effects to remain fair.
 - if any gathered task is cancelled, `Gather` raises `TaskCancelledError`
 - remaining tasks are not auto-cancelled
 
-Use `Safe(...)` when you need partial results instead of fail-fast behavior.
+Use `Try(...)` when you need partial results instead of fail-fast behavior.
 
 ```python
-from doeff import Gather, Safe, Spawn, do
+from doeff import Gather, Try, Spawn, do
 
 @do
 def collect_all_even_on_errors():
-    t1 = yield Spawn(Safe(work_1()))
-    t2 = yield Spawn(Safe(work_2()))
+    t1 = yield Spawn(Try(work_1()))
+    t2 = yield Spawn(Try(work_2()))
     return (yield Gather(t1, t2))  # [Ok(...)/Err(...), Ok(...)/Err(...)]
 ```
 
@@ -232,13 +232,13 @@ Cancellation is explicit and cooperative:
 - cancellation request returns immediately; running tasks cancel at next `SchedulerYield`
 
 ```python
-from doeff import Safe, Spawn, Wait, do
+from doeff import Try, Spawn, Wait, do
 
 @do
 def cancel_child():
     task = yield Spawn(work())
     _ = yield task.cancel()
-    return (yield Safe(Wait(task)))  # Err(TaskCancelledError)
+    return (yield Try(Wait(task)))  # Err(TaskCancelledError)
 ```
 
 ## Promise vs ExternalPromise
@@ -280,7 +280,7 @@ Use `Await(coroutine)` for Python async work; use `Wait` for scheduler waitables
 Use `task = yield Spawn(program)` first, then pass the returned `Task` (or a `Future`) handle.
 
 5. Expecting `Gather` to keep going after first failure.
-Use `Safe(...)` around child programs if you need partial success collection.
+Use `Try(...)` around child programs if you need partial success collection.
 
 6. Assuming `Await` is concurrent under `run(...)`.
 It is sequential under `sync_await_handler`; use `async_run(...)` for overlap.

--- a/docs/09-advanced-effects.md
+++ b/docs/09-advanced-effects.md
@@ -73,7 +73,7 @@ def parallel_async():
 - Remaining branches continue unless you cancel them explicitly.
 - On success, results are returned in input order.
 
-Use `Safe(...)` around child programs when you need partial results instead of fail-fast behavior.
+Use `Try(...)` around child programs when you need partial results instead of fail-fast behavior.
 
 ## State Effects in Concurrent Programs
 
@@ -270,14 +270,14 @@ Cancellation is cooperative and non-blocking:
 - `Wait`, `Gather`, and `Race` raise `TaskCancelledError` when waiting on a cancelled task.
 
 ```python
-from doeff import Safe, Spawn, TaskCancelledError, Wait, do
+from doeff import Try, Spawn, TaskCancelledError, Wait, do
 
 @do
 def cancel_and_join():
     task = yield Spawn(long_running_job())
     _ = yield task.cancel()
 
-    joined = yield Safe(Wait(task))
+    joined = yield Try(Wait(task))
     if joined.is_err() and isinstance(joined.error, TaskCancelledError):
         return "cancelled"
     return joined.value


### PR DESCRIPTION
## Summary
- Renamed effect references from `Safe` to `Try` in the five specified documentation files.
- Updated headers, matrix tables (row/column), prose, inline/code references, import examples, law names, and footnotes per DA7-003 rules.
- Preserved lowercase/non-effect identifiers (for example `safe_result`, `safe_read`, `safe_increment`, `unsafe_increment`).

## Files Changed
- `docs/18-effect-combinations.md`
- `docs/12-patterns.md`
- `docs/03-basic-effects.md`
- `docs/04-async-effects.md`
- `docs/09-advanced-effects.md`

## Validation Evidence
- Scope check (only required files changed):
  - `git diff --name-only`
  - Output: the 5 files above only
- Rename completeness check:
  - `rg -n "\\bSafe\\b" docs/18-effect-combinations.md docs/12-patterns.md docs/03-basic-effects.md docs/04-async-effects.md docs/09-advanced-effects.md || true`
  - Output: no matches
- Exception check for lowercase identifiers:
  - `rg -n "safe_result|safe_increment|safe_read" docs/12-patterns.md docs/03-basic-effects.md docs/09-advanced-effects.md || true`
  - Output: matches remain as expected
- Test run:
  - `uv run pytest`
  - Result: `528 passed, 6 skipped in 21.63s`

## Issue
- Closes DA7-003
