### PR TITLE
Rename Safe to Try in peripheral docs and update revision-log

### DIFF
--- a/docs/07-cache-system.md
+++ b/docs/07-cache-system.md
@@ -87,7 +87,7 @@ def smart_cache(key, fresh=False):
         # Bypass cache
         value = yield compute_value()
     else:
-        safe_result = yield Safe(CacheGet(key))
+        safe_result = yield Try(CacheGet(key))
         if safe_result.is_ok():
             value = safe_result.value
         else:

--- a/docs/10-pinjected-integration.md
+++ b/docs/10-pinjected-integration.md
@@ -161,7 +161,7 @@ result = await resolver.provide(injected)  # 3. Ask -> resolver.provide("databas
 ### Service Layer Pattern
 
 ```python
-from doeff import do, Ask, Tell, Safe
+from doeff import do, Ask, Tell, Try
 
 @do
 def user_service(user_id: int):
@@ -169,7 +169,7 @@ def user_service(user_id: int):
     cache = yield Ask("cache")
     
     # Try cache first
-    cache_result = yield Safe(cache.get(f"user_{user_id}"))
+    cache_result = yield Try(cache.get(f"user_{user_id}"))
     
     if cache_result.is_ok():
         yield Tell(f"Cache hit for user {user_id}")
@@ -260,7 +260,7 @@ def auth_service():
 def api_handler(username, password):
     # Compose services
     auth = yield auth_service()
-    result = yield Safe(auth(username, password))
+    result = yield Try(auth(username, password))
     
     if result.is_err():
         return {"error": "Authentication failed"}
@@ -353,7 +353,7 @@ async def test_error_handling():
     @do
     def error_handling_program():
         db = yield Ask("database")
-        safe_result = yield Safe(db.query())
+        safe_result = yield Try(db.query())
         if safe_result.is_ok():
             return safe_result.value
         else:

--- a/docs/20-why-effects-over-di.md
+++ b/docs/20-why-effects-over-di.md
@@ -136,7 +136,7 @@ def cost_cap_handler(effect, k):
 # One retry handler works for everything
 def retry_handler(effect, k):
     for attempt in range(3):
-        safe = yield Safe(Resume(k, effect))
+        safe = yield Try(Resume(k, effect))
         if safe.is_ok():
             return safe.value
     raise safe.error

--- a/docs/positioning/domain-angles/batch-etl.md
+++ b/docs/positioning/domain-angles/batch-etl.md
@@ -20,7 +20,7 @@ def process_batch(items: list[str]) -> Program[BatchResult]:
     results = []
     for i, item in enumerate(items):
         yield Put("progress", i)
-        result = yield Safe(process_single_item(item))
+        result = yield Try(process_single_item(item))
         if result.is_ok():
             results.append(result.value)
             yield Tell({"processed": item, "status": "ok"})

--- a/docs/positioning/domain-angles/trading-backtesting.md
+++ b/docs/positioning/domain-angles/trading-backtesting.md
@@ -16,7 +16,7 @@ The key insight from [docs/20-why-effects-over-di.md](../20-why-effects-over-di.
 ## The Strategy: Pure Effects
 
 ```python
-from doeff import do, Program, Get, Put, Tell, Safe
+from doeff import do, Program, Get, Put, Tell, Try
 from doeff.effects import Await, Spawn, Gather
 
 @dataclass(frozen=True)

--- a/docs/positioning/three-stage-pitch.md
+++ b/docs/positioning/three-stage-pitch.md
@@ -61,7 +61,7 @@ def process_order(order_id):
 @do
 def process_order(order_id) -> Program[float]:
     yield Tell(f"Processing {order_id}")
-    cached = yield Safe(CacheGet(f"order:{order_id}"))
+    cached = yield Try(CacheGet(f"order:{order_id}"))
     if cached.is_ok():
         return cached.value
 
@@ -72,7 +72,7 @@ def process_order(order_id) -> Program[float]:
     )
 
     total = order.qty * price
-    yield Safe(CachePut(f"order:{order_id}", total, ttl=300))
+    yield Try(CachePut(f"order:{order_id}", total, ttl=300))
     yield Tell(f"Done: {total}")
     return total
 ```

--- a/docs/proposals/001-doeff-flow-webui.md
+++ b/docs/proposals/001-doeff-flow-webui.md
@@ -184,7 +184,7 @@ UI edits can be serialized back to Hy code for version control.
 | **Testing** | Requires GPU + models | **Mock handlers, instant** |
 | **Caching** | Custom hash logic | doeff `@cache` decorator |
 | **Events** | Bespoke WebSocket | Effect interception |
-| **Error handling** | Try/catch scattered | `Safe` effect, structured |
+| **Error handling** | Try/catch scattered | `Try` effect, structured |
 | **Extensibility** | Monkey-patch nodes | Compose programs |
 | **Round-trip** | UI → JSON only | UI ↔ Hy ↔ JSON |
 
@@ -283,7 +283,7 @@ doeff-flow workflows compose like functions:
 (defn with-retry [node-fn retries]
   (defnode retry-wrapper [& args]
     (loop [attempts retries]
-      (let [result (yield (Safe (apply node-fn args)))]
+      (let [result (yield (Try (apply node-fn args)))]
         (if (or (.is-ok result) (zero? attempts))
           (.unwrap result)
           (recur (dec attempts)))))))

--- a/docs/revision-log.md
+++ b/docs/revision-log.md
@@ -3,6 +3,25 @@
 Historical and migration notes are collected here so the main documentation chapters stay focused on
 the current architecture and APIs.
 
+## DA7-004 (2026-02-17)
+
+### Safe to Try
+
+The `Safe` effect has been renamed to `Try` to better convey its purpose as an error-catching wrapper.
+The internal class `ResultSafeEffect` is unchanged.
+
+**Before (deprecated):**
+```uv run python
+from doeff import Safe
+result = yield Safe(risky_operation())
+```
+
+**After (current):**
+```uv run python
+from doeff import Try
+result = yield Try(risky_operation())
+```
+
 ## DA3-007 (2026-02-17)
 
 Removed component matrix for the KPC transition (historical reference):
@@ -93,7 +112,9 @@ yield Fail(ValueError("error"))
 raise ValueError("error")
 ```
 
-### Catch to Safe
+### Catch to Safe to Try
+
+Current API name: `Try` (historically `Catch` -> `Safe` -> `Try`).
 
 **Before (dropped):**
 ```python
@@ -105,11 +126,13 @@ result = yield Catch(
 
 **After:**
 ```python
-safe_result = yield Safe(risky_operation())
+safe_result = yield Try(risky_operation())
 result = safe_result.ok() if safe_result.is_ok() else "fallback"
 ```
 
-### Recover to Safe
+### Recover to Safe to Try
+
+Current API name: `Try` (historically `Recover` -> `Safe` -> `Try`).
 
 **Before (dropped):**
 ```python
@@ -121,7 +144,7 @@ data = yield Recover(
 
 **After:**
 ```python
-safe_result = yield Safe(fetch_data())
+safe_result = yield Try(fetch_data())
 data = safe_result.ok() if safe_result.is_ok() else []
 ```
 
@@ -139,7 +162,7 @@ result = yield Retry(
 **After:**
 ```python
 for attempt in range(5):
-    result = yield Safe(unstable_operation())
+    result = yield Try(unstable_operation())
     if result.is_ok():
         break
     if attempt < 4:
@@ -168,7 +191,7 @@ finally:
     yield cleanup_resource()
 ```
 
-### FirstSuccess to sequential Safe
+### FirstSuccess to sequential Try
 
 **Before (dropped):**
 ```python
@@ -182,7 +205,7 @@ result = yield FirstSuccess(
 **After:**
 ```python
 for fetch_fn in [fetch_from_cache, fetch_from_db, fetch_from_api]:
-    result = yield Safe(fetch_fn())
+    result = yield Try(fetch_fn())
     if result.is_ok():
         break
 else:


### PR DESCRIPTION
## Summary
- Rename doeff effect references from `Safe` to `Try` in all 8 requested peripheral doc files.
- Add a new top revision-log entry for `Safe` -> `Try`, including before/after examples.
- Update historical rename sections to `Catch -> Safe -> Try` and `Recover -> Safe -> Try`, with current API examples using `Try`.

## Validation Evidence
- Updated files only (8 docs):
  - `docs/revision-log.md`
  - `docs/10-pinjected-integration.md`
  - `docs/07-cache-system.md`
  - `docs/20-why-effects-over-di.md`
  - `docs/proposals/001-doeff-flow-webui.md`
  - `docs/positioning/three-stage-pitch.md`
  - `docs/positioning/domain-angles/batch-etl.md`
  - `docs/positioning/domain-angles/trading-backtesting.md`
- Peripheral-doc `Safe` references removed check:
  - Command: `rg -n --fixed-strings "Safe" docs/10-pinjected-integration.md docs/07-cache-system.md docs/20-why-effects-over-di.md docs/proposals/001-doeff-flow-webui.md docs/positioning/three-stage-pitch.md docs/positioning/domain-angles/batch-etl.md docs/positioning/domain-angles/trading-backtesting.md`
  - Result: no matches (exit code 1, expected)
- Revision-log required entries present check:
  - Command: `rg -n "^### Safe to Try$|^### Catch to Safe to Try$|^### Recover to Safe to Try$|ResultSafeEffect|yield Try\\(" docs/revision-log.md`
  - Result includes: `### Safe to Try`, `### Catch to Safe to Try`, `### Recover to Safe to Try`, and `yield Try(...)` examples
- Tests:
  - Command: `uv run pytest`
  - Result: `528 passed, 6 skipped in 16.58s`

## Issue
- DA7-004