### PR TITLE
TRACE-002: switch spawn attribution to GetTraceback

### DIFF
--- a/doeff/effects/spawn.py
+++ b/doeff/effects/spawn.py
@@ -200,6 +200,13 @@ def _spawn_program(effect: SpawnEffect):
     return _spawn_task()
 
 
+def spawn_intercept_handler(effect: Any, k: Any):
+    if isinstance(effect, SpawnEffect):
+        raw = yield doeff_vm.Delegate()
+        return (yield doeff_vm.Resume(k, coerce_task_handle(raw)))
+    yield doeff_vm.Pass()
+
+
 def spawn(
     program: ProgramLike,
     **options: Any,
@@ -262,5 +269,6 @@ __all__ = [
     "coerce_task_handle",
     "promise_id_of",
     "spawn",
+    "spawn_intercept_handler",
     "task_id_of",
 ]


### PR DESCRIPTION
## Summary
- replace scheduler spawn-site frame walking with `DoCtrl::GetTraceback` + new `SpawnAwaitTraceback` phase
- remove `spawn_site_from_continuation` and derive spawn site from traceback hops (outermost hop with user-code frames)
- add coercion-only `spawn_intercept_handler` in `doeff/effects/spawn.py`
- add regression tests for spawn-site attribution under single and nested delegate chains

## Issue
- TRACE-002

## Acceptance Criteria Evidence
- Scheduler now yields `GetTraceback(k_user)` for spawn:
  - `packages/doeff-vm/src/scheduler.rs`
- `spawn_site_from_continuation` is deleted:
  - `rg -n "spawn_site_from_continuation" packages/doeff-vm/src/scheduler.rs` returns no matches
- Spawn attribution under Delegate chains verified:
  - `tests/core/test_traceback_format_default.py::test_spawn_site_attribution_under_single_delegate_handler`
  - `tests/core/test_traceback_format_default.py::test_spawn_site_attribution_under_nested_delegate_handlers`

## Validation
- `make sync` ✅
- `cargo test spawn_site_from_traceback_uses_outermost_user_hop -- --nocapture` (in `packages/doeff-vm`) ✅
- `cargo test scheduler_ast_stream_spawn_sequence_and_debug_location -- --nocapture` (in `packages/doeff-vm`) ✅
- `uv run pytest tests/core/test_traceback_format_default.py -k "spawn_site_attribution_under_single_delegate_handler or spawn_site_attribution_under_nested_delegate_handlers or spawn_shows_effect_in_child"` ✅
- `uv run pytest` ✅ (`635 passed`)
- `make lint` ❌ fails due existing repository-wide Ruff backlog (956 findings unrelated to this branch)

## Notes
- `packages/doeff-vm/src/vm.rs::effect_site_from_continuation` is still used by dispatch trace capture paths (`effect_creation_site_from_continuation` and `DispatchStarted` metadata), so it was intentionally not removed.
