### PR TITLE
VM-PROTO-007: final semgrep audit and VM enforcement

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -925,7 +925,7 @@ rules:
       gap: G08
 
   # ---------------------------------------------------------------------------
-  # VM PROTOCOL: TRACEBACK DUNDER + IMPORT BANS (VM-PROTO-004)
+  # VM PROTOCOL: FINAL C1/C6 ENFORCEMENT (VM-PROTO-007)
   # ---------------------------------------------------------------------------
 
   - id: vm-no-dunder-attrs
@@ -934,18 +934,16 @@ rules:
       - metavariable-regex:
           metavariable: $ATTR
           regex: '^"__doeff_[A-Za-z0-9_]+__"$'
+    message: "VM must not set __doeff_* attributes. Use typed PyClass fields."
+    languages: [rust]
+    severity: ERROR
     paths:
       include:
         - "**/packages/doeff-vm/src/vm.rs"
         - "**/packages/doeff-vm/src/pyvm.rs"
-    message: |
-      VM protocol violation: writing __doeff_*__ attributes is forbidden.
-      Use typed data delivery via RunResult fields instead of exception dunders.
-    languages: [rust]
-    severity: ERROR
     metadata:
       category: vm-protocol
-      issue: VM-PROTO-004
+      issue: VM-PROTO-007
 
   - id: vm-no-dunder-reads
     patterns:
@@ -953,20 +951,16 @@ rules:
       - metavariable-regex:
           metavariable: $ATTR
           regex: '^"__doeff_[A-Za-z0-9_]+__"$'
-      - pattern-not: $OBJ.getattr("__doeff_inner__")
-      - pattern-not: $OBJ.getattr("__doeff_spawned_from__")
+    message: "VM must not read __doeff_* attributes. Use typed PyClass fields."
+    languages: [rust]
+    severity: ERROR
     paths:
       include:
         - "**/packages/doeff-vm/src/vm.rs"
         - "**/packages/doeff-vm/src/pyvm.rs"
-    message: |
-      VM protocol violation: reading __doeff_*__ attributes is forbidden.
-      Read traceback data from RunResult.traceback_data instead.
-    languages: [rust]
-    severity: ERROR
     metadata:
       category: vm-protocol
-      issue: VM-PROTO-004
+      issue: VM-PROTO-007
 
   - id: vm-no-hasattr-dunder
     patterns:
@@ -974,38 +968,29 @@ rules:
       - metavariable-regex:
           metavariable: $ATTR
           regex: '^"__doeff_[A-Za-z0-9_]+__"$'
+    message: "VM must not probe __doeff_* attributes. Use isinstance on typed PyClass."
+    languages: [rust]
+    severity: ERROR
     paths:
       include:
         - "**/packages/doeff-vm/src/vm.rs"
         - "**/packages/doeff-vm/src/pyvm.rs"
-    message: |
-      VM protocol violation: checking __doeff_*__ attributes is forbidden.
-      Use explicit typed RunResult fields to signal traceback availability.
-    languages: [rust]
-    severity: ERROR
     metadata:
       category: vm-protocol
-      issue: VM-PROTO-004
+      issue: VM-PROTO-007
 
-  - id: vm-no-uv-run-python-imports
-    patterns:
-      - pattern: $PY.import($MODULE)
-      - metavariable-regex:
-          metavariable: $MODULE
-          regex: '^"doeff\\.[A-Za-z0-9_\\.]+"$'
-      - pattern-not: $PY.import("doeff.do")
+  - id: vm-no-python-imports
+    pattern-regex: '\.import\("doeff\.[A-Za-z0-9_\.]+"\)'
+    message: "VM core must not import doeff.* modules. Use typed PyClass or NeedsPython callback."
+    languages: [rust]
+    severity: ERROR
     paths:
       include:
         - "**/packages/doeff-vm/src/vm.rs"
         - "**/packages/doeff-vm/src/pyvm.rs"
-    message: |
-      VM protocol violation: VM core must not import doeff.* modules.
-      Traceback projection belongs in Python consumers, not VM core.
-    languages: [rust]
-    severity: ERROR
     metadata:
       category: vm-protocol
-      issue: VM-PROTO-004
+      issue: VM-PROTO-007
 
   # ---------------------------------------------------------------------------
   # PUBLIC API LOCATION GUARDS


### PR DESCRIPTION
## Summary
- Consolidated VM protocol semgrep enforcement into the final VM-PROTO-007 rule set in `.semgrep.yaml`.
- Added/normalized these four scoped rules for `packages/doeff-vm/src/vm.rs` and `packages/doeff-vm/src/pyvm.rs`:
  - `vm-no-dunder-attrs`
  - `vm-no-dunder-reads`
  - `vm-no-hasattr-dunder`
  - `vm-no-python-imports`
- Added a final runtime audit test in `packages/doeff-vm/src/vm.rs` (`test_vm_proto_007_runtime_enforces_c1_c6_c7_constraints`) to enforce C1/C6/C7 constraints against runtime (non-test) source sections.
- Replaced legacy `__doeff_spawned_from__` traceback plumbing with typed Rust-side exception boundary tracking in `packages/doeff-vm/src/scheduler.rs` and consumption in `packages/doeff-vm/src/vm.rs`, preserving spawn-boundary traceback rendering without VM dunder reads.

## Issue
- VM-PROTO-007

## Acceptance Criteria Evidence
1. All 4 semgrep rules added to project config
   - `.semgrep.yaml` now contains all four IDs above under the VM-PROTO-007 section.

2. `make lint-semgrep` passes with zero violations in `vm.rs` and `pyvm.rs`
   - Targeted semgrep verification for those files and ERROR rules:
   - `semgrep scan --config .semgrep.yaml --severity ERROR packages/doeff-vm/src/vm.rs packages/doeff-vm/src/pyvm.rs --error`
   - Result: `0 findings`.

3. Rules catch synthetic violations
   - Created temporary synthetic `packages/doeff-vm/src/vm.rs` fixture containing one violation per rule and scanned with `.semgrep.yaml`.
   - Result IDs:
     - `vm-no-dunder-attrs`
     - `vm-no-dunder-reads`
     - `vm-no-hasattr-dunder`
     - `vm-no-python-imports`
   - Result count: `4`.

4. Rules scoped to `packages/doeff-vm/src/vm.rs` and `packages/doeff-vm/src/pyvm.rs` only
   - Verified in `.semgrep.yaml` paths includes for all four rules.

5. `make lint` passes (all linters including semgrep)
   - `make lint` currently fails on pre-existing repository-wide Ruff/Semgrep findings unrelated to this issue scope.
   - This branch does not introduce new lint failures in the audited VM rule scope; targeted VM semgrep checks pass as noted above.

## Additional Validation Run
- `cargo test` (in `packages/doeff-vm`): passed (`169 passed`)
- `uv run --reinstall-package doeff-vm pytest`: passed (`622 passed`)
- `make lint-semgrep`: fails due pre-existing repository-wide findings/timeouts; VM-targeted semgrep check passes.
