### PR TITLE
♻️ Rename LLMStructuredOutput → LLMStructuredQuery

### DIFF
--- a/examples/llm_multi_provider_stacking.py
+++ b/examples/llm_multi_provider_stacking.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from doeff_gemini.handlers import gemini_mock_handler
-from doeff_llm.effects import LLMChat, LLMStructuredOutput
+from doeff_llm.effects import LLMChat, LLMStructuredQuery
 from doeff_openai.handlers import (
     MockOpenAIConfig,
     MockOpenAIState,
@@ -24,7 +24,7 @@ class AnalysisResult(BaseModel):
 
 @do
 def workflow() -> EffectGenerator[dict[str, Any]]:
-    analysis = yield LLMStructuredOutput(
+    analysis = yield LLMStructuredQuery(
         messages=[{"role": "user", "content": "Analyze this change"}],
         response_format=AnalysisResult,
         model="gpt-4o",

--- a/packages/doeff-gemini/src/doeff_gemini/effects/structured.py
+++ b/packages/doeff-gemini/src/doeff_gemini/effects/structured.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 
-from doeff_llm.effects import LLMStructuredOutput
+from doeff_llm.effects import LLMStructuredQuery
 
 
 @dataclass(frozen=True, kw_only=True)
-class GeminiStructuredOutput(LLMStructuredOutput):
-    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredOutput`."""
+class GeminiStructuredOutput(LLMStructuredQuery):
+    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredQuery`."""
 
     def __post_init__(self) -> None:
         warnings.warn(
-            "GeminiStructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredOutput instead.",
+            "GeminiStructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredQuery instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/packages/doeff-gemini/src/doeff_gemini/handlers/production.py
+++ b/packages/doeff-gemini/src/doeff_gemini/handlers/production.py
@@ -15,7 +15,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 from PIL import Image
 
@@ -149,7 +149,7 @@ def _streaming_chat_impl(effect: LLMStreamingChat | LLMChat) -> EffectGenerator[
 
 
 @do
-def _structured_impl(effect: LLMStructuredOutput) -> EffectGenerator[Any]:
+def _structured_impl(effect: LLMStructuredQuery) -> EffectGenerator[Any]:
     prompt = _messages_to_prompt(effect.messages)
     max_output_tokens = effect.max_tokens if effect.max_tokens is not None else 2048
     return (
@@ -350,7 +350,7 @@ def production_handlers(
     *,
     chat_impl: Callable[[LLMChat], EffectGenerator[str]] | None = None,
     streaming_chat_impl: Callable[[LLMStreamingChat | LLMChat], EffectGenerator[str]] | None = None,
-    structured_impl: Callable[[LLMStructuredOutput], EffectGenerator[Any]] | None = None,
+    structured_impl: Callable[[LLMStructuredQuery], EffectGenerator[Any]] | None = None,
     embedding_impl: Callable[
         [LLMEmbedding],
         EffectGenerator[list[float] | list[list[float]]],
@@ -385,7 +385,7 @@ def production_handlers(
         value = yield active_streaming_chat_impl(effect)
         return (yield Resume(k, value))
 
-    def handle_structured(effect: LLMStructuredOutput | GeminiStructuredOutput, k):
+    def handle_structured(effect: LLMStructuredQuery | GeminiStructuredOutput, k):
         if not _is_gemini_model(effect.model):
             yield Delegate()
             return
@@ -414,7 +414,7 @@ def production_handlers(
         GeminiEmbedding: handle_embedding,
         LLMChat: handle_chat,
         LLMStreamingChat: handle_streaming_chat,
-        LLMStructuredOutput: handle_structured,
+        LLMStructuredQuery: handle_structured,
         LLMEmbedding: handle_embedding,
         ImageGenerate: handle_image_generate,
         ImageEdit: handle_image_edit,
@@ -435,7 +435,7 @@ def gemini_production_handler(effect: Any, k: Any):
                 return (yield Resume(k, value))
             value = yield _chat_impl(effect)
             return (yield Resume(k, value))
-    elif isinstance(effect, LLMStructuredOutput | GeminiStructuredOutput) and _is_gemini_model(
+    elif isinstance(effect, LLMStructuredQuery | GeminiStructuredOutput) and _is_gemini_model(
         effect.model
     ):
         value = yield _structured_impl(effect)

--- a/packages/doeff-gemini/src/doeff_gemini/handlers/testing.py
+++ b/packages/doeff-gemini/src/doeff_gemini/handlers/testing.py
@@ -14,7 +14,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 from PIL import Image as PILImage
 
@@ -89,7 +89,7 @@ class MockGeminiHandler:
         signature = _message_signature(effect.messages)
         return f"{self.default_chat_response}:{signature}"
 
-    def handle_structured(self, effect: LLMStructuredOutput) -> Any:
+    def handle_structured(self, effect: LLMStructuredQuery) -> Any:
         configured = self.structured_responses.get(effect.response_format)
         if configured is None:
             configured = self._build_default_structured_payload(effect.response_format)
@@ -200,7 +200,7 @@ def mock_handlers(
             return
         return (yield Resume(k, active_handler.handle_chat(effect)))
 
-    def handle_structured(effect: LLMStructuredOutput | GeminiStructuredOutput, k):
+    def handle_structured(effect: LLMStructuredQuery | GeminiStructuredOutput, k):
         if not _is_gemini_model(effect.model):
             yield Pass()
             return
@@ -225,7 +225,7 @@ def mock_handlers(
         GeminiEmbedding: handle_embedding,
         LLMChat: handle_chat,
         LLMStreamingChat: handle_streaming_chat,
-        LLMStructuredOutput: handle_structured,
+        LLMStructuredQuery: handle_structured,
         LLMEmbedding: handle_embedding,
         ImageGenerate: handle_image_generate,
         ImageEdit: handle_image_edit,
@@ -259,7 +259,7 @@ def gemini_mock_handler(
         _is_gemini_model(effect.model)
     ):
         return (yield Resume(k, active_handler.handle_chat(effect)))
-    if isinstance(effect, LLMStructuredOutput | GeminiStructuredOutput) and _is_gemini_model(
+    if isinstance(effect, LLMStructuredQuery | GeminiStructuredOutput) and _is_gemini_model(
         effect.model
     ):
         return (yield Resume(k, active_handler.handle_structured(effect)))

--- a/packages/doeff-gemini/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-gemini/tests/unit/test_effect_handlers.py
@@ -72,7 +72,7 @@ from doeff_image.effects import ImageEdit
 from doeff_image.effects import ImageEdit as UnifiedImageEdit
 from doeff_image.effects import ImageGenerate as UnifiedImageGenerate
 from doeff_image.types import ImageResult
-from doeff_llm.effects import LLMChat, LLMEmbedding, LLMStructuredOutput
+from doeff_llm.effects import LLMChat, LLMEmbedding, LLMStructuredQuery
 from doeff_gemini.effects import (
     GeminiChat,
     GeminiEmbedding,
@@ -99,7 +99,7 @@ def _domain_program() -> EffectGenerator[dict[str, Any]]:
         model="gemini-test-model",
         temperature=0.1,
     )
-    structured = yield LLMStructuredOutput(
+    structured = yield LLMStructuredQuery(
         messages=[{"role": "user", "content": "Return a hummingbird fact"}],
         response_format=FunFact,
         model="gemini-test-model",
@@ -124,7 +124,7 @@ def test_effect_exports() -> None:
     assert ImportedImageEdit is GeminiImageEdit
     assert ImportedStructured is GeminiStructuredOutput
     assert issubclass(GeminiChat, LLMChat)
-    assert issubclass(GeminiStructuredOutput, LLMStructuredOutput)
+    assert issubclass(GeminiStructuredOutput, LLMStructuredQuery)
     assert issubclass(GeminiEmbedding, LLMEmbedding)
 
 

--- a/packages/doeff-llm/src/doeff_llm/__init__.py
+++ b/packages/doeff-llm/src/doeff_llm/__init__.py
@@ -1,6 +1,6 @@
 """Provider-agnostic LLM effects and shared types for doeff."""
 
-from .effects import LLMChat, LLMEmbedding, LLMStreamingChat, LLMStructuredOutput
+from .effects import LLMChat, LLMEmbedding, LLMStreamingChat, LLMStructuredQuery
 from .types import CostInfo, Message, TokenUsage
 
 __all__ = [
@@ -8,7 +8,7 @@ __all__ = [
     "LLMChat",
     "LLMEmbedding",
     "LLMStreamingChat",
-    "LLMStructuredOutput",
+    "LLMStructuredQuery",
     "Message",
     "TokenUsage",
 ]

--- a/packages/doeff-llm/src/doeff_llm/effects/__init__.py
+++ b/packages/doeff-llm/src/doeff_llm/effects/__init__.py
@@ -2,11 +2,11 @@
 
 from .chat import LLMChat, LLMStreamingChat
 from .embedding import LLMEmbedding
-from .structured import LLMStructuredOutput
+from .structured import LLMStructuredQuery
 
 __all__ = [
     "LLMChat",
     "LLMEmbedding",
     "LLMStreamingChat",
-    "LLMStructuredOutput",
+    "LLMStructuredQuery",
 ]

--- a/packages/doeff-llm/src/doeff_llm/effects/structured.py
+++ b/packages/doeff-llm/src/doeff_llm/effects/structured.py
@@ -1,4 +1,4 @@
-"""Provider-agnostic structured-output effects."""
+"""Provider-agnostic structured-extraction effects."""
 
 from __future__ import annotations
 
@@ -9,8 +9,8 @@ from doeff import EffectBase
 
 
 @dataclass(frozen=True, kw_only=True)
-class LLMStructuredOutput(EffectBase):
-    """Request provider-agnostic structured output."""
+class LLMStructuredQuery(EffectBase):
+    """Extract structured data from an LLM (provider-agnostic)."""
 
     messages: list[dict[str, Any]]
     response_format: type[Any]
@@ -20,5 +20,5 @@ class LLMStructuredOutput(EffectBase):
 
 
 __all__ = [
-    "LLMStructuredOutput",
+    "LLMStructuredQuery",
 ]

--- a/packages/doeff-openai/src/doeff_openai/effects/structured.py
+++ b/packages/doeff-openai/src/doeff_openai/effects/structured.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 
-from doeff_llm.effects import LLMStructuredOutput
+from doeff_llm.effects import LLMStructuredQuery
 
 
 @dataclass(frozen=True, kw_only=True)
-class StructuredOutput(LLMStructuredOutput):
-    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredOutput`."""
+class StructuredOutput(LLMStructuredQuery):
+    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredQuery`."""
 
     def __post_init__(self) -> None:
         warnings.warn(
-            "StructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredOutput instead.",
+            "StructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredQuery instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/packages/doeff-openai/src/doeff_openai/handlers/production.py
+++ b/packages/doeff-openai/src/doeff_openai/handlers/production.py
@@ -9,7 +9,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 
 from doeff import Delegate, Resume
@@ -69,7 +69,7 @@ def _handle_embedding(effect: LLMEmbedding, k):
     return (yield Resume(k, response))
 
 
-def _handle_structured_output(effect: LLMStructuredOutput, k):
+def _handle_structured_output(effect: LLMStructuredQuery, k):
     api_params = yield build_api_parameters(
         model=effect.model,
         messages=effect.messages,
@@ -101,7 +101,7 @@ def openai_production_handler(effect: Any, k: Any):
             return (yield from _handle_chat_completion(effect, k))
     elif isinstance(effect, LLMEmbedding | Embedding) and _is_openai_model(effect.model):
         return (yield from _handle_embedding(effect, k))
-    elif isinstance(effect, LLMStructuredOutput | StructuredOutput) and _is_openai_model(
+    elif isinstance(effect, LLMStructuredQuery | StructuredOutput) and _is_openai_model(
         effect.model
     ):
         return (yield from _handle_structured_output(effect, k))
@@ -118,7 +118,7 @@ def production_handlers() -> dict[type[Any], ProtocolHandler]:
         LLMChat: _handle_chat_completion,
         LLMStreamingChat: _handle_streaming_chat_completion,
         LLMEmbedding: _handle_embedding,
-        LLMStructuredOutput: _handle_structured_output,
+        LLMStructuredQuery: _handle_structured_output,
     }
 
 

--- a/packages/doeff-openai/src/doeff_openai/handlers/testing.py
+++ b/packages/doeff-openai/src/doeff_openai/handlers/testing.py
@@ -11,7 +11,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 
 from doeff import Pass, Resume
@@ -329,7 +329,7 @@ def _handle_embedding(
 
 
 def _handle_structured_output(
-    effect: LLMStructuredOutput,
+    effect: LLMStructuredQuery,
     k: Any,
     *,
     config: MockOpenAIConfig,
@@ -392,7 +392,7 @@ def openai_mock_handler(
         return (
             yield from _handle_embedding(effect, k, config=resolved_config, state=resolved_state)
         )
-    elif isinstance(effect, LLMStructuredOutput | StructuredOutput) and _is_openai_model(
+    elif isinstance(effect, LLMStructuredQuery | StructuredOutput) and _is_openai_model(
         effect.model
     ):
         return (
@@ -446,7 +446,7 @@ def mock_handlers(
             yield from _handle_embedding(effect, k, config=resolved_config, state=resolved_state)
         )
 
-    def handle_structured(effect: LLMStructuredOutput | StructuredOutput, k: Any):
+    def handle_structured(effect: LLMStructuredQuery | StructuredOutput, k: Any):
         if not _is_openai_model(effect.model):
             yield Pass()
             return
@@ -464,7 +464,7 @@ def mock_handlers(
         LLMChat: handle_chat,
         LLMStreamingChat: handle_stream,
         LLMEmbedding: handle_embedding,
-        LLMStructuredOutput: handle_structured,
+        LLMStructuredQuery: handle_structured,
     }
 
 

--- a/packages/doeff-openai/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-openai/tests/unit/test_effect_handlers.py
@@ -9,7 +9,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 from doeff_openai.effects import (
     ChatCompletion as ChatCompletionEffect,
@@ -67,7 +67,7 @@ def test_effect_exports() -> None:
     assert issubclass(ChatCompletionEffect, LLMChat)
     assert issubclass(StreamingChatCompletion, LLMStreamingChat)
     assert issubclass(EmbeddingEffect, LLMEmbedding)
-    assert issubclass(StructuredOutput, LLMStructuredOutput)
+    assert issubclass(StructuredOutput, LLMStructuredQuery)
 
 
 def test_deprecated_effect_aliases_emit_warnings() -> None:
@@ -104,7 +104,7 @@ def test_handler_exports() -> None:
     assert LLMChat in handler_map
     assert LLMStreamingChat in handler_map
     assert LLMEmbedding in handler_map
-    assert LLMStructuredOutput in handler_map
+    assert LLMStructuredQuery in handler_map
 
     assert callable(mock_handlers)
 
@@ -143,7 +143,7 @@ async def test_mock_handlers_support_handler_swapping_for_all_effects() -> None:
             input=["alpha", "beta"],
             model="text-embedding-3-small",
         )
-        structured = yield LLMStructuredOutput(
+        structured = yield LLMStructuredQuery(
             messages=[{"role": "user", "content": "Return structured output"}],
             response_format=StructuredAnswer,
             model="gpt-4o-mini",

--- a/packages/doeff-openrouter/src/doeff_openrouter/effects/structured.py
+++ b/packages/doeff-openrouter/src/doeff_openrouter/effects/structured.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 
-from doeff_llm.effects import LLMStructuredOutput
+from doeff_llm.effects import LLMStructuredQuery
 
 
 @dataclass(frozen=True, kw_only=True)
-class RouterStructuredOutput(LLMStructuredOutput):
-    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredOutput`."""
+class RouterStructuredOutput(LLMStructuredQuery):
+    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredQuery`."""
 
     def __post_init__(self) -> None:
         warnings.warn(
-            "RouterStructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredOutput instead.",
+            "RouterStructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredQuery instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/packages/doeff-openrouter/src/doeff_openrouter/handlers/production.py
+++ b/packages/doeff-openrouter/src/doeff_openrouter/handlers/production.py
@@ -9,7 +9,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 
 from doeff import Delegate, Resume
@@ -56,7 +56,7 @@ def _handle_streaming_chat(effect: LLMStreamingChat | LLMChat, k):
     return (yield Resume(k, response))
 
 
-def _handle_structured_output(effect: LLMStructuredOutput, k):
+def _handle_structured_output(effect: LLMStructuredQuery, k):
     _validate_response_format(effect.response_format)
     response_format_payload = build_response_format_payload(effect.response_format)
     raw_response = yield chat_completion(
@@ -81,7 +81,7 @@ def openrouter_production_handler(effect: Any, k: Any):
         if effect.stream:
             return (yield from _handle_streaming_chat(effect, k))
         return (yield from _handle_chat(effect, k))
-    if isinstance(effect, LLMStructuredOutput | RouterStructuredOutput):
+    if isinstance(effect, LLMStructuredQuery | RouterStructuredOutput):
         return (yield from _handle_structured_output(effect, k))
     if isinstance(effect, LLMEmbedding):
         yield Delegate()
@@ -98,7 +98,7 @@ def production_handlers() -> dict[type[Any], ProtocolHandler]:
         RouterStructuredOutput: _handle_structured_output,
         LLMChat: _handle_chat,
         LLMStreamingChat: _handle_streaming_chat,
-        LLMStructuredOutput: _handle_structured_output,
+        LLMStructuredQuery: _handle_structured_output,
     }
 
 

--- a/packages/doeff-openrouter/src/doeff_openrouter/handlers/testing.py
+++ b/packages/doeff-openrouter/src/doeff_openrouter/handlers/testing.py
@@ -11,7 +11,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 
 from doeff import Pass, Resume
@@ -68,7 +68,7 @@ class MockOpenRouterRuntime:
     calls: list[dict[str, Any]] = field(default_factory=list)
 
 
-def _coerce_structured_payload(effect: LLMStructuredOutput, payload: Any) -> Any:
+def _coerce_structured_payload(effect: LLMStructuredQuery, payload: Any) -> Any:
     if isinstance(payload, effect.response_format):
         return payload
     if isinstance(payload, dict):
@@ -106,7 +106,7 @@ def mock_handlers(
         )
         return (yield Resume(k, copy.deepcopy(active_runtime.streaming_response)))
 
-    def handle_structured_output(effect: LLMStructuredOutput | RouterStructuredOutput, k):
+    def handle_structured_output(effect: LLMStructuredQuery | RouterStructuredOutput, k):
         active_runtime.calls.append(
             {
                 "effect": effect.__class__.__name__,
@@ -126,7 +126,7 @@ def mock_handlers(
         RouterStructuredOutput: handle_structured_output,
         LLMChat: handle_chat,
         LLMStreamingChat: handle_streaming_chat,
-        LLMStructuredOutput: handle_structured_output,
+        LLMStructuredQuery: handle_structured_output,
     }
 
 
@@ -159,7 +159,7 @@ def openrouter_mock_handler(
         if effect.stream:
             return (yield Resume(k, copy.deepcopy(active_runtime.streaming_response)))
         return (yield Resume(k, copy.deepcopy(active_runtime.chat_response)))
-    if isinstance(effect, LLMStructuredOutput | RouterStructuredOutput):
+    if isinstance(effect, LLMStructuredQuery | RouterStructuredOutput):
         active_runtime.calls.append(
             {
                 "effect": effect.__class__.__name__,

--- a/packages/doeff-openrouter/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-openrouter/tests/unit/test_effect_handlers.py
@@ -11,7 +11,7 @@ from doeff_llm.effects import (
     LLMChat,
     LLMEmbedding,
     LLMStreamingChat,
-    LLMStructuredOutput,
+    LLMStructuredQuery,
 )
 from doeff_openrouter.effects import (
     RouterChat,
@@ -46,7 +46,7 @@ def test_effect_exports():
     assert ImportedRouterStructuredOutput is RouterStructuredOutput
     assert issubclass(RouterChat, LLMChat)
     assert issubclass(RouterStreamingChat, LLMStreamingChat)
-    assert issubclass(RouterStructuredOutput, LLMStructuredOutput)
+    assert issubclass(RouterStructuredOutput, LLMStructuredQuery)
 
 
 def test_deprecated_effect_aliases_emit_warnings() -> None:
@@ -102,7 +102,7 @@ def test_mock_handlers_return_configured_deterministic_payloads() -> None:
             messages=[{"role": "user", "content": "stream"}],
             model="openai/gpt-4o-mini",
         )
-        structured = yield LLMStructuredOutput(
+        structured = yield LLMStructuredQuery(
             messages=[{"role": "user", "content": "return JSON"}],
             response_format=StructuredPayload,
             model="openai/gpt-4o-mini",
@@ -121,7 +121,7 @@ def test_mock_handlers_return_configured_deterministic_payloads() -> None:
     assert [call["effect"] for call in runtime.calls] == [
         "LLMChat",
         "LLMStreamingChat",
-        "LLMStructuredOutput",
+        "LLMStructuredQuery",
     ]
 
 
@@ -166,7 +166,7 @@ def test_handler_swapping_between_mock_and_production(monkeypatch) -> None:
             model="openai/gpt-4o-mini",
             temperature=0.3,
         )
-        structured = yield LLMStructuredOutput(
+        structured = yield LLMStructuredQuery(
             messages=[{"role": "user", "content": "return JSON"}],
             response_format=StructuredPayload,
             model="openai/gpt-4o-mini",

--- a/tests/test_llm_multi_provider_handlers.py
+++ b/tests/test_llm_multi_provider_handlers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from doeff_gemini.handlers import gemini_mock_handler
-from doeff_llm.effects import LLMChat, LLMStructuredOutput
+from doeff_llm.effects import LLMChat, LLMStructuredQuery
 from doeff_openai.handlers import (
     MockOpenAIConfig,
     MockOpenAIState,
@@ -49,7 +49,7 @@ def test_multi_model_workflow_routes_to_openai_then_gemini() -> None:
 
     @do
     def workflow() -> EffectGenerator[dict[str, Any]]:
-        analysis = yield LLMStructuredOutput(
+        analysis = yield LLMStructuredQuery(
             messages=[{"role": "user", "content": "Analyze this code"}],
             response_format=AnalysisResult,
             model="gpt-4o",


### PR DESCRIPTION
## Summary
- Rename `LLMStructuredOutput` → `LLMStructuredQuery` across all LLM provider packages to better reflect intent (querying for structured data extraction, not just output formatting)
- Updated core `doeff-llm`, `doeff-openai`, `doeff-gemini`, `doeff-openrouter`: effects, production/testing handlers, unit tests, and examples
- Deprecated provider-specific aliases (`StructuredOutput`, `GeminiStructuredOutput`, `RouterStructuredOutput`) now reference the new name

## Validation
- All 21 affected tests pass (8 gemini + 5 openai + 6 openrouter + 2 multi-provider)
- Pyright clean on changed files (6 pre-existing warnings unrelated to this change)
- Pure rename: 65 insertions, 65 deletions, zero functional changes