### PR TITLE
MIGRATE-PASS-005: remove effect args from Delegate/Pass

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -35,6 +35,20 @@ rules:
       category: vm-protocol
       issue: VM-PROTO-006
 
+  - id: doeff-no-effect-substitution-on-forward
+    pattern-either:
+      - pattern: yield Delegate($ARG)
+      - pattern: yield Pass($ARG)
+    message: |
+      Delegate() and Pass() do not accept effect arguments.
+      Use the 3-step decomposition: yield the substituted effect directly,
+      then Resume(k, result).
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: architecture
+      issue: MIGRATE-PASS-005
+
   - id: doeff-no-python-side-cancel-state
     patterns:
       - pattern-either:

--- a/packages/doeff-sim/src/doeff_sim/handlers/deterministic.py
+++ b/packages/doeff-sim/src/doeff_sim/handlers/deterministic.py
@@ -194,8 +194,8 @@ def deterministic_sim_handler(
     def handler(effect: Any, k: Any):
         replacement: WriterTellEffect | None = maybe_format_writer_message(effect)
         if replacement is not None:
-            yield Delegate(replacement)
-            return
+            formatted_result: Any = yield replacement
+            return (yield Resume(k, formatted_result))
 
         if _is_delay_effect(effect):
             delay_seconds: float = _extract_delay_seconds(effect)

--- a/tests/core/test_vm_proto_002_doeff_generator_construction.py
+++ b/tests/core/test_vm_proto_002_doeff_generator_construction.py
@@ -68,7 +68,7 @@ def test_with_handler_wraps_generator_handler_returns_as_doeff_generator() -> No
     def handler(effect, k):
         if False:  # pragma: no cover
             yield
-        return doeff_vm.Delegate(effect)
+        return doeff_vm.Delegate()
 
     control = doeff_vm.WithHandler(handler, doeff_vm.Perform(Ask("x")))
     wrapped = control.handler(Ask("x"), None)


### PR DESCRIPTION
## Summary
- Removed `effect` constructor arguments from Rust VM primitives `Delegate` and `Pass`.
- Updated dispatch classification so `Delegate`/`Pass` always forward the current dispatch-stack effect.
- Migrated the deterministic simulation writer-formatting path to the explicit 3-step decomposition (`yield effect` then `Resume(k, result)`).
- Migrated the VM substitution test to the same 3-step decomposition.
- Added a semgrep rule to forbid `yield Delegate($ARG)` / `yield Pass($ARG)`.
- Updated affected core tests to match the new constructor contract.

## Files changed
- `.semgrep.yaml`
- `packages/doeff-vm/src/pyvm.rs`
- `packages/doeff-sim/src/doeff_sim/handlers/deterministic.py`
- `packages/doeff-vm/tests/test_pyvm.py`
- `tests/core/test_pass_primitive.py`
- `tests/core/test_vm_proto_002_doeff_generator_construction.py`

## Acceptance criteria evidence (MIGRATE-PASS-005)
- [x] `Delegate()` and `Pass()` accept no arguments (Python + Rust)
  - Rust constructors now use `#[pyo3(signature = ())]` and no `effect` field.
  - Verified via runtime check:
    - `doeff.Delegate() -> Delegate`
    - `doeff.Pass() -> Pass`
    - `doeff_vm.Delegate() -> Delegate`
    - `doeff_vm.Pass() -> Pass`

- [x] `Delegate(some_effect)` and `Pass(some_effect)` raise `TypeError`
  - Verified via runtime check:
    - `doeff.Delegate(arg) -> TypeError`
    - `doeff.Pass(arg) -> TypeError`
    - `doeff_vm.Delegate(arg) -> TypeError`
    - `doeff_vm.Pass(arg) -> TypeError`
  - Also covered by `packages/doeff-vm/tests/test_pyvm.py::test_delegate_and_pass_reject_effect_arguments`.

- [x] doeff-sim handler uses 3-step decomposition
  - `packages/doeff-sim/src/doeff_sim/handlers/deterministic.py` now does:
    - `formatted_result = yield replacement`
    - `return (yield Resume(k, formatted_result))`

- [x] `test_pyvm.py` uses 3-step decomposition
  - `packages/doeff-vm/tests/test_pyvm.py::test_delegate_substitution_via_reperform_and_resume` now does:
    - `substituted = yield SecondCustomEffect(...)`
    - `return (yield VMResume(k, substituted))`

- [x] Semgrep rule prevents reintroduction
  - Added rule `doeff-no-effect-substitution-on-forward` in `.semgrep.yaml`.
  - Verified with focused semgrep run:
    - `uv run semgrep --config /tmp/migrate-pass-005-semgrep.yaml doeff packages tests`
    - Result: `Findings: 0`.

- [x] `make sync && uv run pytest` passes
  - `make sync` passed (rebuilt `doeff-vm` via maturin).
  - `uv run pytest` passed: `666 passed`.

- [ ] `make lint` (semgrep portion) passes
  - `make lint-semgrep` currently fails with pre-existing repository-wide findings (65) unrelated to this migration (examples/public API rules, etc.).
  - Focused rule validation for this migration passes as shown above.

## Validation commands run
```bash
make sync
uv run pytest
uv run pytest tests/core/test_pass_primitive.py \
  tests/core/test_vm_proto_002_doeff_generator_construction.py \
  packages/doeff-vm/tests/test_pyvm.py::test_transfer_abandons_handler \
  packages/doeff-vm/tests/test_pyvm.py::test_delegate_substitution_via_reperform_and_resume \
  packages/doeff-vm/tests/test_pyvm.py::test_delegate_and_pass_reject_effect_arguments \
  packages/doeff-sim/tests/test_composition.py::test_log_formatter_decorates_tell_messages -v
make lint-semgrep
uv run semgrep --config /tmp/migrate-pass-005-semgrep.yaml doeff packages tests
```

Refs: MIGRATE-PASS-005
