### PR TITLE
VM-REV3 Phase E: handler invoke protocol dispatch

### DIFF
--- a/packages/doeff-vm/src/continuation.rs
+++ b/packages/doeff-vm/src/continuation.rs
@@ -171,16 +171,10 @@ impl Continuation {
                     list.append(identity.bind(py))?;
                     continue;
                 }
-                match handler {
-                    Handler::Python {
-                        callable: py_handler,
-                        ..
-                    } => {
-                        list.append(py_handler.bind(py))?;
-                    }
-                    Handler::RustProgram(_) => {
-                        list.append(py.None().into_bound(py))?;
-                    }
+                if let Some(identity) = handler.py_identity() {
+                    list.append(identity.bind(py))?;
+                } else {
+                    list.append(py.None().into_bound(py))?;
                 }
             }
             dict.set_item("handlers", list)?;

--- a/packages/doeff-vm/src/python_call.rs
+++ b/packages/doeff-vm/src/python_call.rs
@@ -4,7 +4,6 @@ use crate::ast_stream::ASTStreamRef;
 use crate::continuation::Continuation;
 use crate::do_ctrl::DoCtrl;
 use crate::driver::PyException;
-use crate::effect::DispatchEffect;
 use crate::frame::CallMetadata;
 use crate::ids::Marker;
 use crate::py_shared::PyShared;
@@ -19,11 +18,6 @@ pub enum PythonCall {
         func: PyShared,
         args: Vec<Value>,
         kwargs: Vec<(String, Value)>,
-    },
-    CallHandler {
-        handler: PyShared,
-        effect: DispatchEffect,
-        continuation: Continuation,
     },
     GenNext,
     GenSend {
@@ -46,16 +40,13 @@ pub enum PendingPython {
     CallFuncReturn {
         metadata: Option<CallMetadata>,
     },
-    ExpandReturn {
-        metadata: Option<CallMetadata>,
-    },
     StepUserGenerator {
         stream: ASTStreamRef,
         metadata: Option<CallMetadata>,
     },
-    CallPythonHandler {
-        k_user: Continuation,
-        effect: DispatchEffect,
+    ExpandReturn {
+        metadata: Option<CallMetadata>,
+        handler_return: bool,
     },
     RustProgramContinuation {
         marker: Marker,

--- a/tests/core/test_sa003_spec_gaps.py
+++ b/tests/core/test_sa003_spec_gaps.py
@@ -50,8 +50,8 @@ def test_SA_003_G02_python_call_errors_are_normalized_to_generror() -> None:
 
     assert "PythonCall::StartProgram" in body
     assert "to_generator_strict(py, program.clone_ref(py))?" not in body
-    assert "PythonCall::CallHandler" in body
-    assert "to_generator_strict(py, result.unbind())?" not in body
+    assert "PythonCall::CallHandler" not in body
+    assert "PythonCall::CallFunc" in body
     assert "PythonCall::CallAsync" in body
     assert "Ok(PyCallOutcome::GenError" in body
 

--- a/tests/core/test_vm_proto_002_doeff_generator_construction.py
+++ b/tests/core/test_vm_proto_002_doeff_generator_construction.py
@@ -76,4 +76,4 @@ def test_with_handler_wraps_generator_handler_returns_as_doeff_generator() -> No
     assert isinstance(wrapped, doeff_vm.DoeffGenerator)
     assert inspect.isgenerator(wrapped.generator)
     assert wrapped.get_frame is _default_get_frame
-    assert wrapped.function_name == "handler"
+    assert wrapped.function_name == handler.__qualname__

--- a/tests/core/test_vm_proto_003_withhandler_metadata.py
+++ b/tests/core/test_vm_proto_003_withhandler_metadata.py
@@ -62,11 +62,15 @@ def test_handler_trace_metadata_uses_registration_values_not_runtime_dunder_read
         yield Delegate()
 
     control = WithHandler(crash_handler, _probe_program())
+    original_qualname = crash_handler.__qualname__
+    original_source_file = crash_handler.__code__.co_filename
+    original_source_line = crash_handler.__code__.co_firstlineno
 
-    # Mutate the wrapped callable after registration.
+    # Mutate the underlying callable after registration.
     # VM-PROTO-003 requires trace metadata to come from registration-time fields,
     # not runtime getattr("__name__") / getattr("__code__") probing.
-    control.handler.__name__ = "mutated_handler_name"
+    control.handler.callable.__name__ = "mutated_handler_name"
+    control.handler.callable.__qualname__ = "mutated_handler_qualname"
 
     result = run(control, handlers=default_handlers(), print_doeff_trace=False)
     assert result.is_err()
@@ -84,6 +88,6 @@ def test_handler_trace_metadata_uses_registration_values_not_runtime_dunder_read
         handler_source_file = dispatch.handler_source_file
         handler_source_line = dispatch.handler_source_line
 
-    assert handler_name == crash_handler.__qualname__
-    assert handler_source_file == crash_handler.__code__.co_filename
-    assert handler_source_line == crash_handler.__code__.co_firstlineno
+    assert handler_name == original_qualname
+    assert handler_source_file == original_source_file
+    assert handler_source_line == original_source_line


### PR DESCRIPTION
## Summary
- Replace enum-based handler dispatch with `HandlerInvoke` trait-object dispatch (`handler.invoke(...) -> DoExpr`) in VM runtime.
- Introduce `PythonHandler` (`DoeffGeneratorFn` backed) and `RustProgramInvocation` value flow so Apply/Expand execute uniformly.
- Remove legacy `CallHandler` / `CallPythonHandler` pending-path plumbing.
- Enforce strict Rust boundary type checks for `WithHandler` handlers and keep Python-side coercion at API boundaries.
- Update compatibility/contract tests for the new `DoeffGeneratorFn` wrapper semantics.

## Issue
- VM-REV3-PHASE-E

## Acceptance Criteria Evidence
- [x] `Handler` enum removed from codebase
  - `rg -n "enum\s+Handler\b|Handler::RustProgram|Handler::Python" packages/doeff-vm/src` -> no matches
- [x] `Handler::python_from_callable()` removed
  - `rg -n "Handler::python_from_callable" packages/doeff-vm/src` -> no matches
- [x] `_wrap_python_handler()` removed
  - `rg -n "_wrap_python_handler" packages/doeff-vm/doeff_vm/__init__.py doeff/rust_vm.py packages/doeff-vm/src` -> no matches
- [x] All handler dispatch uses `handler.invoke()` -> DoExpr -> evaluate
  - `packages/doeff-vm/src/vm.rs:2758` and `packages/doeff-vm/src/vm.rs:3129` call `handler.invoke(...)`
- [x] No `match handler { RustProgram => ..., Python => ... }` in VM
  - `rg -n "match\s*&?handler\s*\{|Handler::RustProgram|Handler::Python" packages/doeff-vm/src/vm.rs` -> no matches
- [x] `PythonCall::CallHandler` removed
  - `rg -n "PythonCall::CallHandler" packages/doeff-vm/src` -> no matches
- [x] `PendingPython::CallPythonHandler` removed
  - `rg -n "PendingPython::CallPythonHandler" packages/doeff-vm/src` -> no matches
- [x] WithHandler rejects non-DoeffGeneratorFn/non-RustHandler callables with clear error
  - Guard string present at `packages/doeff-vm/src/pyvm.rs:1770` and `packages/doeff-vm/src/pyvm.rs:1779`
- [x] All existing tests pass
  - `uv run --reinstall-package doeff-vm pytest -q` -> `622 passed in 21.57s`

## Validation
- `uv run --reinstall-package doeff-vm pytest -q`
