### PR TITLE
Fix scheduler preemption handoff for promise wakeups

### DIFF
--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -38,11 +38,19 @@ pub enum DoCtrl {
         continuation: Continuation,
         value: Value,
     },
+    ResumeThenTransfer {
+        continuation: Continuation,
+        value: Value,
+    },
     Transfer {
         continuation: Continuation,
         value: Value,
     },
     TransferThrow {
+        continuation: Continuation,
+        exception: PyException,
+    },
+    TransferThrowThenTransfer {
         continuation: Continuation,
         exception: PyException,
     },
@@ -129,6 +137,13 @@ impl DoCtrl {
                 continuation: continuation.clone(),
                 value: value.clone(),
             },
+            DoCtrl::ResumeThenTransfer {
+                continuation,
+                value,
+            } => DoCtrl::ResumeThenTransfer {
+                continuation: continuation.clone(),
+                value: value.clone(),
+            },
             DoCtrl::Transfer {
                 continuation,
                 value,
@@ -140,6 +155,13 @@ impl DoCtrl {
                 continuation,
                 exception,
             } => DoCtrl::TransferThrow {
+                continuation: continuation.clone(),
+                exception: exception.clone_ref(py),
+            },
+            DoCtrl::TransferThrowThenTransfer {
+                continuation,
+                exception,
+            } => DoCtrl::TransferThrowThenTransfer {
                 continuation: continuation.clone(),
                 exception: exception.clone_ref(py),
             },

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -2749,9 +2749,7 @@ mod tests {
     fn test_pass_outside_dispatch_context_is_error() {
         Python::attach(|py| {
             let pyvm = PyVM { vm: VM::new() };
-            let obj = Bound::new(py, PyPass::new())
-                .unwrap()
-                .into_any();
+            let obj = Bound::new(py, PyPass::new()).unwrap().into_any();
             let yielded = pyvm.classify_yielded(py, &obj);
             assert!(yielded.is_err(), "Pass outside dispatch context must error");
         });

--- a/packages/doeff-vm/src/vm.rs
+++ b/packages/doeff-vm/src/vm.rs
@@ -2022,8 +2022,10 @@ impl VM {
             DoCtrl::FlatMap { .. } => "HandleYield(FlatMap)",
             DoCtrl::Perform { .. } => "HandleYield(Perform)",
             DoCtrl::Resume { .. } => "HandleYield(Resume)",
+            DoCtrl::ResumeThenTransfer { .. } => "HandleYield(ResumeThenTransfer)",
             DoCtrl::Transfer { .. } => "HandleYield(Transfer)",
             DoCtrl::TransferThrow { .. } => "HandleYield(TransferThrow)",
+            DoCtrl::TransferThrowThenTransfer { .. } => "HandleYield(TransferThrowThenTransfer)",
             DoCtrl::WithHandler { .. } => "HandleYield(WithHandler)",
             DoCtrl::Delegate { .. } => "HandleYield(Delegate)",
             DoCtrl::Pass { .. } => "HandleYield(Pass)",
@@ -2378,6 +2380,10 @@ impl VM {
                 continuation,
                 value,
             } => self.handle_yield_resume(continuation, value),
+            DoCtrl::ResumeThenTransfer {
+                continuation,
+                value,
+            } => self.handle_yield_resume_then_transfer(continuation, value),
             DoCtrl::Transfer {
                 continuation,
                 value,
@@ -2386,6 +2392,10 @@ impl VM {
                 continuation,
                 exception,
             } => self.handle_yield_transfer_throw(continuation, exception),
+            DoCtrl::TransferThrowThenTransfer {
+                continuation,
+                exception,
+            } => self.handle_yield_transfer_throw_then_transfer(continuation, exception),
             DoCtrl::WithHandler {
                 handler,
                 expr,
@@ -2466,11 +2476,27 @@ impl VM {
         self.handle_resume(continuation, value)
     }
 
+    fn handle_yield_resume_then_transfer(
+        &mut self,
+        continuation: Continuation,
+        value: Value,
+    ) -> StepEvent {
+        self.handle_resume(continuation, value)
+    }
+
     fn handle_yield_transfer(&mut self, continuation: Continuation, value: Value) -> StepEvent {
         self.handle_transfer(continuation, value)
     }
 
     fn handle_yield_transfer_throw(
+        &mut self,
+        continuation: Continuation,
+        exception: PyException,
+    ) -> StepEvent {
+        self.handle_transfer_throw(continuation, exception)
+    }
+
+    fn handle_yield_transfer_throw_then_transfer(
         &mut self,
         continuation: Continuation,
         exception: PyException,

--- a/tests/effects/test_spawn_priority.py
+++ b/tests/effects/test_spawn_priority.py
@@ -11,8 +11,11 @@ from doeff import (
     PRIORITY_IDLE,
     PRIORITY_NORMAL,
     Await,
+    CompletePromise,
+    CreatePromise,
     Gather,
     Spawn,
+    Wait,
     async_run,
     default_async_handlers,
     default_handlers,
@@ -106,6 +109,138 @@ def test_deterministic_ordering_within_priority() -> None:
     result = run(program(), handlers=default_handlers())
     assert _result_is_ok(result)
     assert result.value == ("one", "two", "three")
+
+
+def test_spawn_higher_priority_preempts_current() -> None:
+    events: list[str] = []
+
+    @do
+    def normal_task():
+        events.append("normal-runs")
+        return "done"
+
+    @do
+    def idle_task():
+        events.append("idle-before-spawn")
+        task = yield Spawn(normal_task(), priority=PRIORITY_NORMAL)
+        events.append("idle-after-spawn")
+        return (yield Wait(task))
+
+    @do
+    def program():
+        idle = yield Spawn(idle_task(), priority=PRIORITY_IDLE)
+        return (yield Wait(idle))
+
+    result = run(program(), handlers=default_handlers())
+    assert _result_is_ok(result)
+    assert result.value == "done"
+    assert events == ["idle-before-spawn", "normal-runs", "idle-after-spawn"]
+
+
+def test_complete_promise_preempts_if_woken_task_higher_priority() -> None:
+    events: list[str] = []
+
+    @do
+    def waiter_task(target_promise, waiter_started):
+        events.append("normal-before-wait")
+        yield CompletePromise(waiter_started, None)
+        value = yield Wait(target_promise.future)
+        events.append("normal-after-wait")
+        return value
+
+    @do
+    def idle_completer(target_promise, release_promise, idle_started):
+        yield CompletePromise(idle_started, None)
+        _ = yield Wait(release_promise.future)
+        events.append("idle-before-complete")
+        yield CompletePromise(target_promise, "done")
+        events.append("idle-after-complete")
+        return "idle-done"
+
+    @do
+    def program():
+        target_promise = yield CreatePromise()
+        release_promise = yield CreatePromise()
+        idle_started = yield CreatePromise()
+        waiter_started = yield CreatePromise()
+
+        idle_task = yield Spawn(
+            idle_completer(target_promise, release_promise, idle_started),
+            priority=PRIORITY_IDLE,
+        )
+        _ = yield Wait(idle_started.future)
+
+        waiter_task_handle = yield Spawn(
+            waiter_task(target_promise, waiter_started),
+            priority=PRIORITY_NORMAL,
+        )
+        _ = yield Wait(waiter_started.future)
+
+        yield CompletePromise(release_promise, None)
+        _ = yield Wait(idle_task)
+        _ = yield Wait(waiter_task_handle)
+        return tuple(events)
+
+    result = run(program(), handlers=default_handlers())
+    assert _result_is_ok(result)
+    assert result.value == (
+        "normal-before-wait",
+        "idle-before-complete",
+        "normal-after-wait",
+        "idle-after-complete",
+    )
+
+
+def test_same_priority_spawn_does_not_preempt() -> None:
+    events: list[str] = []
+
+    @do
+    def spawned():
+        events.append("spawned-runs")
+        return "done"
+
+    @do
+    def spawner():
+        events.append("spawner-before")
+        task = yield Spawn(spawned(), priority=PRIORITY_NORMAL)
+        events.append("spawner-after")
+        return (yield Wait(task))
+
+    @do
+    def program():
+        task = yield Spawn(spawner(), priority=PRIORITY_NORMAL)
+        return (yield Wait(task))
+
+    result = run(program(), handlers=default_handlers())
+    assert _result_is_ok(result)
+    assert result.value == "done"
+    assert events == ["spawner-before", "spawner-after", "spawned-runs"]
+
+
+def test_lower_priority_spawn_does_not_preempt() -> None:
+    events: list[str] = []
+
+    @do
+    def spawned():
+        events.append("idle-runs")
+        return "done"
+
+    @do
+    def spawner():
+        events.append("normal-before")
+        task = yield Spawn(spawned(), priority=PRIORITY_IDLE)
+        events.append("normal-after")
+        return (yield Wait(task))
+
+    @do
+    def program():
+        task = yield Spawn(spawner(), priority=PRIORITY_NORMAL)
+        return (yield Wait(task))
+
+    result = run(program(), handlers=default_handlers())
+    assert _result_is_ok(result)
+    assert result.value == "done"
+    assert events == ["normal-before", "normal-after", "idle-runs"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep strict higher-priority-only preemption for `Spawn`, `CompletePromise`, and `FailPromise`
- DRY promise-resolution preemption logic via `handle_promise_resolution(...)`
- fix end-to-end preemption handoff for started continuations by adding non-terminal VM control paths (`ResumeThenTransfer`, `TransferThrowThenTransfer`) so scheduler can observe task completion before returning control
- extend scheduler preemptive-transfer phase tracking so the parked caller can be resumed and still be marked done correctly

## Validation
- `cd packages/doeff-vm && cargo fmt`
- `cd packages/doeff-vm && cargo test priority`
- `cd packages/doeff-vm && cargo test`
- `make sync`
- `uv run pytest tests/effects/test_spawn_priority.py -v`
- `uv run pytest`
- `uv run semgrep --config .semgrep.yaml packages/doeff-vm/src/scheduler.rs tests/effects/test_spawn_priority.py`