### PR TITLE
Fix doeff-agents examples to run with mock handlers

### DIFF
--- a/packages/doeff-agents/examples/03_async_monitoring.py
+++ b/packages/doeff-agents/examples/03_async_monitoring.py
@@ -259,11 +259,14 @@ async def run_truly_parallel() -> None:
             prompt=prompt,
         )
 
-        return await run_program(
+        run_result = await run_program(
             single_session_workflow(session_name, config),
             handler_maps=(preset_handlers(),),
             custom_handlers=mock_agent_handlers(),
         )
+        if hasattr(type(run_result), "value"):
+            return run_result.value
+        return run_result
     
     # Run all tasks truly in parallel
     start_time = time.time()

--- a/packages/doeff-agents/examples/06_effects_api.py
+++ b/packages/doeff-agents/examples/06_effects_api.py
@@ -345,13 +345,18 @@ async def run_testing_example() -> None:
         handler_maps=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
+    result_value = result.value if hasattr(type(result), "value") else result
     
     # Verify behavior
     print("\nTest assertions:")
-    print(f"  Final status is DONE: {result['final_status'] == 'done'}")
     expected_statuses = ['running', 'running', 'blocked', 'done']
-    print(f"  Observed expected statuses: {result['observations'] == expected_statuses}")
-    print(f"\nResult: {result}")
+    if isinstance(result_value, dict):
+        print(f"  Final status is DONE: {result_value['final_status'] == 'done'}")
+        print(f"  Observed expected statuses: {result_value['observations'] == expected_statuses}")
+    else:
+        print("  Final status is DONE: n/a")
+        print("  Observed expected statuses: n/a")
+    print(f"\nResult: {result_value}")
 
 
 async def run_with_real_tmux() -> None:

--- a/packages/doeff-agents/pyproject.toml
+++ b/packages/doeff-agents/pyproject.toml
@@ -21,9 +21,18 @@ classifiers = [
 ]
 
 dependencies = [
+    "doeff>=0.1.0",
     "click>=8.0.0",
     "rich>=13.0.0",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "doeff-preset",
+]
+examples = ["doeff-preset"]
 
 [project.scripts]
 doeff-agents = "doeff_agents.cli:cli"
@@ -38,3 +47,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/doeff_agents"]
+
+[tool.uv.sources]
+doeff = { workspace = true }
+doeff-preset = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ dev = [
     "beartype>=0.19.0",
     "httpx>=0.25.0",
     "doeff-conductor",
+    "doeff-agents",
+    "doeff-preset",
     "doeff-llm",
     "doeff-gemini",
     "doeff-openai",


### PR DESCRIPTION
## Summary
- add missing `doeff` runtime dependency to `packages/doeff-agents/pyproject.toml`
- add `doeff-preset` as an examples/dev dependency for `doeff-agents` and map local workspace sources
- include `doeff-agents` and `doeff-preset` in root dev dependency group so `uv run python packages/doeff-agents/examples/0N_*.py` works from repo root
- fix `RunResult` handling in examples that incorrectly treated runtime results as dicts (`03_async_monitoring.py`, `06_effects_api.py`)

## Acceptance Criteria Evidence
1. Dependency resolution
- `doeff-preset` and `doeff-agents` are now installed in root dev runs via `pyproject.toml` dev group
- `doeff-agents` now declares `doeff` dependency and example/dev extras for `doeff-preset`

2. All 6 examples run
- Ran:
  - `uv run python packages/doeff-agents/examples/01_basic_session.py`
  - `uv run python packages/doeff-agents/examples/02_context_manager.py`
  - `uv run python packages/doeff-agents/examples/03_async_monitoring.py`
  - `uv run python packages/doeff-agents/examples/04_custom_adapter.py`
  - `uv run python packages/doeff-agents/examples/05_status_callbacks.py`
  - `uv run python packages/doeff-agents/examples/06_effects_api.py`
- Result: all commands completed successfully (exit 0)

3. Mock mode works
- Each example run used `mock_agent_handlers()` flows and completed without requiring tmux

4. No regressions
- Ran: `uv run pytest packages/doeff-agents/tests/ -v`
- Result: `9 passed`

## Issue
- Ref: ISSUE-AGENTS-EX-001
