### PR TITLE
Fix doeff-agentic examples import deps and add effect-based mock example

### DIFF
--- a/packages/doeff-agentic/examples/08_testing_with_mocks.py
+++ b/packages/doeff-agentic/examples/08_testing_with_mocks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""
+Example 08: Testing with effect-based mock handlers.
+
+This example demonstrates a full effect flow without external services:
+1. AgenticCreateSession
+2. AgenticSendMessage
+3. AgenticGetMessages
+
+Run:
+    uv run python packages/doeff-agentic/examples/08_testing_with_mocks.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from doeff import default_handlers, do, run
+from doeff_agentic import (
+    AgenticCreateSession,
+    AgenticGetMessages,
+    AgenticGetSessionStatus,
+    AgenticSendMessage,
+)
+from doeff_agentic.handlers.testing import MockAgenticHandler, mock_handlers
+from doeff_agentic.runtime import with_handler_map
+
+
+@do
+def mock_conversation():
+    """Run a deterministic session using the testing handler."""
+    session = yield AgenticCreateSession(name="reviewer", title="Mock Reviewer")
+    yield AgenticSendMessage(
+        session_id=session.id,
+        content="Explain do-notation in one sentence.",
+        wait=True,
+    )
+    messages = yield AgenticGetMessages(session_id=session.id)
+    status = yield AgenticGetSessionStatus(session_id=session.id)
+    return session.id, status.value, messages
+
+
+def main() -> int:
+    # runtime.with_handler_map composes typed handlers via WithHandler internally.
+    handler_impl = MockAgenticHandler(workflow_name="mock-example")
+    program = with_handler_map(mock_conversation(), mock_handlers(handler_impl))
+    result = run(program, handlers=default_handlers())
+
+    if result.is_err():
+        print("Workflow failed")
+        print(result.format())
+        return 1
+
+    session_id, status, messages = result.value
+    assistant_messages = [m for m in messages if m.role == "assistant"]
+    expected_response = "Mock response to: Explain do-notation in one sentence."
+
+    if status != "done":
+        print(f"Unexpected status: {status}")
+        return 1
+    if not assistant_messages:
+        print("No assistant response found")
+        return 1
+    if assistant_messages[-1].content != expected_response:
+        print("Unexpected assistant response")
+        print(f"Expected: {expected_response}")
+        print(f"Actual:   {assistant_messages[-1].content}")
+        return 1
+
+    print("SUCCESS: deterministic mock flow completed")
+    print(f"Session: {session_id}")
+    print(f"Status:  {status}")
+    print(f"Reply:   {assistant_messages[-1].content}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/doeff-agentic/examples/README.md
+++ b/packages/doeff-agentic/examples/README.md
@@ -156,6 +156,12 @@ Complete production-style workflow combining all patterns.
 uv run python examples/07_pr_review_workflow.py https://github.com/org/repo/pull/123
 ```
 
+### 08. Testing with Mock Handlers
+Effect-based deterministic workflow using `MockAgenticHandler` + `with_handler_map`.
+```bash
+uv run python examples/08_testing_with_mocks.py
+```
+
 ## Monitoring Workflows
 
 While examples are running, you can monitor them:
@@ -218,6 +224,13 @@ This tests the JSONL event logging system - creates workflows, sessions, environ
 uv run python examples/test_mock_workflow.py
 ```
 This demonstrates workflow patterns (sequential, conditional, parallel) using mock data without any external services.
+
+### Test Effect-Based Mock Handler Wiring
+```bash
+uv run python examples/08_testing_with_mocks.py
+```
+This demonstrates `AgenticCreateSession -> AgenticSendMessage -> AgenticGetMessages` with
+`MockAgenticHandler` and no external service.
 
 ### Run Unit Tests
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,5 +120,6 @@ dev = [
     "doeff-gemini",
     "doeff-openai",
     "doeff-openrouter",
+    "doeff-preset",
     "doeff-vm",
 ]


### PR DESCRIPTION
## Summary
- add `doeff-preset` to root dev dependencies so workspace example scripts can import `doeff_preset`
- add `packages/doeff-agentic/examples/08_testing_with_mocks.py` showing effect-based mock handler wiring via `with_handler_map` (WithHandler composition)
- update examples README to document example 08

## Acceptance Criteria Evidence
### AC1: dependency issue fixed
Command:
- `uv run python - <<'PY' ...` importing examples `01`-`07`

Result:
- `OK   01_hello_agent.py`
- `OK   02_agent_with_status.py`
- `OK   03_sequential_agents.py`
- `OK   04_conditional_flow.py`
- `OK   05_human_in_loop.py`
- `OK   06_parallel_agents.py`
- `OK   07_pr_review_workflow.py`

### AC2: mock handler example added
Command:
- `uv run python packages/doeff-agentic/examples/08_testing_with_mocks.py`

Result:
- `SUCCESS: deterministic mock flow completed`
- `Status:  done`
- deterministic assistant reply from mock handler

### AC3: non-OpenCode examples verified
Commands:
- `uv run python packages/doeff-agentic/examples/test_mock_workflow.py`
- `uv run python packages/doeff-agentic/examples/test_event_logging.py`
- `uv run python packages/doeff-agentic/examples/08_testing_with_mocks.py`

Result:
- all commands completed successfully

### AC4: no regressions
Command:
- `uv run pytest packages/doeff-agentic/tests/ -v`

Result:
- `122 passed, 1 skipped`

## Issue
- ISSUE-AGENTIC-EX-001