### PR TITLE
Fix doeff-flow examples and add mock handler example

### DIFF
--- a/packages/doeff-flow/README.md
+++ b/packages/doeff-flow/README.md
@@ -117,6 +117,7 @@ The package includes several examples demonstrating different use cases:
 | `02_data_pipeline.py` | ETL pipeline with multiple stages |
 | `03_error_handling.py` | Error capture and failure tracing |
 | `04_concurrent_workflows.py` | Multiple concurrent workers with separate traces |
+| `06_testing_with_mocks.py` | In-memory trace assertions with mock handlers |
 | `07_workflow_status.py` | Workflow status with slog for semantic status updates |
 
 Run examples from the `packages/doeff-flow` directory:
@@ -158,12 +159,13 @@ with trace_observer("wf-001", ".doeff-flow") as on_step:
 ### With Durable Storage
 
 ```python
+from doeff import WithHandler
 from doeff.storage import SQLiteStorage
 
+storage = SQLiteStorage(".doeff-cache.db")
 result = run_workflow(
-    my_workflow(),
+    WithHandler(cache_handler(storage), my_workflow()),
     workflow_id="durable-wf",
-    storage=SQLiteStorage(".doeff-cache.db"),
 )
 ```
 

--- a/packages/doeff-flow/examples/01_live_trace.py
+++ b/packages/doeff-flow/examples/01_live_trace.py
@@ -93,6 +93,7 @@ def example_trace_observer():
     """Run workflow with trace_observer context manager."""
     from doeff_flow.trace import write_terminal_trace
 
+    from doeff import default_handlers
     from doeff import run as run_sync
 
     print("=== Example 2: Using trace_observer ===")
@@ -101,7 +102,7 @@ def example_trace_observer():
     # Uses XDG default trace directory
     with trace_observer("example-wf-002") as on_step:
         _ = on_step
-        result = run_sync(main_workflow())
+        result = run_sync(main_workflow(), handlers=default_handlers())
         write_terminal_trace("example-wf-002", None, result)
 
     print(f"\nResult: {result.value}")

--- a/packages/doeff-flow/examples/02_data_pipeline.py
+++ b/packages/doeff-flow/examples/02_data_pipeline.py
@@ -15,7 +15,9 @@ In another terminal, watch the execution:
 Note: By default, traces are written to ~/.local/state/doeff-flow/ (XDG spec).
 """
 
+import argparse
 import random
+import sys
 import time
 
 from doeff_flow import run_workflow
@@ -145,7 +147,20 @@ def etl_pipeline(source: str, destination: str):
 # =============================================================================
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run the data pipeline example.")
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Start immediately without waiting for interactive confirmation.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
+
     print("=" * 60)
     print("Data Pipeline Example with Live Observability")
     print("=" * 60)
@@ -153,7 +168,10 @@ def main():
     print("Run this command in another terminal to watch:")
     print("  doeff-flow watch data-pipeline --exit-on-complete")
     print()
-    input("Press Enter to start the pipeline...")
+    if not args.no_wait and sys.stdin.isatty():
+        input("Press Enter to start the pipeline...")
+    else:
+        print("Skipping wait prompt (--no-wait or non-interactive stdin detected).")
 
     result = run_workflow(
         etl_pipeline(
@@ -163,7 +181,7 @@ def main():
         workflow_id="data-pipeline",
     )
 
-    if result.is_ok:
+    if result.is_ok():
         print(f"\nFinal Result: {result.value}")
     else:
         print(f"\nPipeline failed: {result.error}")

--- a/packages/doeff-flow/examples/03_error_handling.py
+++ b/packages/doeff-flow/examples/03_error_handling.py
@@ -173,7 +173,7 @@ def main():
         workflow_id="error-demo",
     )
 
-    if result1.is_ok:
+    if result1.is_ok():
         print(f"\nResult: {result1.value['successful']} successful, "
               f"{result1.value['failed']} failed")
     else:
@@ -186,10 +186,12 @@ def main():
         workflow_id="failing-demo",
     )
 
-    if result2.is_ok:
+    if result2.is_ok():
         print(f"\nResult: {result2.value}")
     else:
-        print(f"\nWorkflow failed (expected): {type(result2.error).__name__}")
+        error = result2.error
+        print(f"\nWorkflow failed (expected): {type(error).__name__}: {error}")
+        print(f"Safe failure inspection via result.error: {error!r}")
 
     # Show how to inspect traces
     print("\n" + "=" * 60)

--- a/packages/doeff-flow/examples/04_concurrent_workflows.py
+++ b/packages/doeff-flow/examples/04_concurrent_workflows.py
@@ -18,7 +18,9 @@ Watch a specific workflow:
 Note: By default, traces are written to ~/.local/state/doeff-flow/ (XDG spec).
 """
 
+import argparse
 import random
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -139,7 +141,7 @@ def run_concurrent_workers(num_workers: int, tasks_per_worker: int):
 
     total_tasks = 0
     for worker_id, result in sorted(results.items()):
-        if result.is_ok:
+        if result.is_ok():
             tasks = result.value["tasks_completed"]
             worker_elapsed = result.value["elapsed_seconds"]
             total_tasks += tasks
@@ -158,7 +160,20 @@ def run_concurrent_workers(num_workers: int, tasks_per_worker: int):
 # =============================================================================
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run concurrent workflow workers.")
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Start immediately without waiting for interactive confirmation.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
+
     print("=" * 60)
     print("Concurrent Workflows Example")
     print("=" * 60)
@@ -171,7 +186,10 @@ def main():
     print("  doeff-flow ps                          # List all workflows")
     print("  doeff-flow watch worker-001            # Watch specific worker")
     print()
-    input("Press Enter to start workers...")
+    if not args.no_wait and sys.stdin.isatty():
+        input("Press Enter to start workers...")
+    else:
+        print("Skipping wait prompt (--no-wait or non-interactive stdin detected).")
 
     # Run 3 workers, each processing 4 tasks
     run_concurrent_workers(

--- a/packages/doeff-flow/examples/06_testing_with_mocks.py
+++ b/packages/doeff-flow/examples/06_testing_with_mocks.py
@@ -1,0 +1,89 @@
+"""
+Testing Workflows with Mock Trace Handlers
+==========================================
+
+This example demonstrates how to use doeff-flow's in-memory mock trace handlers.
+It wires handlers via `WithHandler`, executes a workflow, and asserts on captured
+trace data without creating trace files.
+
+Run this example:
+    cd packages/doeff-flow
+    uv run python examples/06_testing_with_mocks.py
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from uuid import uuid4
+
+from doeff_flow.effects import TraceAnnotate, TraceCapture, TracePush, TraceSnapshot
+from doeff_flow.handlers import MockTraceRecorder, mock_handlers
+from doeff_flow.trace import get_default_trace_dir
+
+from doeff import Delegate, WithHandler, default_handlers, do
+from doeff import run as run_sync
+
+
+def with_handler_map(program, handler_map):
+    """Compose typed handlers onto a program using WithHandler layers."""
+    wrapped = program
+    for effect_type, handler in reversed(list(handler_map.items())):
+
+        def typed_handler(effect, k, _effect_type=effect_type, _handler=handler):
+            if isinstance(effect, _effect_type):
+                result = _handler(effect, k)
+                if inspect.isgenerator(result):
+                    return (yield from result)
+                return result
+            yield Delegate()
+
+        wrapped = WithHandler(typed_handler, wrapped)
+    return wrapped
+
+
+@do
+def workflow_under_test():
+    """Workflow that emits trace effects and returns captured snapshots."""
+    yield TracePush(name="load", metadata={"request_id": "req-001"})
+    yield TraceAnnotate(key="tenant", value="acme")
+    yield TraceSnapshot(label="checkpoint")
+    captured = yield TraceCapture(format="dict")
+    return captured
+
+
+def main():
+    print("=" * 60)
+    print("Mock Trace Handler Example")
+    print("=" * 60)
+
+    workflow_id = f"mock-example-{uuid4().hex[:8]}"
+    recorder = MockTraceRecorder(workflow_id=workflow_id)
+    handlers = mock_handlers(recorder=recorder)
+    trace_file = get_default_trace_dir() / workflow_id / "trace.jsonl"
+
+    wrapped = with_handler_map(workflow_under_test(), handlers)
+    result = run_sync(wrapped, handlers=default_handlers())
+    if result.is_err():
+        raise RuntimeError(f"Workflow unexpectedly failed: {result.error!r}")
+
+    captured_entries = result.value
+    assert isinstance(captured_entries, list)
+    assert len(captured_entries) == 3
+
+    last_entry = captured_entries[-1]
+    last_slog = last_entry["last_slog"]
+    assert last_slog is not None
+    assert last_slog["label"] == "checkpoint"
+    assert last_slog["annotations"]["tenant"] == "acme"
+    assert last_slog["annotations"]["request_id"] == "req-001"
+
+    # Mock handlers must avoid production trace file writes.
+    assert not Path(trace_file).exists()
+
+    print(f"Captured {len(captured_entries)} in-memory trace entries for {workflow_id}")
+    print("Assertions passed: mock handler captured trace data without filesystem side effects.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes ISSUE-FLOW-EX-001 by making all `doeff-flow` examples runnable and adding a mock-handler example.

### What changed

- Fixed `01_live_trace.py` Part 2 by running `trace_observer` path with `default_handlers()`.
- Fixed `03_error_handling.py` Part 2 by using `is_ok()` correctly and safely inspecting `result.error`.
- Fixed `05_durable_execution.py` end-to-end by removing invalid `storage=` usage and wiring durable cache via explicit `WithHandler` + `SQLiteStorage` cache effect handler.
- Removed interactive blockers in `02_data_pipeline.py` and `04_concurrent_workflows.py` with `--no-wait` and non-interactive stdin auto-skip (`sys.stdin.isatty()`).
- Added `06_testing_with_mocks.py` that demonstrates:
  - `MockTraceRecorder`
  - `mock_handlers()`
  - `WithHandler` composition
  - in-memory trace assertions with no trace file side effects
- Updated `packages/doeff-flow/README.md` example list and durable-storage snippet to match current API usage.

## Acceptance Criteria Evidence

### AC1: `01_live_trace.py` Part 2 works

```bash
uv run python packages/doeff-flow/examples/01_live_trace.py
```

Observed:
- Example 1 completed (`Result: 30`)
- Example 2 completed (`Result: 30`)
- No `UnhandledEffect` / `PyShared` crash

### AC2: `03_error_handling.py` Part 2 safely inspects failure

```bash
uv run python packages/doeff-flow/examples/03_error_handling.py
```

Observed:
- Example 1 completes with summary output
- Example 2 prints expected failure via `result.error`
- No uncontrolled re-raise from `result.value`

### AC3: `05_durable_execution.py` works end-to-end

```bash
uv run python packages/doeff-flow/examples/05_durable_execution.py --reset
uv run python packages/doeff-flow/examples/05_durable_execution.py
```

Observed:
- First run executes expensive steps and succeeds (~5s)
- Second run uses cache and succeeds (~0s)

### AC4: `input()` blockers removed for non-interactive runs

```bash
echo "" | uv run python packages/doeff-flow/examples/02_data_pipeline.py
echo "" | uv run python packages/doeff-flow/examples/04_concurrent_workflows.py
```

Observed:
- Both print `Skipping wait prompt (--no-wait or non-interactive stdin detected).`
- Both run to completion in non-interactive mode

### AC5: mock handler example added and runnable

```bash
uv run python packages/doeff-flow/examples/06_testing_with_mocks.py
```

Observed:
- Runs successfully
- Captures in-memory trace entries and assertions pass
- No production trace file side effects

### AC6: no regressions in `doeff-flow` tests

```bash
uv run pytest packages/doeff-flow/tests/ -v
```

Observed:
- `44 passed`

## Issue Reference

- ISSUE-FLOW-EX-001
