### PR TITLE
Enforce SPEC-VM-014 TRACE-001/002 invariants with Semgrep

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -1142,6 +1142,53 @@ rules:
       issue: VM-PROTO-007
 
   # ---------------------------------------------------------------------------
+  # SPEC-VM-014 ENFORCEMENT
+  # ---------------------------------------------------------------------------
+
+  - id: vm-no-py-import-in-value-traceback
+    pattern-regex: '\.import\("doeff_vm"\)'
+    paths:
+      include:
+        - "**/packages/doeff-vm/src/value.rs"
+    message: |
+      Value::Traceback conversion must use direct Py::new(py, PyTraceFrame { ... }) construction.
+      Do not import doeff_vm module from value.rs - PyTraceFrame and PyTraceHop are in the same crate.
+      Use: use crate::pyvm::{PyTraceFrame, PyTraceHop};
+    languages: [rust]
+    severity: ERROR
+    metadata:
+      category: vm-protocol
+      spec: SPEC-VM-014
+
+  - id: vm-no-get-yield-site-artifacts
+    pattern-regex: 'GetYieldSite|YieldSite'
+    paths:
+      include:
+        - "**/packages/doeff-vm/src/**"
+    message: |
+      GetYieldSite/YieldSite are replaced by GetTraceback/Traceback (SPEC-VM-014).
+      These artifacts must not exist in VM source.
+    languages: [rust]
+    severity: ERROR
+    metadata:
+      category: vm-protocol
+      spec: SPEC-VM-014
+
+  - id: vm-no-spawn-site-on-py-spawn
+    pattern-regex: 'spawn_site.*Option<Py<PyAny>>'
+    paths:
+      include:
+        - "**/packages/doeff-vm/src/effect.rs"
+    message: |
+      PySpawn must not carry spawn_site field. Spawn site attribution uses
+      GetTraceback DoCtrl via the scheduler (SPEC-VM-014 Phase 2).
+    languages: [rust]
+    severity: ERROR
+    metadata:
+      category: vm-protocol
+      spec: SPEC-VM-014
+
+  # ---------------------------------------------------------------------------
   # PUBLIC API LOCATION GUARDS
   # ---------------------------------------------------------------------------
 

--- a/packages/doeff-vm/.semgrep.yaml
+++ b/packages/doeff-vm/.semgrep.yaml
@@ -280,3 +280,41 @@ rules:
       category: spec-enforcement
       spec: SPEC-008
       invariants: ["R14-C"]
+
+  # ---------------------------------------------------------------------------
+  # SPEC-VM-014 ENFORCEMENT
+  # ---------------------------------------------------------------------------
+
+  - id: scheduler-no-spawn-site-from-continuation
+    pattern-regex: 'fn spawn_site_from_continuation'
+    paths:
+      include:
+        - "**/packages/doeff-vm/src/scheduler.rs"
+    message: |
+      spawn_site_from_continuation is deleted (SPEC-VM-014 Phase 2).
+      Scheduler must use GetTraceback DoCtrl for spawn site attribution.
+      See spawn_site_from_traceback() which walks TraceHop data instead.
+    languages: [rust]
+    severity: ERROR
+    metadata:
+      category: vm-protocol
+      spec: SPEC-VM-014
+
+  - id: scheduler-no-direct-frame-walk
+    patterns:
+      - pattern: |
+          for $FRAME in $K.frames_snapshot.iter() {
+            ...
+          }
+    paths:
+      include:
+        - "**/packages/doeff-vm/src/scheduler.rs"
+    message: |
+      Scheduler must not walk continuation frames directly.
+      Use GetTraceback DoCtrl to query the VM for traceback data.
+      Direct frame walking duplicates VM logic (SPEC-VM-014 C3 violation).
+    languages: [rust]
+    severity: ERROR
+    metadata:
+      category: vm-protocol
+      spec: SPEC-VM-014


### PR DESCRIPTION
## Summary
Add Semgrep enforcement rules for SPEC-VM-014 invariants from TRACE-001/TRACE-002 to prevent protocol regressions in VM traceback/spawn attribution paths.

## Changes
- Add `SPEC-VM-014 ENFORCEMENT` section in `.semgrep.yaml` with:
  - `vm-no-py-import-in-value-traceback`
  - `vm-no-get-yield-site-artifacts`
  - `vm-no-spawn-site-on-py-spawn`
- Add `SPEC-VM-014 ENFORCEMENT` section in `packages/doeff-vm/.semgrep.yaml` with:
  - `scheduler-no-spawn-site-from-continuation`
  - `scheduler-no-direct-frame-walk`

## Acceptance Criteria Evidence
- [x] All 5 semgrep rules added to appropriate files
  - `.semgrep.yaml` and `packages/doeff-vm/.semgrep.yaml`
- [x] Rules placed in clearly labeled `SPEC-VM-014 ENFORCEMENT` sections
- [x] Each rule includes `metadata.spec: SPEC-VM-014`
- [x] Each rule has explanatory messages
- [ ] `make lint-semgrep` passes
  - Current repo baseline has existing blocking findings unrelated to this change (67 findings).
  - Command run: `make lint-semgrep`
- [ ] `make lint` passes (or only pre-existing errors)
  - Fails early in Ruff with pre-existing issues unrelated to this change (954 errors).
  - Command run: `make lint`
- [x] New SPEC-VM-014 rules are green against current source
  - Isolated run of only the 5 new rules: `semgrep --config <temp-config> --error packages/doeff-vm/src/`
  - Result: `0 findings` on `24 files`

## Validation Commands Run
```bash
make lint-semgrep
make lint
semgrep --config <temp-config-with-5-new-rules> --error packages/doeff-vm/src/
```

Refs: TRACE-TDD-001
