### PR TITLE
Rev3 Phase C: unify VM frames on Program AST streams

### DIFF
--- a/packages/doeff-vm/src/python_call.rs
+++ b/packages/doeff-vm/src/python_call.rs
@@ -1,5 +1,6 @@
 //! Python bridge call protocol.
 
+use crate::ast_stream::ASTStreamRef;
 use crate::continuation::Continuation;
 use crate::do_ctrl::DoCtrl;
 use crate::driver::PyException;
@@ -49,9 +50,8 @@ pub enum PendingPython {
         metadata: Option<CallMetadata>,
     },
     StepUserGenerator {
-        generator: PyShared,
+        stream: ASTStreamRef,
         metadata: Option<CallMetadata>,
-        get_frame: PyShared,
     },
     CallPythonHandler {
         k_user: Continuation,
@@ -75,13 +75,13 @@ pub enum PyCallOutcome {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_vm_proto_pending_step_user_generator_has_get_frame_field() {
+    fn test_vm_proto_pending_step_user_generator_has_stream_field() {
         let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/python_call.rs"));
         let runtime_src = src.split("#[cfg(test)]").next().unwrap_or(src);
         assert!(
             runtime_src.contains("StepUserGenerator {")
-                && runtime_src.contains("get_frame: PyShared"),
-            "VM-PROTO-001: PendingPython::StepUserGenerator must carry get_frame callback"
+                && runtime_src.contains("stream: ASTStreamRef"),
+            "VM-PROTO-001: PendingPython::StepUserGenerator must carry ASTStreamRef"
         );
     }
 }


### PR DESCRIPTION
## Summary
Implements **Rev 3 Phase C: Frame Unification** by replacing split frame variants with a unified `Frame::Program { stream: ASTStreamRef, metadata }` and switching VM stepping to a single stream-based path.

Reference: **VM-REV3-PHASE-C**

## What changed
- C1 (`frame.rs`):
  - Removed `Frame::PythonGenerator` and `Frame::RustProgram`.
  - Added unified:
    - `Frame::Program { stream: ASTStreamRef, metadata: Option<CallMetadata> }`
  - Kept `Frame::RustReturn { cb }` unchanged.
- C2/C3 (`vm.rs`):
  - Unified `step_deliver_or_throw` frame execution for `Frame::Program`.
  - Replaced `apply_rust_program_step` with `apply_stream_step(step: ASTStreamStep, stream, metadata)`.
  - `apply_stream_step` handles `Yield` / `Return` / `Throw` / `NeedsPython` uniformly.
- C4 (frame push sites):
  - Python generator pushes now create `PythonGeneratorStream` and push `Frame::Program`.
  - Rust handler pushes now wrap handler programs as streams and push `Frame::Program`.
  - NeedsPython re-push paths now re-push `Frame::Program` with the same `ASTStreamRef`.
- C5 (trace assembly):
  - Live trace/active-chain assembly now uses `stream.debug_location()` via `stream_debug_location(...)`.
  - Removed generator-specific frame-line helpers from runtime VM path.
- C6 (continuations):
  - Continuation snapshots keep `Arc<Vec<Frame>>`, and `Frame::Program` carries `ASTStreamRef` (`Arc<Mutex<...>>`) so cloned snapshots preserve alias semantics.
- Additional safety fix:
  - `HashedPyKey` clone now performs Python-safe cloning under `Python::attach`, preventing runtime panics in rebuilt extension runs.

## Acceptance criteria evidence
### 1) `Frame::PythonGenerator` and `Frame::RustProgram` removed
```bash
rg -n "Frame::PythonGenerator|Frame::RustProgram" packages/doeff-vm/src -S
# no matches
```

### 2) Only `Frame::Program` + `Frame::RustReturn` remain
```bash
rg -n "pub enum Frame|RustReturn|Program" packages/doeff-vm/src/frame.rs -S
# shows enum with RustReturn and Program variants
```

### 3) Single stepping path in `step()`
```bash
rg -n "fn step_deliver_or_throw|Frame::Program \{ stream, metadata \}|fn apply_stream_step" packages/doeff-vm/src/vm.rs -S
```

### 4) `apply_stream_step` handles all `ASTStreamStep` variants
```bash
rg -n "ASTStreamStep::Yield|ASTStreamStep::Return|ASTStreamStep::Throw|ASTStreamStep::NeedsPython" packages/doeff-vm/src/vm.rs -S
```

### 5) `generator_current_line()` eliminated
```bash
rg -n "generator_current_line\(" packages/doeff-vm/src/vm.rs -S
# only appears in test assertion string; no runtime function definition
```

### 6) Trace assembly uses `debug_location()`
```bash
rg -n "stream_debug_location|debug_location\(" packages/doeff-vm/src/vm.rs packages/doeff-vm/src/scheduler.rs -S
```

### 7) Continuation capture/restore still works with unified frame
Validated by passing VM/scheduler continuation-heavy tests in `cargo test --lib` and full `pytest`.

### 8) All existing tests pass
```bash
cargo test --lib                 # in packages/doeff-vm -> 182 passed
uv run --reinstall-package doeff-vm pytest  # repo root -> 622 passed
```

### 9) Performance regression check
Benchmark suite not run in this PR (no benchmark harness invoked in this run).
