### PR TITLE
Rev 3 Phase A: add VM foundation types

### DIFF
--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -177,6 +177,7 @@ ResultOk = Ok
 ResultErr = Err
 K = _ext.K
 DoeffGenerator = _ext.DoeffGenerator
+DoeffGeneratorFn = _ext.DoeffGeneratorFn
 
 
 WithHandler = _ext.WithHandler
@@ -184,6 +185,8 @@ WithHandler = _ext.WithHandler
 
 Pure = _ext.Pure
 Call = _ext.Call
+Apply = _ext.Apply
+Expand = _ext.Expand
 Map = _ext.Map
 FlatMap = _ext.FlatMap
 Eval = _ext.Eval
@@ -255,6 +258,8 @@ TAG_GET_HANDLERS = _ext.TAG_GET_HANDLERS
 TAG_GET_CALL_STACK = _ext.TAG_GET_CALL_STACK
 TAG_GET_TRACE = _ext.TAG_GET_TRACE
 TAG_EVAL = _ext.TAG_EVAL
+TAG_APPLY = _ext.TAG_APPLY
+TAG_EXPAND = _ext.TAG_EXPAND
 TAG_CREATE_CONTINUATION = _ext.TAG_CREATE_CONTINUATION
 TAG_RESUME_CONTINUATION = _ext.TAG_RESUME_CONTINUATION
 TAG_ASYNC_ESCAPE = _ext.TAG_ASYNC_ESCAPE
@@ -276,6 +281,8 @@ __all__ = [
     "K",
     "Delegate",
     "Call",
+    "Apply",
+    "Expand",
     "Eval",
     "Perform",
     "Map",
@@ -283,6 +290,7 @@ __all__ = [
     "DoCtrlBase",
     "DoExpr",
     "DoeffGenerator",
+    "DoeffGeneratorFn",
     "DoThunkBase",
     "EffectBase",
     "PyAsk",
@@ -357,6 +365,8 @@ __all__ = [
     "TAG_GET_CALL_STACK",
     "TAG_GET_TRACE",
     "TAG_EVAL",
+    "TAG_APPLY",
+    "TAG_EXPAND",
     "TAG_CREATE_CONTINUATION",
     "TAG_RESUME_CONTINUATION",
     "TAG_ASYNC_ESCAPE",

--- a/packages/doeff-vm/src/ast_stream.rs
+++ b/packages/doeff-vm/src/ast_stream.rs
@@ -1,0 +1,218 @@
+//! Stream abstraction for stepping AST/program sources.
+
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use pyo3::prelude::*;
+
+use crate::do_ctrl::DoCtrl;
+use crate::driver::PyException;
+use crate::python_call::PythonCall;
+use crate::value::Value;
+use crate::vm::RustStore;
+
+pub trait ASTStream: fmt::Debug + Send {
+    fn resume(&mut self, value: Value, store: &mut RustStore) -> ASTStreamStep;
+    fn throw(&mut self, exc: PyException, store: &mut RustStore) -> ASTStreamStep;
+    fn debug_location(&self) -> Option<StreamLocation> {
+        None
+    }
+}
+
+pub type ASTStreamRef = Arc<Mutex<Box<dyn ASTStream>>>;
+
+#[derive(Debug)]
+pub enum ASTStreamStep {
+    Yield(DoCtrl),
+    Return(Value),
+    Throw(PyException),
+    NeedsPython(PythonCall),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamLocation {
+    pub function_name: String,
+    pub source_file: String,
+    pub source_line: u32,
+    pub phase: Option<String>,
+}
+
+pub struct PythonGeneratorStream {
+    generator: Py<PyAny>,
+    get_frame: Py<PyAny>,
+    started: bool,
+}
+
+impl fmt::Debug for PythonGeneratorStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PythonGeneratorStream")
+            .field("started", &self.started)
+            .finish()
+    }
+}
+
+impl PythonGeneratorStream {
+    pub fn new(generator: Py<PyAny>, get_frame: Py<PyAny>) -> Self {
+        PythonGeneratorStream {
+            generator,
+            get_frame,
+            started: false,
+        }
+    }
+
+    fn resolve_location(&self, py: Python<'_>) -> Option<StreamLocation> {
+        let frame = self
+            .get_frame
+            .bind(py)
+            .call1((self.generator.bind(py),))
+            .ok()?;
+        if frame.is_none() {
+            return None;
+        }
+
+        let code = frame.getattr("f_code").ok()?;
+        let function_name = code.getattr("co_name").ok()?.extract::<String>().ok()?;
+        let source_file = code.getattr("co_filename").ok()?.extract::<String>().ok()?;
+        let source_line = frame.getattr("f_lineno").ok()?.extract::<u32>().ok()?;
+
+        Some(StreamLocation {
+            function_name,
+            source_file,
+            source_line,
+            phase: None,
+        })
+    }
+}
+
+impl ASTStream for PythonGeneratorStream {
+    fn resume(&mut self, value: Value, _store: &mut RustStore) -> ASTStreamStep {
+        if self.started {
+            ASTStreamStep::NeedsPython(PythonCall::GenSend { value })
+        } else {
+            self.started = true;
+            ASTStreamStep::NeedsPython(PythonCall::GenNext)
+        }
+    }
+
+    fn throw(&mut self, exc: PyException, _store: &mut RustStore) -> ASTStreamStep {
+        self.started = true;
+        ASTStreamStep::NeedsPython(PythonCall::GenThrow { exc })
+    }
+
+    fn debug_location(&self) -> Option<StreamLocation> {
+        Python::attach(|py| self.resolve_location(py))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::types::PyDict;
+
+    use super::*;
+
+    #[test]
+    fn test_python_generator_stream_resume_sequence() {
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                c"def _gen():\n    yield 1\n\ngen = _gen()\n\ndef _get_frame(g):\n    return g.gi_frame\n",
+                Some(&locals),
+                Some(&locals),
+            )
+            .expect("failed to define generator test fixtures");
+
+            let generator = locals
+                .get_item("gen")
+                .expect("locals.get_item failed")
+                .expect("gen missing")
+                .unbind();
+            let get_frame = locals
+                .get_item("_get_frame")
+                .expect("locals.get_item failed")
+                .expect("_get_frame missing")
+                .unbind();
+
+            let mut stream = PythonGeneratorStream::new(generator, get_frame);
+            let mut store = RustStore::new();
+
+            let step1 = stream.resume(Value::Unit, &mut store);
+            assert!(matches!(
+                step1,
+                ASTStreamStep::NeedsPython(PythonCall::GenNext)
+            ));
+
+            let step2 = stream.resume(Value::Int(7), &mut store);
+            assert!(matches!(
+                step2,
+                ASTStreamStep::NeedsPython(PythonCall::GenSend {
+                    value: Value::Int(7)
+                })
+            ));
+        });
+    }
+
+    #[test]
+    fn test_python_generator_stream_throw_uses_gen_throw() {
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                c"def _gen():\n    yield 1\n\ngen = _gen()\n\ndef _get_frame(g):\n    return g.gi_frame\n",
+                Some(&locals),
+                Some(&locals),
+            )
+            .expect("failed to define generator test fixtures");
+
+            let generator = locals
+                .get_item("gen")
+                .expect("locals.get_item failed")
+                .expect("gen missing")
+                .unbind();
+            let get_frame = locals
+                .get_item("_get_frame")
+                .expect("locals.get_item failed")
+                .expect("_get_frame missing")
+                .unbind();
+
+            let mut stream = PythonGeneratorStream::new(generator, get_frame);
+            let mut store = RustStore::new();
+            let step = stream.throw(PyException::runtime_error("boom"), &mut store);
+            assert!(matches!(
+                step,
+                ASTStreamStep::NeedsPython(PythonCall::GenThrow { .. })
+            ));
+        });
+    }
+
+    #[test]
+    fn test_python_generator_stream_debug_location_uses_get_frame_callback() {
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                c"def _gen():\n    yield 1\n\ngen = _gen()\nnext(gen)\n\ndef _get_frame(g):\n    return g.gi_frame\n",
+                Some(&locals),
+                Some(&locals),
+            )
+            .expect("failed to define generator test fixtures");
+
+            let generator = locals
+                .get_item("gen")
+                .expect("locals.get_item failed")
+                .expect("gen missing")
+                .unbind();
+            let get_frame = locals
+                .get_item("_get_frame")
+                .expect("locals.get_item failed")
+                .expect("_get_frame missing")
+                .unbind();
+            let stream = PythonGeneratorStream::new(generator, get_frame);
+
+            let location = stream
+                .debug_location()
+                .expect("expected location from get_frame callback");
+            assert_eq!(location.function_name, "_gen");
+            assert!(!location.source_file.is_empty());
+            assert!(location.source_line > 0);
+            assert_eq!(location.phase, None);
+        });
+    }
+}

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -74,6 +74,18 @@ pub enum DoCtrl {
         kwargs: Vec<(String, CallArg)>,
         metadata: CallMetadata,
     },
+    Apply {
+        f: CallArg,
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+    },
+    Expand {
+        factory: CallArg,
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+    },
     Eval {
         expr: PyShared,
         handlers: Vec<Handler>,
@@ -171,6 +183,28 @@ impl DoCtrl {
                 metadata,
             } => DoCtrl::Call {
                 f: f.clone(),
+                args: args.clone(),
+                kwargs: kwargs.clone(),
+                metadata: metadata.clone(),
+            },
+            DoCtrl::Apply {
+                f,
+                args,
+                kwargs,
+                metadata,
+            } => DoCtrl::Apply {
+                f: f.clone(),
+                args: args.clone(),
+                kwargs: kwargs.clone(),
+                metadata: metadata.clone(),
+            },
+            DoCtrl::Expand {
+                factory,
+                args,
+                kwargs,
+                metadata,
+            } => DoCtrl::Expand {
+                factory: factory.clone(),
                 args: args.clone(),
                 kwargs: kwargs.clone(),
                 metadata: metadata.clone(),

--- a/packages/doeff-vm/src/doeff_generator.rs
+++ b/packages/doeff-vm/src/doeff_generator.rs
@@ -1,5 +1,70 @@
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
+
+/// Typed generator factory carrying metadata and frame resolver callback.
+#[pyclass(frozen, name = "DoeffGeneratorFn")]
+#[derive(Debug, Clone)]
+pub struct DoeffGeneratorFn {
+    #[pyo3(get)]
+    pub callable: Py<PyAny>,
+    #[pyo3(get)]
+    pub function_name: String,
+    #[pyo3(get)]
+    pub source_file: String,
+    #[pyo3(get)]
+    pub source_line: u32,
+    #[pyo3(get)]
+    pub get_frame: Py<PyAny>,
+}
+
+#[pymethods]
+impl DoeffGeneratorFn {
+    #[new]
+    #[pyo3(signature = (callable, function_name, source_file, source_line, get_frame))]
+    fn new(
+        py: Python<'_>,
+        callable: Py<PyAny>,
+        function_name: String,
+        source_file: String,
+        source_line: u32,
+        get_frame: Py<PyAny>,
+    ) -> PyResult<Self> {
+        if !callable.bind(py).is_callable() {
+            return Err(PyTypeError::new_err(
+                "DoeffGeneratorFn.callable must be callable",
+            ));
+        }
+        if !get_frame.bind(py).is_callable() {
+            return Err(PyTypeError::new_err(
+                "DoeffGeneratorFn.get_frame must be callable",
+            ));
+        }
+        Ok(Self {
+            callable,
+            function_name,
+            source_file,
+            source_line,
+            get_frame,
+        })
+    }
+
+    #[pyo3(signature = (*args, **kwargs))]
+    fn __call__(
+        slf: PyRef<'_, Self>,
+        py: Python<'_>,
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<DoeffGenerator> {
+        let callable = slf.callable.clone_ref(py);
+        let produced = match kwargs {
+            Some(kwargs) => callable.bind(py).call(args, Some(kwargs))?,
+            None => callable.bind(py).call1(args)?,
+        };
+        let factory_ref: Py<DoeffGeneratorFn> = slf.into();
+        DoeffGenerator::from_factory(py, produced.unbind(), factory_ref)
+    }
+}
 
 /// VM protocol wrapper that carries generator metadata and frame resolver callback.
 #[pyclass(frozen, name = "DoeffGenerator")]
@@ -15,20 +80,49 @@ pub struct DoeffGenerator {
     pub source_line: u32,
     #[pyo3(get)]
     pub get_frame: Py<PyAny>,
+    #[pyo3(get)]
+    pub factory: Option<Py<DoeffGeneratorFn>>,
 }
 
 #[pymethods]
 impl DoeffGenerator {
     #[new]
-    #[pyo3(signature = (generator, function_name, source_file, source_line, get_frame))]
+    #[pyo3(signature = (generator, function_name=None, source_file=None, source_line=None, get_frame=None, factory=None))]
     fn new(
         py: Python<'_>,
         generator: Py<PyAny>,
-        function_name: String,
-        source_file: String,
-        source_line: u32,
-        get_frame: Py<PyAny>,
+        function_name: Option<String>,
+        source_file: Option<String>,
+        source_line: Option<u32>,
+        get_frame: Option<Py<PyAny>>,
+        factory: Option<Py<DoeffGeneratorFn>>,
     ) -> PyResult<Self> {
+        let (default_function_name, default_source_file, default_source_line, default_get_frame) =
+            if let Some(factory_ref) = &factory {
+                let factory_borrow = factory_ref.bind(py).borrow();
+                (
+                    Some(factory_borrow.function_name.clone()),
+                    Some(factory_borrow.source_file.clone()),
+                    Some(factory_borrow.source_line),
+                    Some(factory_borrow.get_frame.clone_ref(py)),
+                )
+            } else {
+                (None, None, None, None)
+            };
+
+        let function_name = function_name.or(default_function_name).ok_or_else(|| {
+            PyTypeError::new_err("DoeffGenerator.function_name is required when factory is absent")
+        })?;
+        let source_file = source_file.or(default_source_file).ok_or_else(|| {
+            PyTypeError::new_err("DoeffGenerator.source_file is required when factory is absent")
+        })?;
+        let source_line = source_line.or(default_source_line).ok_or_else(|| {
+            PyTypeError::new_err("DoeffGenerator.source_line is required when factory is absent")
+        })?;
+        let get_frame = get_frame.or(default_get_frame).ok_or_else(|| {
+            PyTypeError::new_err("DoeffGenerator.get_frame is required when factory is absent")
+        })?;
+
         if !get_frame.bind(py).is_callable() {
             return Err(PyTypeError::new_err(
                 "DoeffGenerator.get_frame must be callable",
@@ -40,6 +134,7 @@ impl DoeffGenerator {
             source_file,
             source_line,
             get_frame,
+            factory,
         })
     }
 
@@ -53,5 +148,89 @@ impl DoeffGenerator {
     #[getter]
     fn __doeff_inner__(&self, py: Python<'_>) -> Py<PyAny> {
         self.generator.clone_ref(py)
+    }
+}
+
+impl DoeffGenerator {
+    pub fn from_factory(
+        py: Python<'_>,
+        generator: Py<PyAny>,
+        factory: Py<DoeffGeneratorFn>,
+    ) -> PyResult<Self> {
+        let factory_borrow = factory.bind(py).borrow();
+        let get_frame = factory_borrow.get_frame.clone_ref(py);
+        if !get_frame.bind(py).is_callable() {
+            return Err(PyTypeError::new_err(
+                "DoeffGeneratorFn.get_frame must be callable",
+            ));
+        }
+        Ok(Self {
+            generator,
+            function_name: factory_borrow.function_name.clone(),
+            source_file: factory_borrow.source_file.clone(),
+            source_line: factory_borrow.source_line,
+            get_frame,
+            factory: Some(factory.clone_ref(py)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::types::PyDict;
+
+    use super::*;
+
+    #[test]
+    fn test_doeff_generator_fn_call_wraps_result_with_factory_back_pointer() {
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                c"def build_gen():\n    yield 1\n\ndef get_frame(g):\n    return g.gi_frame\n",
+                Some(&locals),
+                Some(&locals),
+            )
+            .expect("failed to define generator factory fixtures");
+
+            let callable = locals
+                .get_item("build_gen")
+                .expect("locals.get_item failed")
+                .expect("build_gen missing")
+                .unbind();
+            let get_frame = locals
+                .get_item("get_frame")
+                .expect("locals.get_item failed")
+                .expect("get_frame missing")
+                .unbind();
+
+            let factory = Bound::new(
+                py,
+                DoeffGeneratorFn::new(
+                    py,
+                    callable,
+                    "build_gen".to_string(),
+                    "/tmp/sample.py".to_string(),
+                    12,
+                    get_frame,
+                )
+                .expect("failed to build DoeffGeneratorFn"),
+            )
+            .expect("failed to bind factory");
+
+            let wrapped: PyRef<'_, DoeffGenerator> = factory
+                .call0()
+                .expect("factory call failed")
+                .extract()
+                .expect("expected DoeffGenerator result");
+
+            assert_eq!(wrapped.function_name, "build_gen");
+            assert_eq!(wrapped.source_file, "/tmp/sample.py");
+            assert_eq!(wrapped.source_line, 12);
+            let factory_back = wrapped
+                .factory
+                .as_ref()
+                .expect("missing factory back-pointer");
+            assert_eq!(factory_back.bind(py).as_ptr(), factory.as_any().as_ptr());
+        });
     }
 }

--- a/packages/doeff-vm/src/handler.rs
+++ b/packages/doeff-vm/src/handler.rs
@@ -86,6 +86,24 @@ pub trait RustProgramHandler: std::fmt::Debug + Send + Sync {
     fn on_run_end(&self, _run_token: u64) {}
 }
 
+pub type DoExpr = DoCtrl;
+
+#[derive(Debug, Clone)]
+pub struct HandlerDebugInfo {
+    pub name: String,
+    pub file: Option<String>,
+    pub line: Option<u32>,
+}
+
+pub trait HandlerInvoke: std::fmt::Debug + Send + Sync {
+    fn can_handle(&self, effect: &DispatchEffect) -> bool;
+    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr;
+    fn handler_name(&self) -> &str;
+    fn handler_debug_info(&self) -> HandlerDebugInfo;
+}
+
+pub type HandlerRef = Arc<dyn HandlerInvoke>;
+
 /// Shared reference to a Rust program handler factory.
 pub type RustProgramHandlerRef = Arc<dyn RustProgramHandler + Send + Sync>;
 

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -10,6 +10,7 @@
 //! - **All effects dispatch**: No bypass for stdlib effects
 
 pub mod arena;
+pub mod ast_stream;
 pub mod capture;
 pub mod continuation;
 pub mod dispatch;
@@ -34,6 +35,9 @@ mod vm;
 
 // Re-exports for convenience
 pub use arena::SegmentArena;
+pub use ast_stream::{
+    ASTStream, ASTStreamRef, ASTStreamStep, PythonGeneratorStream, StreamLocation,
+};
 pub use capture::{
     ActiveChainEntry, CaptureEvent, DelegationEntry, DispatchAction, EffectResult, FrameId,
     HandlerAction, HandlerDispatchEntry, HandlerKind, HandlerSnapshotEntry, HandlerStatus,
@@ -42,14 +46,14 @@ pub use capture::{
 pub use continuation::Continuation;
 pub use dispatch::DispatchContext;
 pub use do_ctrl::DoCtrl;
-pub use doeff_generator::DoeffGenerator;
+pub use doeff_generator::{DoeffGenerator, DoeffGeneratorFn};
 pub use driver::{Mode, StepEvent};
 pub use effect::{Effect, PyAsk, PyCancelEffect, PyGet, PyLocal, PyModify, PyPut, PyTell};
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{
-    Handler, HandlerEntry, LazyAskHandlerFactory, ReaderHandlerFactory, StateHandlerFactory,
-    WriterHandlerFactory,
+    Handler, HandlerDebugInfo, HandlerEntry, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
+    ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
 };
 pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
 pub use py_key::HashedPyKey;

--- a/packages/doeff-vm/src/vm.rs
+++ b/packages/doeff-vm/src/vm.rs
@@ -1687,6 +1687,8 @@ impl VM {
                 DoCtrl::ResumeContinuation { .. } => "HandleYield(ResumeContinuation)",
                 DoCtrl::PythonAsyncSyntaxEscape { .. } => "HandleYield(AsyncEscape)",
                 DoCtrl::Call { .. } => "HandleYield(Call)",
+                DoCtrl::Apply { .. } => "HandleYield(Apply)",
+                DoCtrl::Expand { .. } => "HandleYield(Expand)",
                 DoCtrl::Eval { .. } => "HandleYield(Eval)",
                 DoCtrl::GetCallStack => "HandleYield(GetCallStack)",
                 DoCtrl::GetTrace => "HandleYield(GetTrace)",
@@ -1775,6 +1777,8 @@ impl VM {
                 DoCtrl::ResumeContinuation { .. } => "HandleYield(ResumeContinuation)",
                 DoCtrl::PythonAsyncSyntaxEscape { .. } => "HandleYield(AsyncEscape)",
                 DoCtrl::Call { .. } => "HandleYield(Call)",
+                DoCtrl::Apply { .. } => "HandleYield(Apply)",
+                DoCtrl::Expand { .. } => "HandleYield(Expand)",
                 DoCtrl::Eval { .. } => "HandleYield(Eval)",
                 DoCtrl::GetCallStack => "HandleYield(GetCallStack)",
                 DoCtrl::GetTrace => "HandleYield(GetTrace)",
@@ -2208,6 +2212,34 @@ impl VM {
                     args: value_args,
                     kwargs: value_kwargs,
                 })
+            }
+            DoCtrl::Apply {
+                f,
+                args,
+                kwargs,
+                metadata,
+            } => {
+                self.mode = Mode::HandleYield(DoCtrl::Call {
+                    f,
+                    args,
+                    kwargs,
+                    metadata,
+                });
+                StepEvent::Continue
+            }
+            DoCtrl::Expand {
+                factory,
+                args,
+                kwargs,
+                metadata,
+            } => {
+                self.mode = Mode::HandleYield(DoCtrl::Call {
+                    f: factory,
+                    args,
+                    kwargs,
+                    metadata,
+                });
+                StepEvent::Continue
             }
             DoCtrl::Eval {
                 expr,


### PR DESCRIPTION
## Summary
- Add `ASTStream` protocol surface (`ast_stream.rs`) with `PythonGeneratorStream` and typed stream-step/location structs.
- Add `DoeffGeneratorFn` PyClass and extend `DoeffGenerator` with optional `factory` back-pointer while keeping existing metadata/get_frame fields.
- Add `HandlerInvoke`, `HandlerDebugInfo`, and `HandlerRef` trait/types in `handler.rs`.
- Add new DoCtrl variants `Apply` and `Expand`, plus PyClass/type-tag plumbing and module exports.
- Wire exports through `lib.rs` and `doeff_vm/__init__.py` (`DoeffGeneratorFn`, `Apply`, `Expand`, `TAG_APPLY`, `TAG_EXPAND`).
- Add/extend unit tests for DoeffGeneratorFn call/back-pointer, ASTStream stepping/debug location, and Apply/Expand tag/classification paths.

## Acceptance Criteria Evidence
Issue reference: **VM-REV3-PHASE-A**

- [x] All new types compile
  - `cargo test` (in `packages/doeff-vm`) passed, including compile and full Rust unit suite.

- [x] All new PyClasses constructible from Python
  - Verified via `uv run python` snippet constructing `DoeffGeneratorFn`, `Apply`, and `Expand`.
  - Output: `ok`.

- [x] `DoeffGeneratorFn.__call__` produces `DoeffGenerator` with `factory` back-pointer
  - Rust unit: `doeff_generator::tests::test_doeff_generator_fn_call_wraps_result_with_factory_back_pointer` passed.
  - Python unit: `packages/doeff-vm/tests/test_pyvm.py::test_doeff_generator_fn_call_wraps_generator_with_factory` passed.

- [x] `PythonGeneratorStream` implements `ASTStream`
  - Added trait implementation and tests in `packages/doeff-vm/src/ast_stream.rs`:
    - `test_python_generator_stream_resume_sequence`
    - `test_python_generator_stream_throw_uses_gen_throw`
    - `test_python_generator_stream_debug_location_uses_get_frame_callback`

- [ ] All existing tests pass unchanged
  - Root suite run: `uv run pytest`
  - Result: `619 passed, 3 failed`.
  - Failing tests (existing traceback formatting expectations):
    - `tests/core/test_traceback_format_default.py::test_format_default_shows_effect_yield_on_handler_throw`
    - `tests/core/test_traceback_format_default.py::test_format_default_shows_program_yield_chain`
    - `tests/core/test_traceback_format_default.py::test_format_default_shows_delegation_chain`

- [x] New unit tests for DoeffGeneratorFn construction/call, PythonGeneratorStream stepping, Apply/Expand classification
  - Added and passing in Rust + Python test files listed above.

## Validation Commands
- `cargo test` (workdir: `packages/doeff-vm`) -> passed
- `uv run pytest tests/core/test_vm_proto_002_doeff_generator_construction.py` -> `5 passed`
- `uv run pytest packages/doeff-vm/tests/test_pyvm.py::test_tag_attribute_accessible packages/doeff-vm/tests/test_pyvm.py::test_tag_on_concrete_instances packages/doeff-vm/tests/test_pyvm.py::test_doeff_generator_fn_call_wraps_generator_with_factory` -> `3 passed`
- `uv run pytest packages/doeff-vm/tests/test_package_exports.py` -> `3 passed`
- `uv run pytest` -> `619 passed, 3 failed` (listed above)

## Risk
- Changes are additive and preserve existing fields/paths for transition compatibility.
- `Apply`/`Expand` runtime handling currently lowers to existing `Call` semantics in VM dispatch to avoid behavior churn while wiring new typed surface.
