### PR TITLE
Fix TRACE-PASS-DELEGATE-001: distinguish Pass vs Delegate traceback markers

### DIFF
--- a/doeff/trace.py
+++ b/doeff/trace.py
@@ -10,6 +10,7 @@ TraceDispatchAction: TypeAlias = Literal["active", "resumed", "transferred", "re
 HandlerStatusKind: TypeAlias = Literal[
     "active",
     "pending",
+    "passed",
     "delegated",
     "resumed",
     "transferred",
@@ -179,6 +180,7 @@ def _coerce_handler_status(value: Any) -> HandlerStatusKind:
     lookup: dict[str, HandlerStatusKind] = {
         "active": "active",
         "pending": "pending",
+        "passed": "passed",
         "delegated": "delegated",
         "resumed": "resumed",
         "transferred": "transferred",

--- a/doeff/traceback.py
+++ b/doeff/traceback.py
@@ -338,7 +338,8 @@ else:
             marker = {
                 "active": "⚡",
                 "pending": "·",
-                "delegated": "↗",
+                "passed": "↗",
+                "delegated": "⇆",
                 "resumed": "✓",
                 "transferred": "⇢",
                 "returned": "✓",

--- a/packages/doeff-vm/src/capture.rs
+++ b/packages/doeff-vm/src/capture.rs
@@ -19,6 +19,7 @@ pub enum HandlerKind {
 pub enum HandlerStatus {
     Active,
     Pending,
+    Passed,
     Delegated,
     Resumed,
     Transferred,
@@ -170,6 +171,16 @@ pub enum CaptureEvent {
         effect_source_line: Option<u32>,
     },
     Delegated {
+        dispatch_id: DispatchId,
+        from_handler_name: String,
+        from_handler_index: usize,
+        to_handler_name: String,
+        to_handler_index: usize,
+        to_handler_kind: HandlerKind,
+        to_handler_source_file: Option<String>,
+        to_handler_source_line: Option<u32>,
+    },
+    Passed {
         dispatch_id: DispatchId,
         from_handler_name: String,
         from_handler_index: usize,

--- a/packages/doeff-vm/src/value.rs
+++ b/packages/doeff-vm/src/value.rs
@@ -62,6 +62,7 @@ impl Value {
         match status {
             HandlerStatus::Active => "active",
             HandlerStatus::Pending => "pending",
+            HandlerStatus::Passed => "passed",
             HandlerStatus::Delegated => "delegated",
             HandlerStatus::Resumed => "resumed",
             HandlerStatus::Transferred => "transferred",

--- a/tests/core/test_spec_trace_001_examples.py
+++ b/tests/core/test_spec_trace_001_examples.py
@@ -17,7 +17,7 @@ _DEFAULT_HANDLER_NAMES = (
     "ReaderHandler",
     "StateHandler",
 )
-_HANDLER_STATUS_MARKERS = {"⚡", "·", "↗", "✓", "⇢", "✗"}
+_HANDLER_STATUS_MARKERS = {"⚡", "·", "↗", "⇆", "✓", "⇢", "✗"}
 
 
 def _line_of(function: object, needle: str) -> int:

--- a/tests/core/test_traceback_spec_compliance.py
+++ b/tests/core/test_traceback_spec_compliance.py
@@ -17,7 +17,7 @@ _DEFAULT_HANDLER_NAMES = (
     "ReaderHandler",
     "StateHandler",
 )
-_HANDLER_STATUS_MARKERS = {"⚡", "·", "↗", "✓", "⇢", "✗"}
+_HANDLER_STATUS_MARKERS = {"⚡", "·", "↗", "⇆", "✓", "⇢", "✗"}
 
 
 def _line_of(function: object, needle: str) -> int:


### PR DESCRIPTION
## Summary
Fixes TRACE-PASS-DELEGATE-001 by preserving Pass vs Delegate semantics through capture, VM assembly, Python conversion, and default traceback rendering.

- Added `HandlerStatus::Passed` and `CaptureEvent::Passed` in Rust capture types.
- Updated `handle_pass()` to emit `CaptureEvent::Passed` (instead of `Delegated`).
- Updated active-chain assembly to map `Passed` events to `HandlerStatus::Passed` and `Delegated` events to `HandlerStatus::Delegated`.
- Updated value conversion to emit `"passed"` for passed handler status.
- Updated Python trace coercion to accept `"passed"`.
- Updated default traceback markers:
  - `passed` -> `↗`
  - `delegated` -> `⇆`
- Updated traceback/spec tests for marker expectations and added explicit pass-vs-delegate regression coverage.

## TDD Evidence (failing tests first)
Before implementation (non-test changes rolled back), running:

`uv run pytest tests/core/test_traceback_format_default.py -k "shows_sync_await_handler_when_delegated or distinguishes_passed_and_delegated" -q`

failed with 3 failures:
- delegated handler still rendered `↗` instead of `⇆`
- `"passed"` status was rejected (`Unknown handler status: 'passed'`)
- runtime stack showed delegated marker for both pass/delegate handlers

After implementation and Rust rebuild (`make sync`), the same targeted test selection passed:
- `3 passed, 25 deselected`

## Acceptance Criteria Verification
- [x] Pass renders as `↗` and Delegate renders as `⇆` in default traceback output.
  - Verified by runtime snippet output line:
    - `[inner_pass_handler↗ > middle_delegate_handler⇆ > outer_throw_handler✗ > ...]`
- [x] Existing traceback/default formatting behavior remains valid.
  - `uv run pytest tests/core/test_traceback_format_default.py -q`
  - Result: `28 passed`
- [x] Spec marker parsers accept both markers.
  - `uv run pytest tests/core/test_traceback_spec_compliance.py -q`
  - Result: `6 passed`
  - `uv run pytest tests/core/test_spec_trace_001_examples.py -q`
  - Result: `7 passed`

## Validation Commands
- `make sync`
- `uv run pytest`
  - Result: `657 passed`
- `uv run semgrep --config packages/doeff-vm/.semgrep.yaml packages/doeff-vm/src/ --error`
  - Result: `0 findings`

## Issue
Refs: TRACE-PASS-DELEGATE-001
