### PR TITLE
Implement SPEC-TRACE-001 default traceback visualization

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -807,3 +807,17 @@ rules:
     metadata:
       category: public-api-location
       rationale: "Docs should reflect stable top-level public API"
+
+  - id: traceback-must-use-format-default
+    patterns:
+      - pattern: format_chained()
+      - pattern-inside: |
+          def _print_doeff_trace_if_present(...):
+              ...
+    message: >
+      SPEC-TRACE-001 violation: _print_doeff_trace_if_present must use
+      format_default() (not format_chained()) as the default stderr output.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      spec: SPEC-TRACE-001

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -71,7 +71,7 @@ def _print_doeff_trace_if_present(run_result: Any) -> None:
     try:
         import sys
 
-        print(doeff_tb.format_chained(), file=sys.stderr)
+        print(doeff_tb.format_default(), file=sys.stderr)
     except Exception:
         return
 

--- a/packages/doeff-vm/src/effect.rs
+++ b/packages/doeff-vm/src/effect.rs
@@ -132,6 +132,10 @@ impl PyGet {
         })
         .add_subclass(PyGet { key })
     }
+
+    fn __repr__(&self) -> String {
+        format!("Get({:?})", self.key)
+    }
 }
 
 #[pymethods]
@@ -142,6 +146,16 @@ impl PyPut {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyPut { key, value })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let value_repr = self
+            .value
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<value>".to_string());
+        format!("Put({:?}, {})", self.key, value_repr)
     }
 }
 
@@ -154,6 +168,16 @@ impl PyModify {
         })
         .add_subclass(PyModify { key, func })
     }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let modifier_repr = self
+            .func
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<modifier>".to_string());
+        format!("Modify({:?}, {})", self.key, modifier_repr)
+    }
 }
 
 #[pymethods]
@@ -164,6 +188,16 @@ impl PyAsk {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyAsk { key })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let key_repr = self
+            .key
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<key>".to_string());
+        format!("Ask({})", key_repr)
     }
 }
 
@@ -178,6 +212,22 @@ impl PyLocal {
             env_update,
             sub_program,
         })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let update_repr = self
+            .env_update
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<env_update>".to_string());
+        let sub_repr = self
+            .sub_program
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<program>".to_string());
+        format!("Local({}, {})", update_repr, sub_repr)
     }
 }
 
@@ -249,6 +299,31 @@ impl PySpawn {
             store_mode,
         )
     }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let program_repr = self
+            .program
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<program>".to_string());
+        let handlers_repr = self
+            .handlers
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "[]".to_string());
+        let store_mode_repr = self
+            .store_mode
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "None".to_string());
+        format!(
+            "Spawn(program={}, handlers={}, store_mode={})",
+            program_repr, handlers_repr, store_mode_repr
+        )
+    }
 }
 
 impl PyGather {
@@ -281,6 +356,16 @@ impl PyGather {
     ) -> PyClassInitializer<Self> {
         Self::create(py, items, _partial_results)
     }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let items_repr = self
+            .items
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<items>".to_string());
+        format!("Gather({})", items_repr)
+    }
 }
 
 #[pymethods]
@@ -294,6 +379,16 @@ impl PyRace {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyRace { futures })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let futures_repr = self
+            .futures
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<futures>".to_string());
+        format!("Race({})", futures_repr)
     }
 }
 
@@ -309,6 +404,10 @@ impl PyCreatePromise {
         })
         .add_subclass(PyCreatePromise)
     }
+
+    fn __repr__(&self) -> String {
+        "CreatePromise()".to_string()
+    }
 }
 
 #[pymethods]
@@ -322,6 +421,22 @@ impl PyCompletePromise {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyCompletePromise { promise, value })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let promise_repr = self
+            .promise
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<promise>".to_string());
+        let value_repr = self
+            .value
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<value>".to_string());
+        format!("CompletePromise({}, {})", promise_repr, value_repr)
     }
 }
 
@@ -337,6 +452,22 @@ impl PyFailPromise {
         })
         .add_subclass(PyFailPromise { promise, error })
     }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let promise_repr = self
+            .promise
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<promise>".to_string());
+        let error_repr = self
+            .error
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<error>".to_string());
+        format!("FailPromise({}, {})", promise_repr, error_repr)
+    }
 }
 
 #[pymethods]
@@ -351,6 +482,10 @@ impl PyCreateExternalPromise {
         })
         .add_subclass(PyCreateExternalPromise)
     }
+
+    fn __repr__(&self) -> String {
+        "CreateExternalPromise()".to_string()
+    }
 }
 
 #[pymethods]
@@ -364,6 +499,16 @@ impl PyCancelEffect {
             tag: DoExprTag::Effect as u8,
         })
         .add_subclass(PyCancelEffect { task })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let task_repr = self
+            .task
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "<task>".to_string());
+        format!("CancelTask({})", task_repr)
     }
 }
 
@@ -390,6 +535,22 @@ impl PyTaskCompleted {
             handle_id: handle_id.unwrap_or_else(|| py.None()),
             result: result.unwrap_or_else(|| py.None()),
         })
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let task_repr = self
+            .task
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "None".to_string());
+        let result_repr = self
+            .result
+            .bind(py)
+            .repr()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|_| "None".to_string());
+        format!("TaskCompleted(task={}, result={})", task_repr, result_repr)
     }
 }
 

--- a/tests/core/test_doeff_trace_stderr.py
+++ b/tests/core/test_doeff_trace_stderr.py
@@ -83,6 +83,5 @@ def test_doeff_trace_includes_handler_chain(capsys: pytest.CaptureFixture[str]) 
     assert result.is_err()
 
     captured = capsys.readouterr()
-    assert "[handler]" in captured.err
     assert "exploding_handler" in captured.err
     assert "Boom" in captured.err

--- a/tests/core/test_traceback_format_default.py
+++ b/tests/core/test_traceback_format_default.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import Protocol, cast
+
+from doeff import Ask, Program, Put, default_handlers, do, run
+from doeff.trace import HandlerStackEntry, TraceDispatch
+from doeff.traceback import build_doeff_traceback
+
+
+class _ErrResult(Protocol):
+    error: object
+
+    def is_err(self) -> bool: ...
+
+
+def _assert_err(result: object) -> BaseException:
+    err_result = cast(_ErrResult, result)
+    assert err_result.is_err()
+    error = err_result.error
+    assert isinstance(error, BaseException)
+    return error
+
+
+def test_format_default_effect_repr_human_readable() -> None:
+    @do
+    def body() -> Program[int]:
+        yield Put("counter", 1)
+        raise RuntimeError("boom")
+        yield
+
+    result = run(body(), handlers=default_handlers(), store={"counter": 0}, print_doeff_trace=False)
+    error = _assert_err(result)
+    rendered = error.__doeff_traceback__.format_default()
+    assert "Put(" in rendered
+    assert "counter" in rendered
+    assert "object at 0x" not in rendered
+
+
+def test_format_default_hides_internal_handlers() -> None:
+    @do
+    def body() -> Program[int]:
+        _ = yield Ask("missing_key")
+        return 1
+
+    result = run(body(), handlers=default_handlers(), print_doeff_trace=False)
+    error = _assert_err(result)
+    rendered = error.__doeff_traceback__.format_default()
+    assert "sync_await_handler↗" not in rendered
+    assert "async_await_handler↗" not in rendered
+
+
+def test_format_default_resume_value_truncated_80() -> None:
+    long_value = "x" * 200
+    dispatch = TraceDispatch(
+        dispatch_id=101,
+        effect_repr='Put("key", 1)',
+        handler_name="StateHandlerFactory",
+        handler_kind="rust_builtin",
+        handler_source_file=None,
+        handler_source_line=None,
+        delegation_chain=(),
+        handler_stack=(HandlerStackEntry("StateHandlerFactory", "resumed"),),
+        action="resumed",
+        value_repr=long_value,
+        exception_repr=None,
+    )
+    ex = RuntimeError("boom")
+    rendered = build_doeff_traceback(ex, [dispatch], allow_active=True).format_default()
+    resumed_line = next(line for line in rendered.splitlines() if "→ resumed with" in line)
+    resumed_value = resumed_line.split("→ resumed with ", 1)[1]
+    assert len(resumed_value) <= 83
+    assert resumed_value.endswith("...")
+
+
+def test_format_default_spawn_separator_from_payload() -> None:
+    root_dispatch = TraceDispatch(
+        dispatch_id=1,
+        effect_repr='Gather(["t0"])',
+        handler_name="SchedulerHandler",
+        handler_kind="rust_builtin",
+        handler_source_file=None,
+        handler_source_line=None,
+        delegation_chain=(),
+        handler_stack=(HandlerStackEntry("SchedulerHandler", "threw"),),
+        action="threw",
+        value_repr=None,
+        exception_repr='RuntimeError("boom")',
+    )
+    child_dispatch = TraceDispatch(
+        dispatch_id=2,
+        effect_repr='Put("x", 1)',
+        handler_name="StateHandlerFactory",
+        handler_kind="rust_builtin",
+        handler_source_file=None,
+        handler_source_line=None,
+        delegation_chain=(),
+        handler_stack=(HandlerStackEntry("StateHandlerFactory", "threw"),),
+        action="threw",
+        value_repr=None,
+        exception_repr='RuntimeError("boom")',
+    )
+    payload = {
+        "trace": [root_dispatch],
+        "spawned_from": {
+            "trace": [child_dispatch],
+            "task_id": 9,
+            "parent_task": 0,
+            "spawn_site": {
+                "function_name": "parent",
+                "file": "tests/sample.py",
+                "line": 42,
+            },
+        },
+    }
+    ex = RuntimeError("boom")
+    doeff_tb = build_doeff_traceback(ex, payload, allow_active=True)
+    rendered = doeff_tb.format_default()
+    assert "── in task 9 (spawned at parent tests/sample.py:42) ──" in rendered
+
+
+def test_existing_formats_unchanged() -> None:
+    @do
+    def body() -> Program[int]:
+        _ = yield Ask("missing_key")
+        return 1
+
+    result = run(body(), handlers=default_handlers(), print_doeff_trace=False)
+    error = _assert_err(result)
+    doeff_tb = error.__doeff_traceback__
+    chained = doeff_tb.format_chained()
+    sectioned = doeff_tb.format_sectioned()
+    short = doeff_tb.format_short()
+    assert "doeff Traceback (most recent call last):" in chained
+    assert "Program Stack:" in sectioned
+    assert "RuntimeError" in short or "KeyError" in short or "TypeError" in short


### PR DESCRIPTION
## Summary

Implements SPEC-TRACE-001 default traceback rendering for ISSUE-CORE-512.

### What changed
- Extended Rust capture model with full handler stack snapshots and per-handler status tracking.
- Propagated handler-stack/status data into Python trace objects.
- Added `format_default()` traceback renderer with handler markers, `[same]` collapsing, result-line rendering, and spawn-chain separators.
- Switched default stderr traceback printing to `format_default()`.
- Added spawn metadata (`parent_task`, `spawn_site`) attachment for task-failure payloads.
- Added readable `__repr__` implementations for effect classes used in traces.
- Added semgrep regression rule enforcing default formatting call site.
- Added/updated traceback tests.

## Acceptance Criteria Evidence

### Core format
1. Default stderr traceback uses `format_default()`:
   - `doeff/rust_vm.py:74`
   - semgrep rule: `.semgrep.yaml` (`traceback-must-use-format-default`)
2. Active-call-chain-focused formatting with per-effect rows and terminal exception line:
   - `doeff/traceback.py:506` (`format_default`)
3. Yield-site line usage for resumed frames:
   - `packages/doeff-vm/src/vm.rs` (`generator_current_line` + resume location)
4. Handler stack markers + internal delegate-only filtering:
   - `doeff/traceback.py` `_STATUS_MARKERS`, `_render_stack`
   - `doeff/traceback.py` `_INTERNAL_DELEGATE_ONLY_HANDLERS`
5. `[same]` stack collapsing:
   - `doeff/traceback.py:_render_stack`
6. Human-readable effect reprs:
   - `packages/doeff-vm/src/effect.rs` (`__repr__` additions)
7. Existing alternate formats preserved:
   - `tests/core/test_traceback_format_default.py::test_existing_formats_unchanged`

### Transfer and spawn-chain plumbing
8. Handler status includes transferred state and transfer result line:
   - `packages/doeff-vm/src/capture.rs` (`HandlerStatus::Transferred`)
   - `doeff/traceback.py:_result_line`
9. Spawn metadata and nested payload chain:
   - `packages/doeff-vm/src/scheduler.rs` (`TaskMetadata`, `SpawnSite`, `annotate_failed_task`)
   - `packages/doeff-vm/src/vm.rs` + `packages/doeff-vm/src/pyvm.rs` (`spawned_from` payload merge)
10. Spawn separator rendering:
   - `doeff/traceback.py:_task_separator`
   - `tests/core/test_traceback_format_default.py::test_format_default_spawn_separator_from_payload`

## Verification

### Passed
- `cargo test` (run in `packages/doeff-vm`)
  - Result: `155 passed, 0 failed`
- `uv run pytest tests/ -x`
  - Result: `574 passed, 0 failed`
- `uv run pytest tests/core/test_traceback_format_default.py -q`
  - Result: `5 passed`
- `uv run ruff check doeff/trace.py tests/core/test_traceback_format_default.py`
  - Result: `All checks passed`

### Known pre-existing lint debt (not introduced in this PR)
- `make lint`
  - Fails at `ruff` due many existing repository-wide violations.
- `make lint-semgrep`
  - Runs successfully but reports existing blocking findings across the repo (`81 findings`).

Issue reference: ISSUE-CORE-512
