### PR TITLE
VM-FAILFAST-001C: log swallowed traceback/runtime failures

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -364,6 +364,65 @@ rules:
       issue: VM-PROTO-003
       rationale: "Eliminate runtime handler metadata probing"
 
+  - id: doeff-traceback-except-must-log
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: "^(_build_doeff_traceback_if_present|_print_doeff_trace_if_present)$"
+      - pattern-either:
+          - pattern: |
+              try:
+                  ...
+              except Exception:
+                  ...
+          - pattern: |
+              try:
+                  ...
+              except Exception as $ERR:
+                  ...
+      - pattern-not: |
+          try:
+              ...
+          except Exception:
+              ...
+              warnings.warn(...)
+              ...
+      - pattern-not: |
+          try:
+              ...
+          except Exception as $ERR:
+              ...
+              warnings.warn(...)
+              ...
+      - pattern-not: |
+          try:
+              ...
+          except Exception:
+              ...
+              logging.warning(...)
+              ...
+      - pattern-not: |
+          try:
+              ...
+          except Exception as $ERR:
+              ...
+              logging.warning(...)
+              ...
+    paths:
+      include:
+        - "**/doeff/rust_vm.py"
+    message: |
+      Traceback-layer exception handlers must log before graceful degradation.
+      Add warnings.warn(...) or logging.warning(...) inside except Exception blocks.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: traceback-invariant
+      issue: VM-FAILFAST-001C
+
   # ---------------------------------------------------------------------------
   # LAYER BOUNDARIES
   # ---------------------------------------------------------------------------

--- a/doeff/_types_internal.py
+++ b/doeff/_types_internal.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import traceback
+import warnings
 from abc import abstractmethod
 from collections.abc import Callable, Generator, Hashable, Iterable, Iterator
 from dataclasses import dataclass, field
@@ -1145,7 +1146,8 @@ class PyRunResult(Generic[T]):
             return "{}"
         try:
             json_str = json.dumps(value, indent=None, default=str)
-        except Exception:
+        except Exception as exc:
+            warnings.warn(f"Failed to format dict value for display: {exc}", stacklevel=2)
             return f"<dict with {len(value)} items>"
 
         if len(json_str) <= max_length:
@@ -1164,7 +1166,8 @@ class PyRunResult(Generic[T]):
             return f"[{len(value)} items]"
         try:
             json_str = json.dumps(value, indent=None, default=str)
-        except Exception:
+        except Exception as exc:
+            warnings.warn(f"Failed to format list value for display: {exc}", stacklevel=2)
             return f"<list with {len(value)} items>"
         if len(json_str) > max_length:
             return f"[{len(value)} items]"

--- a/doeff/effects/semaphore.py
+++ b/doeff/effects/semaphore.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 
 import doeff_vm
@@ -36,8 +37,12 @@ class Semaphore:
 
         try:
             notify(self._scheduler_state_id, self.id)
-        except Exception:
+        except Exception as exc:
             # Best-effort cleanup hook; never let destructor exceptions escape.
+            warnings.warn(
+                f"Failed to notify semaphore handle drop for id={self.id}: {exc}",
+                stacklevel=2,
+            )
             return
 
 

--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import inspect
 import types
+import warnings
 from collections.abc import Callable
 from collections.abc import Callable as TypingCallable
 from dataclasses import dataclass
@@ -71,8 +72,9 @@ class KleisliProgram(Generic[P, T]):
         return types.MethodType(self, instance)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Program[T]:
-        from doeff.types import EffectBase
         from doeff_vm import Apply, DoCtrlBase, Expand, Perform, Pure
+
+        from doeff.types import EffectBase
 
         strategy = getattr(self, "_auto_unwrap_strategy", None)
         if strategy is None:
@@ -228,7 +230,8 @@ def _hydrate_future_annotations() -> None:
 
     try:
         hints = get_type_hints(KleisliProgram.__call__, include_extras=True)
-    except Exception:  # pragma: no cover - defensive guard
+    except Exception as exc:  # pragma: no cover - defensive guard
+        warnings.warn(f"Failed to hydrate KleisliProgram.__call__ annotations: {exc}", stacklevel=2)
         hints = {}
     if hints:
         KleisliProgram.__call__.__annotations__ = hints

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -100,9 +100,20 @@ fn build_traceback_data_pyobject(
     trace: Vec<crate::capture::TraceEntry>,
     active_chain: Vec<crate::capture::ActiveChainEntry>,
 ) -> Option<Py<PyAny>> {
-    let entries = Value::Trace(trace).to_pyobject(py).ok()?.unbind();
+    let entries = Value::Trace(trace)
+        .to_pyobject(py)
+        .map_err(|e| {
+            eprintln!("[VM WARNING] traceback serialization failed for entries: {e}");
+            e
+        })
+        .ok()?
+        .unbind();
     let active_chain = Value::ActiveChain(active_chain)
         .to_pyobject(py)
+        .map_err(|e| {
+            eprintln!("[VM WARNING] traceback serialization failed for active_chain: {e}");
+            e
+        })
         .ok()?
         .unbind();
     let data = Bound::new(
@@ -112,6 +123,10 @@ fn build_traceback_data_pyobject(
             active_chain,
         },
     )
+    .map_err(|e| {
+        eprintln!("[VM WARNING] traceback serialization failed for traceback_data object: {e}");
+        e
+    })
     .ok()?;
     Some(data.into_any().unbind())
 }

--- a/tests/program/test_kleisli_beartype.py
+++ b/tests/program/test_kleisli_beartype.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 from beartype import beartype
 
+import doeff.kleisli as kleisli_module
 from doeff import Program
 from doeff.kleisli import KleisliProgram, P
 
@@ -36,3 +37,15 @@ def test_kleisli_call_is_beartype_decoratable() -> None:
     result = decorated_call(kleisli)
 
     assert isinstance(result, Program)
+
+
+def test_hydrate_future_annotations_warns_on_resolution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_resolution_error(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise NameError("forward reference missing")
+
+    monkeypatch.setattr(kleisli_module, "get_type_hints", _raise_resolution_error)
+
+    with pytest.warns(UserWarning, match="Failed to hydrate KleisliProgram.__call__ annotations"):
+        kleisli_module._hydrate_future_annotations()

--- a/tests/program/test_program_type_hints_warning.py
+++ b/tests/program/test_program_type_hints_warning.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+import doeff.program as program_module
+
+
+def test_safe_get_type_hints_warns_on_resolution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_type_hint_error(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise NameError("missing symbol")
+
+    def sample(value: int) -> int:
+        return value
+
+    monkeypatch.setattr(program_module, "get_type_hints", _raise_type_hint_error)
+
+    with pytest.warns(UserWarning, match="Failed to resolve type hints for"):
+        hints = program_module._safe_get_type_hints(sample)
+
+    assert hints == {}


### PR DESCRIPTION
## Summary
- Converted silent broad exception swallowing paths to warning-emitting graceful degradation across runtime hotspots.
- Enforced direct `RunResult` attribute access for unhandled-effect gate logic (fail-fast on binding contract breakage).
- Added Rust-side traceback serialization warning logs before `.ok()?` fallback.
- Added traceback-layer semgrep guard (`doeff-traceback-except-must-log`) and regression tests for warning emission paths.

## Acceptance Criteria Evidence

### 1) All 6 Python silent swallowing sites converted to logging + graceful degradation
Updated sites:
- `doeff/rust_vm.py`
  - `_raise_unhandled_effect_if_present`: `is_err = run_result.is_err`
  - `_build_doeff_traceback_if_present`: warnings on traceback build/attach failures
  - `_print_doeff_trace_if_present`: warning on format/print failure
- `doeff/program.py`
  - `_safe_get_type_hints`: warning + `{}` fallback on resolution failure
- `doeff/effects/semaphore.py`
  - `Semaphore.__del__`: warning in destructor failure path
- `doeff/kleisli.py`
  - `_hydrate_future_annotations`: warning on hydration failure

Verification:
```bash
rg -n "def _raise_unhandled_effect_if_present|is_err = run_result\.is_err|Failed to build doeff traceback|Failed to print doeff trace|Failed to attach doeff traceback" doeff/rust_vm.py
rg -n "def _safe_get_type_hints|Failed to resolve type hints" doeff/program.py
rg -n "def __del__|Failed to notify semaphore handle drop" doeff/effects/semaphore.py
rg -n "def _hydrate_future_annotations|Failed to hydrate KleisliProgram" doeff/kleisli.py
```

### 2) All 3 `pyvm.rs` traceback `.ok()?` sites log before fallback
Verification:
```bash
rg -n "build_traceback_data_pyobject|map_err|traceback serialization failed" packages/doeff-vm/src/pyvm.rs
```
Includes warning logs at the three traceback serialization fallible points.

### 3) Tests verify warnings are emitted on failure
Added tests:
- `tests/core/test_rust_vm_api_strict.py`
  - traceback build failure warns
  - traceback print formatting failure warns
  - direct RunResult attribute access behavior
- `tests/program/test_program_type_hints_warning.py`
  - `_safe_get_type_hints` warning on failure
- `tests/program/test_kleisli_beartype.py`
  - `_hydrate_future_annotations` warning on failure
- `tests/effects/test_semaphore.py`
  - `Semaphore.__del__` warning on cleanup hook failure

Targeted verification:
```bash
uv run pytest tests/core/test_rust_vm_api_strict.py tests/program/test_program_type_hints_warning.py tests/program/test_kleisli_beartype.py tests/effects/test_semaphore.py
# 28 passed
```

### 4) `make sync && uv run pytest` all tests pass
Verification:
```bash
make sync
uv run pytest
# 663 passed in 38.22s
```

### 5) No bare `except Exception: return` without logging
Verification (no matches):
```bash
rg -n -U "except Exception(?: as [A-Za-z_][A-Za-z0-9_]*)?:\\n\\s*return" doeff packages/doeff-vm/src
```

### Semgrep enforcement for traceback layer
Added rule:
- `.semgrep.yaml`: `doeff-traceback-except-must-log`

Rule presence:
```bash
rg -n "doeff-traceback-except-must-log" .semgrep.yaml
```

Check shows no findings from this rule on `doeff/rust_vm.py`.

## Issue
- VM-FAILFAST-001C
