### PR TITLE
Rename Safe to Try across all spec files

### DIFF
--- a/specs/core/SPEC-CORE-001-effect-boundaries.md
+++ b/specs/core/SPEC-CORE-001-effect-boundaries.md
@@ -620,7 +620,7 @@ Core Effects (standard handlers):
 +-- Modify(key, fn)       - modify state
 +-- Tell(message)         - append to log (Writer)
 +-- Listen(program)       - capture log output
-+-- Safe(program)         - catch errors
++-- Try(program)         - catch errors
 +-- IO(fn)                - perform IO
 +-- GetTime()             - current time
 +-- CacheGet/Put/Delete   - cache operations
@@ -993,7 +993,7 @@ Almost all monads can be implemented as **handlers** inside doeff:
 | State | Get, Put, Modify | No |
 | Reader | Ask, Local | No |
 | Writer | Tell, Log, Listen | No |
-| Error | Safe, try/catch | No |
+| Error | Try, try/catch | No |
 | IO | Handler runs IO | No |
 | Future | Spawn, Wait (task queue) | No |
 | List | Nondeterminism handler | No |

--- a/specs/effects/SPEC-EFF-001-reader.md
+++ b/specs/effects/SPEC-EFF-001-reader.md
@@ -65,7 +65,7 @@ Required behavior:
 |-------------|----------|
 | Local + Ask | Ask sees override inside, original restored after |
 | Local + Local | Inner wins, both restore independently (LIFO) |
-| Local + Safe | Env restored even on error |
+| Local + Try | Env restored even on error |
 | Local + Gather | Children inherit parent env; child's Local isolated |
 | Local + State | State (Get/Put) persists outside Local (intentional) |
 

--- a/specs/effects/SPEC-EFF-002-state.md
+++ b/specs/effects/SPEC-EFF-002-state.md
@@ -27,12 +27,12 @@ Retrieves the value associated with `key` from the store.
    None-handling when you know the key exists
 
 **Handling missing keys:**
-Use `Safe` to handle potentially missing keys:
+Use `Try` to handle potentially missing keys:
 
 ```python
 @do
 def counter():
-    result = yield Safe(Get("counter"))
+    result = yield Try(Get("counter"))
     current = result.value_or(0)  # Default to 0 if missing
     yield Put("counter", current + 1)
     return current + 1
@@ -84,9 +84,9 @@ def test_immediate_visibility():
 
 **Verified by:** `test_put_get_immediate_visibility`
 
-### Safe + Put: Changes Persist on Caught Error
+### Try + Put: Changes Persist on Caught Error
 
-State modifications made before an error occurs persist even when `Safe` catches the error.
+State modifications made before an error occurs persist even when `Try` catches the error.
 There is NO automatic rollback.
 
 ```python
@@ -98,7 +98,7 @@ def risky_operation():
 @do
 def test_safe_preserves_state():
     yield Put("modified", False)
-    result = yield Safe(risky_operation())
+    result = yield Try(risky_operation())
     # result is Err(ValueError)
     value = yield Get("modified")
     return value  # Returns True - change persisted
@@ -179,16 +179,16 @@ def test_modify_atomicity():
 - **Fail-fast**: Explicit errors catch bugs earlier than silent None propagation
 - **Type safety**: `Get[T]` returns `T`, not `T | None`
 
-**Handling missing keys:** Use `Safe(Get(...))` or `Modify` for initialization patterns.
+**Handling missing keys:** Use `Try(Get(...))` or `Modify` for initialization patterns.
 
 ### D2: No Transaction Rollback on Error
 
-**Decision:** State changes persist through `Safe` error boundaries.
+**Decision:** State changes persist through `Try` error boundaries.
 
 **Considered alternatives:**
-1. Automatic rollback on Safe-caught errors
+1. Automatic rollback on Try-caught errors
 2. Explicit `Transaction` effect wrapper
-3. Copy-on-write semantics for Safe blocks
+3. Copy-on-write semantics for Try blocks
 
 **Rationale:**
 - Complexity of implementing true transaction semantics
@@ -218,7 +218,7 @@ All composition rules are verified by tests in `tests/effects/test_state_semanti
 | Rule | Test |
 |------|------|
 | Put + Get | `test_put_get_immediate_visibility` |
-| Safe + Put | `test_safe_preserves_state_changes` |
+| Try + Put | `test_safe_preserves_state_changes` |
 | Gather + Put | `test_gather_shared_store_semantics` |
 | Modify atomicity | `test_modify_atomic_on_error` |
 | Modify missing key | `test_modify_missing_key_receives_none` |

--- a/specs/effects/SPEC-EFF-003-writer.md
+++ b/specs/effects/SPEC-EFF-003-writer.md
@@ -89,9 +89,9 @@ def program():
 
 **Status: CONFIRMED**
 
-### Listen + Safe
+### Listen + Try
 
-Logs are preserved even when Safe catches an error. The logs accumulated before the error are NOT lost.
+Logs are preserved even when Try catches an error. The logs accumulated before the error are NOT lost.
 
 ```python
 @do
@@ -101,7 +101,7 @@ def inner():
 
 @do
 def program():
-    result = yield Listen(Safe(inner()))
+    result = yield Listen(Try(inner()))
     # result.value is Err(ValueError("error"))
     # result.log contains ["before_error"]  # Log preserved!
 ```
@@ -179,9 +179,9 @@ def outer():
 
 This is intentional - parallel execution means parallel logging. If deterministic ordering is required, use sequential execution or sort logs by timestamp.
 
-### 2. Listen + Safe (logs preserved on error)
+### 2. Listen + Try (logs preserved on error)
 
-**Resolution:** Yes, logs are preserved. Safe only catches the error and converts to Err result; it does not touch the log store.
+**Resolution:** Yes, logs are preserved. Try only catches the error and converts to Err result; it does not touch the log store.
 
 ### 3. Nested Listen
 
@@ -215,8 +215,8 @@ def slog(**entries: object) -> WriterTellEffect:
 |-------------|--------|------|
 | Listen + Tell | Yes | `tests/effects/test_effect_combinations.py` |
 | Listen + Local | Yes | `tests/effects/test_effect_combinations.py` |
-| Listen + Safe (success) | Yes | `tests/effects/test_effect_combinations.py` |
-| Listen + Safe (error) | Yes | `tests/effects/test_effect_combinations.py` |
+| Listen + Try (success) | Yes | `tests/effects/test_effect_combinations.py` |
+| Listen + Try (error) | Yes | `tests/effects/test_effect_combinations.py` |
 | Listen + Gather (sync) | Yes | `tests/effects/test_effect_combinations.py` |
 | Listen + Gather (async) | Yes | `tests/effects/test_effect_combinations.py` |
 | Listen + Listen (nested) | Yes | `tests/effects/test_effect_combinations.py` |

--- a/specs/vm/SPEC-SCHED-001-cooperative-scheduling.md
+++ b/specs/vm/SPEC-SCHED-001-cooperative-scheduling.md
@@ -38,7 +38,7 @@ yield Get("x") ──────► yield Get("x") ─────► (state ha
 | SPEC-008 | Rust VM spec. §Built-in Scheduler Handler defers to this spec. |
 | SPEC-008 §Continuation | Continuation primitives (Transfer, TransferThrow, ResumeContinuation, CreateContinuation). |
 | SPEC-EFF-011 | Await effect (asyncio bridge). Orthogonal to scheduler. |
-| SPEC-EFF-012 | Safe wrapper. Uses Ok/Err from SPEC-EFF-013. |
+| SPEC-EFF-012 | Try wrapper. Uses Ok/Err from SPEC-EFF-013. |
 | SPEC-EFF-013 | Result types (Ok/Err). TaskCompleted.result is Ok or Err. |
 | ~~SPEC-EFF-005~~ | **DEPRECATED.** Superseded by this spec. |
 | ~~SPEC-EFF-007~~ | **DEPRECATED.** Superseded by §Waitable Types in this spec. |
@@ -47,8 +47,8 @@ yield Get("x") ──────► yield Get("x") ─────► (state ha
 ### Out of scope (dedicated specs exist)
 
 - **Await effect** (SPEC-EFF-011): Bridging Python asyncio coroutines into doeff programs
-- **Safe wrapper** (SPEC-EFF-012): Collecting partial results from Gather (error-tolerant aggregation)
-- **Result types** (SPEC-EFF-013): Rust Ok/Err types used by TaskCompleted and Safe
+- **Try wrapper** (SPEC-EFF-012): Collecting partial results from Gather (error-tolerant aggregation)
+- **Result types** (SPEC-EFF-013): Rust Ok/Err types used by TaskCompleted and Try
 
 ## Motivation
 
@@ -659,7 +659,7 @@ Case 5: Some waitables still PENDING
 
 **Fail-fast**: On first error/cancellation among gathered waitables, Gather
 fails immediately. Remaining waitables continue running (NOT auto-cancelled).
-Use `Safe` wrapper (SPEC-EFF-012) to collect partial results.
+Use `Try` wrapper (SPEC-EFF-012) to collect partial results.
 
 **Result ordering**: Results are in the same order as waitables were passed,
 regardless of completion order.
@@ -841,7 +841,7 @@ If the future is CANCELLED, Wait raises `TaskCancelledError`.
 On the first error from any gathered future, Gather fails immediately with
 that error.
 
-To collect all results including errors, wrap individual programs in `Safe`
+To collect all results including errors, wrap individual programs in `Try`
 before Spawn.
 
 ### Race: first error propagates


### PR DESCRIPTION
## Summary
- Renamed `specs/effects/SPEC-EFF-012-safe.md` to `specs/effects/SPEC-EFF-012-try.md`.
- Updated all Safe-effect API references to Try across the 9 scoped spec files.
- Preserved internal names that must not change (`ResultSafeEffect`, `SafeFrame`) and updated the SPEC-EFF-012 location export line to `Try`, `try_`, `ResultSafeEffect`.

## Validation Evidence
- Scope check (`git status --short` before commit): only the 9 requested spec files were modified.
- Rename completeness check:
  - Command: `rg -n "\\bSafe\\b|SPEC-EFF-012-safe\\.md" specs/effects/SPEC-EFF-012-try.md specs/effects/SPEC-EFF-004-control.md specs/effects/SPEC-EFF-100-combinations.md specs/effects/SPEC-EFF-002-state.md specs/effects/SPEC-EFF-003-writer.md specs/effects/SPEC-EFF-001-reader.md specs/effects/SPEC-EFF-013-result-types.md specs/vm/SPEC-SCHED-001-cooperative-scheduling.md specs/core/SPEC-CORE-001-effect-boundaries.md`
  - Result: no matches.
- Must-not-rename check:
  - Command: `rg -n "SafeFrame|ResultSafeEffect" <same 9 files>`
  - Result: expected references remain.
- Test run:
  - Command: `uv run pytest`
  - Result: `528 passed, 6 skipped in 15.72s`.

## Issue
- DA7-001
