### PR TITLE
Print DoeffTraceback to stderr by default in run()/async_run()

### DIFF
--- a/doeff/__main__.py
+++ b/doeff/__main__.py
@@ -30,7 +30,13 @@ def sync_run(
     store: dict[str, Any] | None = None,
 ) -> RunResult[Any]:
     selected_handlers = sync_handlers_preset if handlers is None else handlers
-    return vm_run(program, handlers=selected_handlers, env=env, store=store)
+    return vm_run(
+        program,
+        handlers=selected_handlers,
+        env=env,
+        store=store,
+        print_doeff_trace=False,
+    )
 
 
 @dataclass
@@ -126,7 +132,9 @@ class ProgramBuilder:
 
         merged_env_program = self._merger.merge_envs(env_sources)
         try:
-            merged_env_dict = vm_run(merged_env_program, handlers=default_handlers()).value
+            merged_env_dict = vm_run(
+                merged_env_program, handlers=default_handlers(), print_doeff_trace=False
+            ).value
         except Exception as exc:
             print("[DOEFF][DISCOVERY] Environment merge failed:", file=sys.stderr)
             print(repr(exc), file=sys.stderr)
@@ -479,7 +487,7 @@ def _finalize_result(value: Any) -> tuple[Any, RunResult[Any] | None]:
     from doeff.program import Program as ProgramType
 
     if isinstance(value, ProgramType):
-        result = vm_run(value, handlers=default_handlers())
+        result = vm_run(value, handlers=default_handlers(), print_doeff_trace=False)
         return result.value, None
     if isinstance(value, RunResult):
         return _unwrap_run_result(value), value
@@ -804,6 +812,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     try:
         return args.func(args)
     except Exception as exc:
+        doeff_tb = getattr(exc, "__doeff_traceback__", None)
         captured = capture_traceback(exc)
         if getattr(args, "format", "text") == "json":
             payload = {
@@ -811,9 +820,13 @@ def main(argv: Iterable[str] | None = None) -> int:
                 "error": exc.__class__.__name__,
                 "message": str(exc),
             }
-            if captured is not None:
+            if doeff_tb is not None:
+                payload["traceback"] = doeff_tb.format_chained()
+            elif captured is not None:
                 payload["traceback"] = captured.format(condensed=False, max_lines=200)
             print(json.dumps(payload))
+        elif doeff_tb is not None:
+            print(doeff_tb.format_chained(), file=sys.stderr)
         elif captured is not None:
             print(captured.format(condensed=False, max_lines=200), file=sys.stderr)
         else:

--- a/doeff/run.py
+++ b/doeff/run.py
@@ -453,7 +453,7 @@ def _execute_program(
     from doeff.rust_vm import run as vm_run
 
     if interpreter_obj is None:
-        return vm_run(program, handlers=default_handlers()).value
+        return vm_run(program, handlers=default_handlers(), print_doeff_trace=False).value
 
     if callable(interpreter_obj):
         result = _call_interpreter(interpreter_obj, program)

--- a/tests/cli/test_cli_error_traces.py
+++ b/tests/cli/test_cli_error_traces.py
@@ -190,3 +190,30 @@ def test_disable_default_env_flag(tmp_path: Path) -> None:
     assert payload["status"] == "ok"
     assert payload["result"] == 5
     assert "Error executing ~/.doeff.py" not in result.stderr
+
+
+def test_cli_json_uses_doeff_traceback() -> None:
+    result = run_cli(
+        "-c",
+        "from doeff import Ask, do\n@do\ndef f():\n    yield Ask('x')\n    return 1\nf()",
+        "--interpreter",
+        "tests.cli.cli_assets.sync_interpreter",
+        "--format",
+        "json",
+    )
+
+    assert result.returncode == 1
+    payload = parse_json(result.stdout)
+    assert "doeff Traceback" in str(payload.get("traceback", ""))
+
+
+def test_cli_text_uses_doeff_traceback() -> None:
+    result = run_cli(
+        "-c",
+        "from doeff import Ask, do\n@do\ndef f():\n    yield Ask('x')\n    return 1\nf()",
+        "--interpreter",
+        "tests.cli.cli_assets.sync_interpreter",
+    )
+
+    assert result.returncode == 1
+    assert "doeff Traceback" in result.stderr

--- a/tests/core/test_doeff_trace_stderr.py
+++ b/tests/core/test_doeff_trace_stderr.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from doeff import Ask, Delegate, EffectBase, Program, WithHandler, async_run, default_async_handlers
+from doeff import default_handlers, do, run
+
+
+def test_run_prints_doeff_trace_to_stderr_on_error(capsys: pytest.CaptureFixture[str]) -> None:
+    @do
+    def failing() -> Program[int]:
+        _ = yield Ask("nonexistent_key")
+        return 42
+
+    result = run(failing(), handlers=default_handlers())
+    assert result.is_err()
+
+    captured = capsys.readouterr()
+    assert "doeff Traceback" in captured.err
+    assert "nonexistent_key" in captured.err
+
+
+def test_run_suppresses_trace_when_flag_is_false(capsys: pytest.CaptureFixture[str]) -> None:
+    @do
+    def failing() -> Program[int]:
+        _ = yield Ask("nonexistent_key")
+        return 42
+
+    result = run(failing(), handlers=default_handlers(), print_doeff_trace=False)
+    assert result.is_err()
+
+    captured = capsys.readouterr()
+    assert "doeff Traceback" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_async_run_prints_doeff_trace_to_stderr_on_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    @do
+    def failing() -> Program[int]:
+        _ = yield Ask("nonexistent_key")
+        return 42
+
+    result = await async_run(failing(), handlers=default_async_handlers())
+    assert result.is_err()
+
+    captured = capsys.readouterr()
+    assert "doeff Traceback" in captured.err
+    assert "nonexistent_key" in captured.err
+
+
+def test_run_no_stderr_on_success(capsys: pytest.CaptureFixture[str]) -> None:
+    @do
+    def ok() -> Program[int]:
+        return 42
+
+    result = run(ok(), handlers=default_handlers())
+    assert result.is_ok()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_doeff_trace_includes_handler_chain(capsys: pytest.CaptureFixture[str]) -> None:
+    @dataclass(frozen=True, kw_only=True)
+    class Boom(EffectBase):
+        pass
+
+    def exploding_handler(effect: object, _k: object):
+        if isinstance(effect, Boom):
+            raise RuntimeError("handler exploded")
+        yield Delegate()
+
+    @do
+    def body() -> Program[int]:
+        yield Boom()
+        return 1
+
+    result = run(WithHandler(exploding_handler, body()), handlers=default_handlers())
+    assert result.is_err()
+
+    captured = capsys.readouterr()
+    assert "[handler]" in captured.err
+    assert "exploding_handler" in captured.err
+    assert "Boom" in captured.err


### PR DESCRIPTION
## Summary
- Add `print_doeff_trace: bool = True` to `run()` and `async_run()` in `doeff/rust_vm.py`.
- Add `_print_doeff_trace_if_present(run_result)` to print `error.__doeff_traceback__.format_chained()` to `stderr` on error results (best-effort).
- Forward `print_doeff_trace` through `run_with_handler_map()` and `async_run_with_handler_map()`.
- Prevent CLI double-printing by passing `print_doeff_trace=False` in internal `vm_run()` call sites in `doeff/__main__.py` and `doeff/run.py::_execute_program`.
- Update CLI top-level error rendering in `doeff/__main__.py` to prefer `__doeff_traceback__.format_chained()` for both JSON and text output.
- Add new core stderr tests in `tests/core/test_doeff_trace_stderr.py` and append CLI tests in `tests/cli/test_cli_error_traces.py`.

## Issue
- Ref: ISSUE-CORE-509

## Acceptance Criteria Evidence
- [x] AC-1 `run()` has `print_doeff_trace: bool = True`.
  - `doeff/rust_vm.py:241`
- [x] AC-2 `async_run()` has `print_doeff_trace: bool = True`.
  - `doeff/rust_vm.py:269`
- [x] AC-3 `run_with_handler_map()` and `async_run_with_handler_map()` forward flag.
  - `doeff/rust_vm.py:199`, `doeff/rust_vm.py:220`
- [x] AC-4 T1 passes.
  - `tests/core/test_doeff_trace_stderr.py::test_run_prints_doeff_trace_to_stderr_on_error`
- [x] AC-5 T2 passes.
  - `tests/core/test_doeff_trace_stderr.py::test_run_suppresses_trace_when_flag_is_false`
- [x] AC-6 T3 passes.
  - `tests/core/test_doeff_trace_stderr.py::test_async_run_prints_doeff_trace_to_stderr_on_error`
- [x] AC-7 T4 passes.
  - `tests/core/test_doeff_trace_stderr.py::test_run_no_stderr_on_success`
- [x] AC-8 T5 passes.
  - `tests/core/test_doeff_trace_stderr.py::test_doeff_trace_includes_handler_chain`
- [x] AC-9 T6 passes.
  - `tests/cli/test_cli_error_traces.py::test_cli_json_uses_doeff_traceback`
- [x] AC-10 T7 passes.
  - `tests/cli/test_cli_error_traces.py::test_cli_text_uses_doeff_traceback`
- [x] AC-11 CLI internal `vm_run()` call sites now pass `print_doeff_trace=False`.
  - `doeff/__main__.py:33`, `doeff/__main__.py:135`, `doeff/__main__.py:490`
  - `doeff/run.py:456`
- [x] AC-12 command passed:
  - `uv run pytest tests/core/test_doeff_trace_stderr.py -v` -> `5 passed`
- [x] AC-13 command passed:
  - `uv run pytest tests/cli/test_cli_error_traces.py -v` -> `8 passed`
- [x] AC-14 command passed:
  - `uv run pytest tests/ -q` -> `547 passed`

## Validation Output
```bash
$ uv run pytest tests/core/test_doeff_trace_stderr.py -v
... 5 passed in 0.03s

$ uv run pytest tests/cli/test_cli_error_traces.py -v
... 8 passed in 2.29s

$ uv run pytest tests/ -q
... 547 passed in 22.23s
```
