### PR TITLE
Add semgrep guards against silent fallbacks (VM-FAILFAST-001D)

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -423,6 +423,45 @@ rules:
       category: traceback-invariant
       issue: VM-FAILFAST-001C
 
+  - id: no-silent-except-in-traceback
+    patterns:
+      - pattern: |
+          try:
+              ...
+          except Exception:
+              return ...
+    message: "FAILFAST: Do not silently swallow exceptions. Add warnings.warn() or logging before return."
+    languages: [python]
+    paths:
+      include:
+        - "**/doeff/rust_vm.py"
+        - "**/doeff/traceback.py"
+        - "**/doeff/trace.py"
+    severity: ERROR
+    metadata:
+      spec: VM-FAILFAST-001C
+      category: fail-fast
+
+  - id: no-silent-except-return-none
+    patterns:
+      - pattern: |
+          try:
+              ...
+          except Exception:
+              return None
+    message: "FAILFAST: Do not silently return None on exception. Add warnings.warn() or re-raise."
+    languages: [python]
+    paths:
+      include:
+        - "**/doeff/*.py"
+      exclude:
+        - "**/doeff/test_*.py"
+        - "**/doeff/*_test.py"
+    severity: WARNING
+    metadata:
+      spec: VM-FAILFAST-001C
+      category: fail-fast
+
   # ---------------------------------------------------------------------------
   # LAYER BOUNDARIES
   # ---------------------------------------------------------------------------

--- a/packages/doeff-vm/.semgrep.yaml
+++ b/packages/doeff-vm/.semgrep.yaml
@@ -464,3 +464,44 @@ rules:
     metadata:
       spec: TRACE-INVARIANT-001
       invariant: INV-1
+
+  # ---------------------------------------------------------------------------
+  # VM-FAILFAST-001 REGRESSION GUARDS
+  # ---------------------------------------------------------------------------
+
+  - id: no-bare-ok-in-handler-can-handle
+    pattern-regex: '\.ok\(\)\s*\?'
+    message: "FAILFAST: Do not use .ok()? to discard errors in can_handle(). Use .map_err() to convert or log the error."
+    languages: [generic]
+    paths:
+      include:
+        - "**/doeff-vm/src/handler.rs"
+    severity: ERROR
+    metadata:
+      spec: VM-FAILFAST-001B
+      category: fail-fast
+
+  - id: no-silent-if-let-current-segment
+    pattern-regex: 'if\s+let\s+Some\(\w+\)\s*=\s*self\.current_segment_mut\(\)'
+    message: "FAILFAST: Do not silently skip when current_segment_mut() returns None. Use .ok_or_else(|| VMError::internal(...))? instead."
+    languages: [generic]
+    paths:
+      include:
+        - "**/doeff-vm/src/vm.rs"
+    severity: ERROR
+    metadata:
+      spec: VM-FAILFAST-001A
+      category: fail-fast
+
+  - id: no-bare-ok-in-traceback-build
+    pattern-regex: '\.ok\(\)\s*\?'
+    message: "FAILFAST: Do not use .ok()? in traceback building. Add eprintln! logging before .ok()? or use .map_err()."
+    languages: [generic]
+    paths:
+      include:
+        - "**/doeff-vm/src/pyvm.rs"
+    severity: WARNING
+    metadata:
+      spec: VM-FAILFAST-001C
+      category: fail-fast
+      note: "Traceback layer should not crash, but must log errors"

--- a/tests/semgrep/fixtures/python/doeff/core_failfast_sample.py
+++ b/tests/semgrep/fixtures/python/doeff/core_failfast_sample.py
@@ -1,0 +1,5 @@
+def load_optional_value_bad() -> object | None:
+    try:
+        return object()
+    except Exception:
+        return None

--- a/tests/semgrep/fixtures/python/doeff/rust_vm.py
+++ b/tests/semgrep/fixtures/python/doeff/rust_vm.py
@@ -1,0 +1,5 @@
+def _traceback_fallback_bad() -> str:
+    try:
+        return "ok"
+    except Exception:
+        return "fallback"

--- a/tests/semgrep/fixtures/rust/packages/doeff-vm/src/handler.rs
+++ b/tests/semgrep/fixtures/rust/packages/doeff-vm/src/handler.rs
@@ -1,0 +1,5 @@
+pub fn can_handle_bad() -> Option<()> {
+    let conversion: Result<u8, u8> = Ok(1);
+    conversion.ok()?;
+    Some(())
+}

--- a/tests/semgrep/fixtures/rust/packages/doeff-vm/src/pyvm.rs
+++ b/tests/semgrep/fixtures/rust/packages/doeff-vm/src/pyvm.rs
@@ -1,0 +1,5 @@
+pub fn build_traceback_data_bad() -> Option<()> {
+    let serialized: Result<(), ()> = Err(());
+    serialized.ok()?;
+    Some(())
+}

--- a/tests/semgrep/fixtures/rust/packages/doeff-vm/src/vm.rs
+++ b/tests/semgrep/fixtures/rust/packages/doeff-vm/src/vm.rs
@@ -1,0 +1,13 @@
+pub struct VM;
+
+impl VM {
+    fn current_segment_mut(&mut self) -> Option<u8> {
+        None
+    }
+
+    fn maybe_skip_bad(&mut self) {
+        if let Some(segment) = self.current_segment_mut() {
+            let _ = segment;
+        }
+    }
+}

--- a/tests/semgrep/test_vm_failfast_semgrep_rules.py
+++ b/tests/semgrep/test_vm_failfast_semgrep_rules.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _semgrep_rule_ids(config: Path, target: str, *, cwd: Path) -> set[str]:
+    semgrep_bin = shutil.which("semgrep")
+    if semgrep_bin is None:
+        pytest.skip("semgrep is not installed")
+
+    completed = subprocess.run(
+        [semgrep_bin, "--config", str(config), "--json", target],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode not in {0, 1}:
+        raise AssertionError(f"semgrep failed:\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+
+    payload = json.loads(completed.stdout)
+    return {result["check_id"] for result in payload.get("results", [])}
+
+
+def _has_rule(check_ids: set[str], expected_rule_id: str) -> bool:
+    suffix = f".{expected_rule_id}"
+    return any(check_id == expected_rule_id or check_id.endswith(suffix) for check_id in check_ids)
+
+
+def test_vm_failfast_rust_rules_detect_known_bad_examples() -> None:
+    fixture_root = REPO_ROOT / "tests/semgrep/fixtures/rust"
+    check_ids = _semgrep_rule_ids(
+        REPO_ROOT / "packages/doeff-vm/.semgrep.yaml",
+        "packages/doeff-vm/src",
+        cwd=fixture_root,
+    )
+
+    expected = {
+        "no-bare-ok-in-handler-can-handle",
+        "no-silent-if-let-current-segment",
+        "no-bare-ok-in-traceback-build",
+    }
+    assert all(_has_rule(check_ids, rule_id) for rule_id in expected)
+
+
+def test_vm_failfast_python_rules_detect_known_bad_examples() -> None:
+    fixture_root = REPO_ROOT / "tests/semgrep/fixtures/python"
+    check_ids = _semgrep_rule_ids(
+        REPO_ROOT / ".semgrep.yaml",
+        "doeff",
+        cwd=fixture_root,
+    )
+
+    expected = {
+        "no-silent-except-in-traceback",
+        "no-silent-except-return-none",
+    }
+    assert all(_has_rule(check_ids, rule_id) for rule_id in expected)


### PR DESCRIPTION
## Summary
- add 3 Rust semgrep regression guards to `packages/doeff-vm/.semgrep.yaml` for VM-FAILFAST-001A/B/C
- add 2 Python semgrep regression guards to `.semgrep.yaml` for silent `except` return patterns
- add `tests/semgrep/` fixtures + pytest harness to verify all five new rule IDs trigger on known-bad samples
- remove `.ok()?` fall-throughs from traceback serialization path in `packages/doeff-vm/src/pyvm.rs` and keep explicit warning logs before graceful fallback

## Issue
- VM-FAILFAST-001D

## Acceptance Evidence
- [x] 3 new Rust semgrep rules added to `packages/doeff-vm/.semgrep.yaml`
- [x] 2 new Python semgrep rules added to `.semgrep.yaml`
- [x] Each new rule has known-bad regression fixtures under `tests/semgrep/fixtures/`
- [x] Rule regression verification test passes:
  - `uv run pytest tests/semgrep/test_vm_failfast_semgrep_rules.py`
  - Result: `2 passed`
- [x] Rust rulepack scan passes:
  - `uv run semgrep --config packages/doeff-vm/.semgrep.yaml packages/doeff-vm/src/ --error`
  - Result: `0 findings`
- [x] Full test suite passes after required rebuild:
  - `make sync`
  - `uv run pytest`
  - Result: `665 passed, 21 warnings`

## Notes on Existing Repository Baseline
- `make lint-semgrep` currently fails with pre-existing unrelated findings in this branch baseline:
  - Result: `67 findings` (for example `doeff-no-typing-any-in-public-api`, `doeff-no-print-in-core`, `doeff-no-sleep-in-tests`, etc.)
- `uv run semgrep --config .semgrep.yaml doeff/ --error` also reports pre-existing findings:
  - Result: `40 findings`
- These failures are outside VM-FAILFAST-001D scope; new fail-fast rules themselves are validated by dedicated fixtures/tests and by the Rust rulepack zero-finding scan above.
