### PR TITLE
Purge handler_map APIs and migrate to WithHandler handlers

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -1423,6 +1423,84 @@ rules:
     metadata:
       category: public-api-removed
 
+  - id: doeff-no-handler-map-run-helpers
+    pattern-regex: '\b(run_with_handler_map|async_run_with_handler_map|_wrap_with_handler_map|merge_handler_maps)\b'
+    paths:
+      include:
+        - "**/doeff/**/*.py"
+        - "**/packages/**/src/**/*.py"
+        - "**/packages/**/examples/**/*.py"
+        - "**/tests/**/*.py"
+    message: |
+      handler_map bridging APIs are removed.
+      Use explicit WithHandler stacking:
+        program = WithHandler(handler, program)
+        result = run(program, handlers=default_handlers())
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: handler-stacking
+      issue: ISSUE-HANDLER-MAP-001
+
+  - id: doeff-no-handler-map-param-annotation
+    pattern-regex: 'def\s+\w+\([^)]*\bhandler_map\s*:\s*dict\[type'
+    paths:
+      include:
+        - "**/doeff/**/*.py"
+        - "**/packages/**/src/**/*.py"
+    message: |
+      Type-keyed handler_map annotations are banned.
+      Accept a protocol handler callable and stack with WithHandler instead.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: handler-stacking
+      issue: ISSUE-HANDLER-MAP-001
+
+  - id: doeff-no-handler-factory-dict-return
+    pattern-regex: 'def\s+(production_handlers|mock_handlers|[A-Za-z0-9_]*handlers)\s*\([^)]*\)\s*->\s*dict\[type'
+    paths:
+      include:
+        - "**/doeff/**/*.py"
+        - "**/packages/**/src/**/*.py"
+    message: |
+      Handler factories must return a protocol handler callable, not dict[type, handler].
+      Compose handlers by WithHandler stacking.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: handler-stacking
+      issue: ISSUE-HANDLER-MAP-001
+
+  - id: doeff-no-effect-keyed-handler-dict-literal
+    patterns:
+      - pattern-either:
+          - pattern: |
+              return {
+                $EFFECT: $HANDLER,
+                ...
+              }
+          - pattern: |
+              $HANDLERS = {
+                $EFFECT: $HANDLER,
+                ...
+              }
+      - metavariable-regex:
+          metavariable: $EFFECT
+          regex: '^[A-Z][A-Za-z0-9_]*$'
+    paths:
+      include:
+        - "**/doeff/**/*.py"
+        - "**/packages/**/src/**/handlers/**/*.py"
+    message: |
+      Type-keyed handler dict literals are banned.
+      Build a single protocol handler with isinstance(...) checks and Delegate/Pass forwarding.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: handler-stacking
+      issue: ISSUE-HANDLER-MAP-001
+
   - id: doeff-no-safe-use-try
     pattern-regex: '(from\s+doeff[.\w]*\s+import\s+[^#\n]*\bSafe\b|yield\s+Safe\()'
     paths:

--- a/doeff/nonblocking_await.py
+++ b/doeff/nonblocking_await.py
@@ -117,6 +117,10 @@ def get_loop() -> asyncio.AbstractEventLoop:
 
 def _nonblocking_await_handler(effect: PythonAsyncioAwaitEffect, k: Any):
     """Handle PythonAsyncioAwaitEffect by submitting to the background loop."""
+    if not isinstance(effect, PythonAsyncioAwaitEffect):
+        yield doeff_vm.Pass()
+        return
+
     promise = yield CreateExternalPromise()
 
     awaitable = effect.awaitable
@@ -148,11 +152,11 @@ def with_nonblocking_await(program: Any) -> Any:
     awaitables on a persistent background event loop, communicating results
     via ExternalPromise.
     """
-    from doeff.rust_vm import _wrap_with_handler_map
+    from doeff import WithHandler
 
-    return _wrap_with_handler_map(
-        program,
-        {PythonAsyncioAwaitEffect: _nonblocking_await_handler},
+    return WithHandler(
+        handler=_nonblocking_await_handler,
+        expr=program,
     )
 
 

--- a/packages/doeff-agentic/docs/testing-guide.md
+++ b/packages/doeff-agentic/docs/testing-guide.md
@@ -149,8 +149,7 @@ Test workflow patterns using mock handlers that don't require real agent session
 
 ```python
 from datetime import datetime, timezone
-from doeff import default_handlers, do, run
-from doeff_agentic.runtime import with_handler_map
+from doeff import WithHandler, default_handlers, do, run
 
 from doeff_agentic import (
     AgenticCreateSession,
@@ -240,7 +239,7 @@ def test_workflow():
 
 # Run the test
 handlers = mock_handler()
-program = with_handler_map(test_workflow(), handlers)
+program = WithHandler(handlers, test_workflow())
 result = run(program, handlers=default_handlers())
 print(f"Result: {result}")
 ```

--- a/packages/doeff-agentic/examples/01_hello_agent.py
+++ b/packages/doeff-agentic/examples/01_hello_agent.py
@@ -47,8 +47,7 @@ def hello_agent():
 
 if __name__ == "__main__":
     import asyncio
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         print("Starting hello_agent workflow...")
@@ -58,10 +57,12 @@ if __name__ == "__main__":
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            hello_agent(),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                hello_agent(),
+            ),
         )
         result = await async_run(program, handlers=default_handlers())
 

--- a/packages/doeff-agentic/examples/02_agent_with_status.py
+++ b/packages/doeff-agentic/examples/02_agent_with_status.py
@@ -61,8 +61,7 @@ def agent_with_status():
 
 if __name__ == "__main__":
     import asyncio
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         print("Starting agent_with_status workflow...")
@@ -75,10 +74,12 @@ if __name__ == "__main__":
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            agent_with_status(),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                agent_with_status(),
+            ),
         )
         result = await async_run(program, handlers=default_handlers())
 

--- a/packages/doeff-agentic/examples/03_sequential_agents.py
+++ b/packages/doeff-agentic/examples/03_sequential_agents.py
@@ -67,8 +67,7 @@ def research_and_summarize(topic: str):
 
 if __name__ == "__main__":
     import asyncio
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         topic = "functional programming"
@@ -79,10 +78,12 @@ if __name__ == "__main__":
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            research_and_summarize(topic),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                research_and_summarize(topic),
+            ),
         )
         result = await async_run(program, handlers=default_handlers())
 

--- a/packages/doeff-agentic/examples/04_conditional_flow.py
+++ b/packages/doeff-agentic/examples/04_conditional_flow.py
@@ -79,8 +79,7 @@ def review_and_maybe_fix(code: str):
 
 if __name__ == "__main__":
     import asyncio
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         # Code with issues to review
@@ -101,10 +100,12 @@ def calculate_average(numbers):
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            review_and_maybe_fix(sample_code),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                review_and_maybe_fix(sample_code),
+            ),
         )
         result = await async_run(program, handlers=default_handlers())
 

--- a/packages/doeff-agentic/examples/05_human_in_loop.py
+++ b/packages/doeff-agentic/examples/05_human_in_loop.py
@@ -163,8 +163,7 @@ def draft_with_approval(task: str):
 
 if __name__ == "__main__":
     import asyncio
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         task = "Write a haiku about programming"
@@ -176,10 +175,12 @@ if __name__ == "__main__":
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            draft_with_approval(task),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                draft_with_approval(task),
+            ),
         )
         result = await async_run(program, handlers=default_handlers())
 

--- a/packages/doeff-agentic/examples/06_parallel_agents.py
+++ b/packages/doeff-agentic/examples/06_parallel_agents.py
@@ -115,8 +115,7 @@ def multi_perspective_analysis(topic: str):
 
 if __name__ == "__main__":
     import asyncio
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         topic = "AI code assistants"
@@ -127,10 +126,12 @@ if __name__ == "__main__":
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            multi_perspective_analysis(topic),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                multi_perspective_analysis(topic),
+            ),
         )
         result = await async_run(program, handlers=default_handlers())
 

--- a/packages/doeff-agentic/examples/07_pr_review_workflow.py
+++ b/packages/doeff-agentic/examples/07_pr_review_workflow.py
@@ -209,8 +209,7 @@ if __name__ == "__main__":
     import asyncio
     import sys
 
-    from doeff import async_run, default_handlers
-    from doeff_agentic.runtime import with_handler_maps
+    from doeff import WithHandler, async_run, default_handlers
 
     async def main():
         # Use a sample PR URL or accept from command line
@@ -227,10 +226,12 @@ if __name__ == "__main__":
         # Merge preset handlers with opencode handlers
         # Preset provides: slog display (WriterTellEffect) + config (Ask preset.*)
         # OpenCode provides: agent session management effects
-        program = with_handler_maps(
-            pr_review_workflow(pr_url, require_approval),
+        program = WithHandler(
             preset_handlers(),
-            opencode_handler(),
+            WithHandler(
+                opencode_handler(),
+                pr_review_workflow(pr_url, require_approval),
+            ),
         )
 
         try:

--- a/packages/doeff-agentic/examples/08_testing_with_mocks.py
+++ b/packages/doeff-agentic/examples/08_testing_with_mocks.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import sys
 
-from doeff import default_handlers, do, run
+from doeff import WithHandler, default_handlers, do, run
 from doeff_agentic import (
     AgenticCreateSession,
     AgenticGetMessages,
@@ -23,7 +23,6 @@ from doeff_agentic import (
     AgenticSendMessage,
 )
 from doeff_agentic.handlers.testing import MockAgenticHandler, mock_handlers
-from doeff_agentic.runtime import with_handler_map
 
 
 @do
@@ -41,9 +40,9 @@ def mock_conversation():
 
 
 def main() -> int:
-    # runtime.with_handler_map composes typed handlers via WithHandler internally.
+    # Compose the mock protocol handler directly with WithHandler.
     handler_impl = MockAgenticHandler(workflow_name="mock-example")
-    program = with_handler_map(mock_conversation(), mock_handlers(handler_impl))
+    program = WithHandler(mock_handlers(handler_impl), mock_conversation())
     result = run(program, handlers=default_handlers())
 
     if result.is_err():

--- a/packages/doeff-agentic/examples/README.md
+++ b/packages/doeff-agentic/examples/README.md
@@ -31,14 +31,13 @@ For parallel execution, use core doeff effects: `Spawn` + `Gather` (see example 
 
 ```python
 import asyncio
-from doeff import async_run, default_handlers, do
+from doeff import WithHandler, async_run, default_handlers, do
 from doeff_agentic import (
     AgenticCreateSession,
     AgenticSendMessage,
     AgenticGetMessages,
 )
 from doeff_agentic.opencode_handler import opencode_handler
-from doeff_agentic.runtime import with_handler_map
 
 @do
 def my_workflow():
@@ -59,7 +58,7 @@ def my_workflow():
 # Run the workflow
 async def main():
     handlers = opencode_handler()
-    program = with_handler_map(my_workflow(), handlers)
+    program = WithHandler(handlers, my_workflow())
     result = await async_run(program, handlers=default_handlers())
     print(result.value)  # Access the result value
 
@@ -73,7 +72,7 @@ When workflows fail, use `result.format()` to get rich debugging information:
 ```python
 async def main():
     handlers = opencode_handler()
-    program = with_handler_map(my_workflow(), handlers)
+    program = WithHandler(handlers, my_workflow())
     result = await async_run(program, handlers=default_handlers())
 
     if result.is_err():
@@ -157,7 +156,7 @@ uv run python examples/07_pr_review_workflow.py https://github.com/org/repo/pull
 ```
 
 ### 08. Testing with Mock Handlers
-Effect-based deterministic workflow using `MockAgenticHandler` + `with_handler_map`.
+Effect-based deterministic workflow using `MockAgenticHandler` + `WithHandler`.
 ```bash
 uv run python examples/08_testing_with_mocks.py
 ```

--- a/packages/doeff-agentic/src/doeff_agentic/handlers/__init__.py
+++ b/packages/doeff-agentic/src/doeff_agentic/handlers/__init__.py
@@ -32,8 +32,8 @@ def production_handlers(
     port: int | None = None,
     startup_timeout: float = 30.0,
     working_dir: str | None = None,
-) -> dict[type, Any]:
-    """Create production handler maps for new agentic effects."""
+) -> Any:
+    """Create a production protocol handler for new agentic effects."""
     if backend == "opencode":
         return opencode_handler(
             server_url=server_url,

--- a/packages/doeff-agentic/src/doeff_agentic/runtime.py
+++ b/packages/doeff-agentic/src/doeff_agentic/runtime.py
@@ -1,50 +1,19 @@
-"""Runtime helpers for composing handler maps with doeff_vm public APIs."""
+"""Runtime helpers for explicit handler stacking with ``WithHandler``."""
 
 from __future__ import annotations
 
-import inspect
-from collections.abc import Callable, Mapping
+from collections.abc import Sequence
 from typing import Any
 
-from doeff import Delegate, WithHandler
-
-HandlerProtocol = Callable[[Any, Any], Any]
-HandlerMap = Mapping[type, HandlerProtocol]
+from doeff import WithHandler
 
 
-def with_handler_map(program: Any, handler_map: HandlerMap) -> Any:
-    """Wrap a program with a typed effect-handler map."""
-    typed_handlers = tuple(handler_map.items())
-
-    def dispatch_handler(effect: Any, k):
-        for effect_type, handler in typed_handlers:
-            if isinstance(effect, effect_type):
-                result = handler(effect, k)
-                if inspect.isgenerator(result):
-                    return (yield from result)
-                return result
-        yield Delegate()
-
-    return WithHandler(handler=dispatch_handler, expr=program)
+def with_handlers(program: Any, handlers: Sequence[Any]) -> Any:
+    """Wrap ``program`` with handlers ordered from outer to inner."""
+    wrapped = program
+    for handler in reversed(tuple(handlers)):
+        wrapped = WithHandler(handler=handler, expr=wrapped)
+    return wrapped
 
 
-def merge_handler_maps(*handler_maps: HandlerMap) -> dict[type, HandlerProtocol]:
-    """Merge handler maps left-to-right, with later maps overriding earlier ones."""
-    merged: dict[type, HandlerProtocol] = {}
-    for handler_map in handler_maps:
-        merged.update(handler_map)
-    return merged
-
-
-def with_handler_maps(program: Any, *handler_maps: HandlerMap) -> Any:
-    """Wrap a program with multiple handler maps using merge order semantics."""
-    return with_handler_map(program, merge_handler_maps(*handler_maps))
-
-
-__all__ = [
-    "HandlerMap",
-    "HandlerProtocol",
-    "merge_handler_maps",
-    "with_handler_map",
-    "with_handler_maps",
-]
+__all__ = ["with_handlers"]

--- a/packages/doeff-agentic/tests/test_handlers_module.py
+++ b/packages/doeff-agentic/tests/test_handlers_module.py
@@ -10,9 +10,8 @@ from doeff_agentic.effects import (
     AgenticSendMessage,
 )
 from doeff_agentic.handlers import mock_handlers, production_handlers
-from doeff_agentic.runtime import with_handler_map
 
-from doeff import default_handlers, do, run
+from doeff import WithHandler, default_handlers, do, run
 
 
 def test_handlers_init_exports_required_factory_functions() -> None:
@@ -21,11 +20,10 @@ def test_handlers_init_exports_required_factory_functions() -> None:
     assert callable(mock_handlers)
 
 
-def test_production_handlers_factory_returns_typed_map() -> None:
-    """Production factory returns a handler map without side effects at construction time."""
-    handler_map = production_handlers()
-    assert isinstance(handler_map, dict)
-    assert AgenticCreateSession in handler_map
+def test_production_handlers_factory_returns_protocol_handler() -> None:
+    """Production factory returns a protocol handler without side effects at construction time."""
+    handler = production_handlers()
+    assert callable(handler)
 
 
 def test_mock_handlers_execute_simple_workflow() -> None:
@@ -43,7 +41,7 @@ def test_mock_handlers_execute_simple_workflow() -> None:
         status = yield AgenticGetSessionStatus(session_id=session.id)
         return msg.role, messages[-1].role, status.value
 
-    program = with_handler_map(workflow(), mock_handlers())
+    program = WithHandler(mock_handlers(), workflow())
     result = run(program, handlers=default_handlers())
 
     assert result.value == ("user", "assistant", "done")

--- a/packages/doeff-agents/examples/01_basic_session.py
+++ b/packages/doeff-agents/examples/01_basic_session.py
@@ -128,7 +128,7 @@ async def run_with_mock_handlers() -> None:
 
     result = await run_program(
         basic_session_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -160,7 +160,7 @@ async def run_with_real_tmux() -> None:
     
     result = await run_program(
         basic_session_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=agent_effectful_handlers(),
     )
     print(f"\nResult: {result}")

--- a/packages/doeff-agents/examples/02_context_manager.py
+++ b/packages/doeff-agents/examples/02_context_manager.py
@@ -184,7 +184,7 @@ async def run_interactive_example() -> None:
 
     result = await run_program(
         run_with_bracket(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -214,7 +214,7 @@ async def run_exception_demo() -> None:
 
     result = await run_program(
         demonstrate_exception_safety(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -242,7 +242,7 @@ async def run_with_real_tmux() -> None:
     
     result = await run_program(
         run_with_bracket(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=agent_effectful_handlers(),
     )
     print(f"\nResult: {result}")

--- a/packages/doeff-agents/examples/03_async_monitoring.py
+++ b/packages/doeff-agents/examples/03_async_monitoring.py
@@ -218,7 +218,7 @@ async def run_with_mock_runtime() -> None:
 
     result = await run_program(
         single_session_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -261,7 +261,7 @@ async def run_truly_parallel() -> None:
 
         run_result = await run_program(
             single_session_workflow(session_name, config),
-            handler_maps=(preset_handlers(),),
+            scoped_handlers=(preset_handlers(),),
             custom_handlers=mock_agent_handlers(),
         )
         if hasattr(type(run_result), "value"):
@@ -303,7 +303,7 @@ async def run_with_real_tmux() -> None:
     
     result = await run_program(
         single_session_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=agent_effectful_handlers(),
     )
     print(f"\nResult: {result}")

--- a/packages/doeff-agents/examples/04_custom_adapter.py
+++ b/packages/doeff-agents/examples/04_custom_adapter.py
@@ -296,7 +296,7 @@ async def run_with_mock_handlers() -> None:
 
     result = await run_program(
         custom_adapter_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -323,7 +323,7 @@ async def run_with_real_tmux() -> None:
 
     result = await run_program(
         custom_adapter_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=agent_effectful_handlers(),
     )
     print(f"\nResult: {result}")

--- a/packages/doeff-agents/examples/05_status_callbacks.py
+++ b/packages/doeff-agents/examples/05_status_callbacks.py
@@ -311,7 +311,7 @@ async def run_monitored_session() -> None:
 
     result = await run_program(
         monitored_session_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -364,7 +364,7 @@ async def run_with_real_tmux() -> None:
 
     result = await run_program(
         notification_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=agent_effectful_handlers(),
     )
     print(f"\nResult: {result}")

--- a/packages/doeff-agents/examples/06_effects_api.py
+++ b/packages/doeff-agents/examples/06_effects_api.py
@@ -250,7 +250,7 @@ async def run_direct_effects_example() -> None:
 
     result = await run_program(
         direct_effects_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -280,7 +280,7 @@ async def run_high_level_programs_example() -> None:
 
     result = await run_program(
         high_level_programs_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -310,7 +310,7 @@ async def run_bracket_pattern_example() -> None:
 
     result = await run_program(
         bracket_pattern_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     print(f"\nResult: {result}")
@@ -342,7 +342,7 @@ async def run_testing_example() -> None:
 
     result = await run_program(
         testable_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=mock_agent_handlers(),
     )
     result_value = result.value if hasattr(type(result), "value") else result
@@ -385,7 +385,7 @@ async def run_with_real_tmux() -> None:
     
     result = await run_program(
         direct_effects_workflow(session_name, config),
-        handler_maps=(preset_handlers(),),
+        scoped_handlers=(preset_handlers(),),
         custom_handlers=agent_effectful_handlers(),
     )
     

--- a/packages/doeff-agents/examples/_runtime.py
+++ b/packages/doeff-agents/examples/_runtime.py
@@ -2,46 +2,26 @@
 
 from __future__ import annotations
 
-import inspect
 from collections.abc import Callable, Sequence
 from typing import Any
 
-from doeff import Delegate, WithHandler, async_run, default_handlers
+from doeff import WithHandler, async_run, default_handlers
 
 ProtocolHandler = Callable[[Any, Any], Any]
-HandlerMap = dict[type, ProtocolHandler]
-
-
-def _wrap_with_handler_map(program: Any, handler_map: HandlerMap) -> Any:
-    wrapped = program
-
-    for effect_type, handler in reversed(list(handler_map.items())):
-
-        def typed_handler(effect, k, _effect_type=effect_type, _handler=handler):
-            if isinstance(effect, _effect_type):
-                result = _handler(effect, k)
-                if inspect.isgenerator(result):
-                    return (yield from result)
-                return result
-            yield Delegate()
-
-        wrapped = WithHandler(handler=typed_handler, expr=wrapped)
-
-    return wrapped
 
 
 async def run_program(
     program: Any,
     *,
-    handler_maps: Sequence[HandlerMap] = (),
     custom_handlers: Sequence[ProtocolHandler] = (),
+    scoped_handlers: Sequence[ProtocolHandler] = (),
     store: dict[str, Any] | None = None,
     env: dict[str, Any] | None = None,
 ) -> Any:
-    """Run a program with handler-map wrappers plus protocol handlers."""
+    """Run a program with explicit ``WithHandler`` stacking plus runtime handlers."""
     wrapped = program
-    for handler_map in handler_maps:
-        wrapped = _wrap_with_handler_map(wrapped, handler_map)
+    for handler in reversed(tuple(scoped_handlers)):
+        wrapped = WithHandler(handler=handler, expr=wrapped)
 
     return await async_run(
         wrapped,

--- a/packages/doeff-conductor/tests/test_effects.py
+++ b/packages/doeff-conductor/tests/test_effects.py
@@ -28,16 +28,9 @@ class TestEffectBase:
         """Test that effects follow the protocol."""
         effect = CreateWorktree()
 
-        # Should have created_at attribute
-        assert hasattr(effect, "created_at")
-
-        # Should have with_created_at method
-        new_effect = effect.with_created_at("test")
-        assert new_effect.created_at == "test"
-
-        # Should have intercept method
+        # Should have intercept method (no nested programs for conductor effects).
         intercepted = effect.intercept(lambda x: x)
-        assert intercepted is effect  # No nested programs to intercept
+        assert intercepted is effect
 
         # Effect should be a first-class doeff effect value
         from doeff import EffectBase
@@ -464,24 +457,6 @@ class TestModuleExports:
         from doeff_conductor.handlers.testing import MockConductorRuntime
 
         runtime = MockConductorRuntime(tmp_path)
-        expected_effects = {
-            CreateWorktree,
-            MergeBranches,
-            DeleteWorktree,
-            CreateIssue,
-            ListIssues,
-            GetIssue,
-            ResolveIssue,
-            RunAgent,
-            SpawnAgent,
-            SendMessage,
-            WaitForStatus,
-            CaptureOutput,
-            Commit,
-            Push,
-            CreatePR,
-            MergePR,
-        }
 
         production = production_handlers(
             worktree_handler=runtime,
@@ -491,5 +466,5 @@ class TestModuleExports:
         )
         mocked = mock_handlers(runtime=runtime)
 
-        assert expected_effects.issubset(set(production))
-        assert expected_effects.issubset(set(mocked))
+        assert callable(production)
+        assert callable(mocked)

--- a/packages/doeff-conductor/tests/test_workflow_e2e.py
+++ b/packages/doeff-conductor/tests/test_workflow_e2e.py
@@ -206,6 +206,7 @@ class TestTemplateE2E:
         assert callable(func)
 
     def test_basic_pr_template_structure(self):
+        from doeff import ProgramBase
         from doeff_conductor.templates import basic_pr
         from doeff_conductor.types import Issue
 
@@ -219,4 +220,4 @@ class TestTemplateE2E:
         program = basic_pr(issue)
 
         assert program is not None
-        assert hasattr(program, "execution_kernel")
+        assert isinstance(program, ProgramBase)

--- a/packages/doeff-flow/tests/test_effect_handlers.py
+++ b/packages/doeff-flow/tests/test_effect_handlers.py
@@ -8,14 +8,20 @@ from pathlib import Path
 from doeff_flow.effects import TraceAnnotate, TraceCapture, TracePush, TraceSnapshot
 from doeff_flow.handlers import mock_handlers, production_handlers
 
-from doeff import do
-from doeff.rust_vm import run_with_handler_map
+from doeff import WithHandler, default_handlers, do, run
 
 
 def _read_entries(trace_dir: Path, workflow_id: str) -> list[dict]:
     trace_file = trace_dir / workflow_id / "trace.jsonl"
     assert trace_file.exists()
     return [json.loads(line) for line in trace_file.read_text().splitlines() if line.strip()]
+
+
+def _run_with_handler(program, handler):
+    return run(
+        WithHandler(handler, program),
+        handlers=default_handlers(),
+    )
 
 
 @do
@@ -44,7 +50,7 @@ def test_handler_exports():
 
 
 def test_mock_handlers_capture_in_memory() -> None:
-    result = run_with_handler_map(_trace_program(), mock_handlers())
+    result = _run_with_handler(_trace_program(), mock_handlers())
 
     assert result.is_ok()
     entries = result.value
@@ -56,7 +62,7 @@ def test_mock_handlers_capture_in_memory() -> None:
 
 def test_production_handlers_write_trace_file(tmp_path: Path) -> None:
     workflow_id = "trace-prod-test"
-    result = run_with_handler_map(
+    result = _run_with_handler(
         _trace_program(),
         production_handlers(workflow_id=workflow_id, trace_dir=tmp_path),
     )
@@ -77,11 +83,11 @@ def test_handler_swapping_changes_trace_side_effects(tmp_path: Path) -> None:
     trace_file = tmp_path / workflow_id / "trace.jsonl"
     assert not trace_file.exists()
 
-    mock_result = run_with_handler_map(_trace_program(), mock_handlers())
+    mock_result = _run_with_handler(_trace_program(), mock_handlers())
     assert mock_result.is_ok()
     assert not trace_file.exists()
 
-    prod_result = run_with_handler_map(
+    prod_result = _run_with_handler(
         _trace_program(),
         production_handlers(workflow_id=workflow_id, trace_dir=tmp_path),
     )

--- a/packages/doeff-git/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-git/tests/unit/test_effect_handlers.py
@@ -9,8 +9,7 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from doeff import do
-from doeff.rust_vm import run_with_handler_map
+from doeff import WithHandler, default_handlers, do, run
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "src"
 if str(PACKAGE_ROOT) not in sys.path:
@@ -25,6 +24,13 @@ from doeff_git.handlers import (
     production_handlers,
 )
 from doeff_git.types import MergeStrategy, PRHandle
+
+
+def _run_with_handler(program, handler):
+    return run(
+        WithHandler(handler, program),
+        handlers=default_handlers(),
+    )
 
 
 @do
@@ -52,7 +58,7 @@ def test_handler_exports() -> None:
 
 def test_mock_handlers_run_program() -> None:
     runtime = MockGitRuntime()
-    result = run_with_handler_map(
+    result = _run_with_handler(
         _mock_flow(Path("/tmp/mock-repo")),
         mock_handlers(runtime=runtime),
     )
@@ -211,7 +217,7 @@ def test_production_handlers_support_handler_swapping() -> None:
         pr = yield CreatePR(work_dir=Path("/tmp/repo"), title="Title")
         return sha, pr
 
-    result = run_with_handler_map(
+    result = _run_with_handler(
         flow(),
         production_handlers(local_handler=LocalStub(), github_handler=HostingStub()),
     )

--- a/packages/doeff-google-secret-manager/README.md
+++ b/packages/doeff-google-secret-manager/README.md
@@ -41,10 +41,10 @@ result = run_with_env(fetch_db_password())
 print("password length:", len(result.value))
 ```
 
-## Handler Map Usage
+## Handler Stacking Usage
 
 ```python
-from doeff import do, run_with_handler_map
+from doeff import WithHandler, default_handlers, do, run
 from doeff_google_secret_manager.handlers import production_handlers
 from doeff_secret.effects import GetSecret
 
@@ -54,9 +54,12 @@ def workflow():
     return (yield GetSecret(secret_id="db-password"))
 
 
-result = run_with_handler_map(
-    workflow(),
-    production_handlers(project="my-gcp-project"),
+result = run(
+    WithHandler(
+        production_handlers(project="my-gcp-project"),
+        workflow(),
+    ),
+    handlers=default_handlers(),
 )
 ```
 

--- a/packages/doeff-google-secret-manager/src/doeff_google_secret_manager/handlers/testing.py
+++ b/packages/doeff-google-secret-manager/src/doeff_google_secret_manager/handlers/testing.py
@@ -19,8 +19,8 @@ def mock_handlers(
     seed_data: Mapping[str, SeedValue] | None = None,
     project: str = "mock-project",
     store: InMemorySecretStore | None = None,
-) -> dict[type[Any], ProtocolHandler]:
-    """Build in-memory handler map for secret effects.
+) -> ProtocolHandler:
+    """Build an in-memory protocol handler for secret effects.
 
     Deprecated: use `doeff_secret.testing.in_memory_handlers(...)`.
     """

--- a/packages/doeff-openai/src/doeff_openai/handlers/production.py
+++ b/packages/doeff-openai/src/doeff_openai/handlers/production.py
@@ -108,18 +108,9 @@ def openai_production_handler(effect: Any, k: Any):
     yield Delegate()
 
 
-def production_handlers() -> dict[type[Any], ProtocolHandler]:
-    """Typed handler map for real OpenAI API execution."""
-    return {
-        ChatCompletion: _handle_chat_completion,
-        StreamingChatCompletion: _handle_streaming_chat_completion,
-        Embedding: _handle_embedding,
-        StructuredOutput: _handle_structured_output,
-        LLMChat: _handle_chat_completion,
-        LLMStreamingChat: _handle_streaming_chat_completion,
-        LLMEmbedding: _handle_embedding,
-        LLMStructuredOutput: _handle_structured_output,
-    }
+def production_handlers() -> ProtocolHandler:
+    """Protocol handler for real OpenAI API execution."""
+    return openai_production_handler
 
 
 __all__ = [

--- a/packages/doeff-openrouter/src/doeff_openrouter/handlers/production.py
+++ b/packages/doeff-openrouter/src/doeff_openrouter/handlers/production.py
@@ -89,17 +89,9 @@ def openrouter_production_handler(effect: Any, k: Any):
     yield Delegate()
 
 
-def production_handlers() -> dict[type[Any], ProtocolHandler]:
-    """Build handler map backed by the real OpenRouter client helpers."""
-
-    return {
-        RouterChat: _handle_chat,
-        RouterStreamingChat: _handle_streaming_chat,
-        RouterStructuredOutput: _handle_structured_output,
-        LLMChat: _handle_chat,
-        LLMStreamingChat: _handle_streaming_chat,
-        LLMStructuredOutput: _handle_structured_output,
-    }
+def production_handlers() -> ProtocolHandler:
+    """Build a protocol handler backed by the real OpenRouter client helpers."""
+    return openrouter_production_handler
 
 
 __all__ = [

--- a/packages/doeff-pinjected/src/doeff_pinjected/bridge.py
+++ b/packages/doeff-pinjected/src/doeff_pinjected/bridge.py
@@ -12,9 +12,8 @@ from typing import TypeVar, cast
 from loguru import logger
 from pinjected import AsyncResolver, Injected, IProxy
 
-from doeff import Effect, Program, RunResult
+from doeff import Effect, Program, RunResult, WithHandler, async_run, default_async_handlers
 from doeff.effects import AskEffect, GraphAnnotateEffect, GraphStepEffect, Intercept, Pure
-from doeff.rust_vm import async_run_with_handler_map
 from doeff_pinjected.effects import PinjectedResolve
 from doeff_pinjected.handlers import production_handlers
 
@@ -107,9 +106,12 @@ def program_to_injected(prog: Program[T]) -> Injected[T]:
 
         try:
             # Run with env containing the resolver for use by ask effects
-            result = await async_run_with_handler_map(
-                wrapped_program,
-                production_handlers(resolver=__resolver__),
+            result = await async_run(
+                WithHandler(
+                    production_handlers(resolver=__resolver__),
+                    wrapped_program,
+                ),
+                handlers=default_async_handlers(),
                 env={"__resolver__": __resolver__},
             )
         finally:
@@ -182,9 +184,12 @@ def program_to_injected_result(prog: Program[T]) -> Injected[RunResult[T]]:
 
         try:
             # Run with env containing the resolver for use by ask effects
-            result = await async_run_with_handler_map(
-                wrapped_program,
-                production_handlers(resolver=__resolver__),
+            result = await async_run(
+                WithHandler(
+                    production_handlers(resolver=__resolver__),
+                    wrapped_program,
+                ),
+                handlers=default_async_handlers(),
                 env={"__resolver__": __resolver__},
             )
         finally:

--- a/packages/doeff-preset/examples/01_basic_slog.py
+++ b/packages/doeff-preset/examples/01_basic_slog.py
@@ -12,8 +12,7 @@ Run:
 
 from doeff_preset import preset_handlers
 
-from doeff import do, slog
-from doeff.rust_vm import run_with_handler_map
+from doeff import WithHandler, default_handlers, do, run, slog
 
 
 @do
@@ -44,7 +43,10 @@ def main():
     """Run the basic slog example."""
     print("=== Basic slog Display Example ===\n")
 
-    result = run_with_handler_map(basic_workflow(), preset_handlers())
+    result = run(
+        WithHandler(preset_handlers(), basic_workflow()),
+        handlers=default_handlers(),
+    )
 
     print("\n=== Results ===")
     print(f"Return value: {result.value}")

--- a/packages/doeff-preset/examples/02_configuration.py
+++ b/packages/doeff-preset/examples/02_configuration.py
@@ -12,8 +12,7 @@ Run:
 
 from doeff_preset import preset_handlers
 
-from doeff import Ask, do, slog
-from doeff.rust_vm import run_with_handler_map
+from doeff import Ask, WithHandler, default_handlers, do, run, slog
 
 
 @do
@@ -47,7 +46,10 @@ def main():
     """Run configuration examples."""
     # Example 1: Default configuration
     print("=== Default Configuration ===\n")
-    result = run_with_handler_map(configurable_workflow(), preset_handlers())
+    result = run(
+        WithHandler(preset_handlers(), configurable_workflow()),
+        handlers=default_handlers(),
+    )
     print(f"\nConfig: {result.value}")
 
     # Example 2: Custom configuration
@@ -59,7 +61,10 @@ def main():
             "preset.log_format": "json",
         }
     )
-    result2 = run_with_handler_map(configurable_workflow(), custom_handlers)
+    result2 = run(
+        WithHandler(custom_handlers, configurable_workflow()),
+        handlers=default_handlers(),
+    )
     print(f"\nConfig: {result2.value}")
 
 

--- a/packages/doeff-preset/examples/05_async_runtime.py
+++ b/packages/doeff-preset/examples/05_async_runtime.py
@@ -13,8 +13,16 @@ import asyncio
 
 from doeff_preset import preset_handlers
 
-from doeff import Ask, do, slog
-from doeff.rust_vm import async_run_with_handler_map, run_with_handler_map
+from doeff import (
+    Ask,
+    WithHandler,
+    async_run,
+    default_async_handlers,
+    default_handlers,
+    do,
+    run,
+    slog,
+)
 
 
 @do
@@ -40,13 +48,19 @@ async def main():
 
     # Run with run()
     print("=== Running with run() ===\n")
-    sync_result = run_with_handler_map(async_workflow(), handlers)
+    sync_result = run(
+        WithHandler(handlers, async_workflow()),
+        handlers=default_handlers(),
+    )
     print(f"\nSync result: {sync_result.value}")
     print(f"Log entries: {len(sync_result.log)}")
 
     # Run with async_run()
     print("\n=== Running with async_run() ===\n")
-    async_result = await async_run_with_handler_map(async_workflow(), handlers)
+    async_result = await async_run(
+        WithHandler(handlers, async_workflow()),
+        handlers=default_async_handlers(),
+    )
     print(f"\nAsync result: {async_result.value}")
     print(f"Log entries: {len(async_result.log)}")
 

--- a/packages/doeff-preset/src/doeff_preset/__init__.py
+++ b/packages/doeff-preset/src/doeff_preset/__init__.py
@@ -6,7 +6,7 @@ experience for examples, demos, and rapid development.
 
 Example:
     >>> from doeff import do, slog
-    >>> from doeff.rust_vm import run_with_handler_map
+    >>> from doeff import WithHandler, default_handlers, run
     >>> from doeff_preset import preset_handlers
     >>>
     >>> @do
@@ -16,7 +16,10 @@ Example:
     ...     yield slog(step="done", msg="Workflow complete")
     ...     return "success"
     >>>
-    >>> result = run_with_handler_map(my_workflow(), preset_handlers())
+    >>> result = run(
+    ...     WithHandler(preset_handlers(), my_workflow()),
+    ...     handlers=default_handlers(),
+    ... )
     >>> # slog messages are displayed to console AND accumulated in log
 """
 
@@ -35,36 +38,14 @@ from doeff_preset.handlers import (
 
 def preset_handlers(
     config_defaults: dict[str, Any] | None = None,
-) -> dict[type, Any]:
-    """Return all preset handlers combined.
+) -> Any:
+    """Return the combined preset protocol handler.
 
     Args:
         config_defaults: Optional dict to override default preset.* config values.
 
     Returns:
-        Handler dict combining log display and config handlers.
-
-    Example:
-        >>> from doeff.rust_vm import run_with_handler_map
-        >>> from doeff_preset import preset_handlers
-        >>>
-        >>> result = run_with_handler_map(my_workflow(), preset_handlers())
-        >>>
-        >>> # With custom config
-        >>> custom = preset_handlers(config_defaults={"preset.log_level": "debug"})
-        >>> result = run_with_handler_map(my_workflow(), custom)
-
-    Handler Merge Pattern:
-        Preset handlers can be merged with domain-specific handlers:
-
-        >>> from doeff_preset import preset_handlers
-        >>> from my_domain import domain_handlers
-        >>>
-        >>> # Domain handlers win on conflict
-        >>> handlers = {**preset_handlers(), **domain_handlers()}
-        >>>
-        >>> # Preset handlers win on conflict
-        >>> handlers = {**domain_handlers(), **preset_handlers()}
+        Protocol handler combining log display and config behavior.
     """
     return production_handlers(config_defaults=config_defaults)
 

--- a/packages/doeff-preset/src/doeff_preset/handlers/production.py
+++ b/packages/doeff-preset/src/doeff_preset/handlers/production.py
@@ -5,18 +5,26 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from doeff import AskEffect, Pass, WriterTellEffect
 from doeff_preset.handlers.config import config_handlers
 from doeff_preset.handlers.log_display import log_display_handlers
 
 ProtocolHandler = Callable[[Any, Any], Any]
 
 
-def production_handlers(config_defaults: dict[str, Any] | None = None) -> dict[type[Any], Any]:
-    """Return production preset handlers (display + configuration)."""
-    return {
-        **log_display_handlers(),
-        **config_handlers(config_defaults),
-    }
+def production_handlers(config_defaults: dict[str, Any] | None = None) -> ProtocolHandler:
+    """Return the production preset protocol handler (display + configuration)."""
+    slog_handler = log_display_handlers()
+    ask_handler = config_handlers(config_defaults)
+
+    def handler(effect: Any, k: Any):
+        if isinstance(effect, WriterTellEffect):
+            return (yield from slog_handler(effect, k))
+        if isinstance(effect, AskEffect):
+            return (yield from ask_handler(effect, k))
+        yield Pass()
+
+    return handler
 
 
 __all__ = [

--- a/packages/doeff-preset/src/doeff_preset/handlers/testing.py
+++ b/packages/doeff-preset/src/doeff_preset/handlers/testing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from doeff import Delegate, WriterTellEffect
+from doeff import AskEffect, Pass, WriterTellEffect
 from doeff_preset.handlers.config import config_handlers
 
 ProtocolHandler = Callable[[Any, Any], Any]
@@ -14,24 +14,29 @@ ProtocolHandler = Callable[[Any, Any], Any]
 def _handle_tell_noop(effect: Any, _k):
     """Do not display structured logs during tests; delegate writer behavior."""
     if not isinstance(effect, WriterTellEffect):
-        yield Delegate()
+        yield Pass()
         return
-    yield Delegate()
+    yield Pass()
 
 
-def mock_log_display_handlers() -> dict[type[Any], Any]:
-    """Return no-op log display handlers for tests."""
-    return {
-        WriterTellEffect: _handle_tell_noop,
-    }
+def mock_log_display_handlers() -> ProtocolHandler:
+    """Return a no-op log display protocol handler for tests."""
+    return _handle_tell_noop
 
 
-def mock_handlers(config_defaults: dict[str, Any] | None = None) -> dict[type[Any], Any]:
-    """Return test preset handlers (no-op display + configuration)."""
-    return {
-        **mock_log_display_handlers(),
-        **config_handlers(config_defaults),
-    }
+def mock_handlers(config_defaults: dict[str, Any] | None = None) -> ProtocolHandler:
+    """Return the test preset protocol handler (no-op display + configuration)."""
+    slog_handler = mock_log_display_handlers()
+    ask_handler = config_handlers(config_defaults)
+
+    def handler(effect: Any, k: Any):
+        if isinstance(effect, WriterTellEffect):
+            return (yield from slog_handler(effect, k))
+        if isinstance(effect, AskEffect):
+            return (yield from ask_handler(effect, k))
+        yield Pass()
+
+    return handler
 
 
 __all__ = [

--- a/packages/doeff-secret/README.md
+++ b/packages/doeff-secret/README.md
@@ -34,11 +34,14 @@ def deploy_workflow():
 `doeff-secret` ships with an in-memory secret store for deterministic tests.
 
 ```python
-from doeff import run_with_handler_map
+from doeff import WithHandler, default_handlers, run
 from doeff_secret.testing import in_memory_handlers
 
 handlers = in_memory_handlers(seed_data={"db-password": "mock-pass"})
-result = run_with_handler_map(deploy_workflow(), handlers)
+result = run(
+    WithHandler(handlers, deploy_workflow()),
+    handlers=default_handlers(),
+)
 ```
 
 ## Environment Variable Fallback

--- a/packages/doeff-secret/tests/test_effect_handlers.py
+++ b/packages/doeff-secret/tests/test_effect_handlers.py
@@ -20,12 +20,18 @@ from doeff_secret.testing import (  # noqa: E402
 )
 
 from doeff import WithHandler, default_handlers, do, run  # noqa: E402
-from doeff.rust_vm import run_with_handler_map
 
 
 def _is_ok(run_result: Any) -> bool:
     checker = run_result.is_ok
     return checker() if callable(checker) else bool(checker)
+
+
+def _run_with_handler(program, handler):
+    return run(
+        WithHandler(handler, program),
+        handlers=default_handlers(),
+    )
 
 
 @do
@@ -50,7 +56,7 @@ def test_effect_exports() -> None:
 
 
 def test_in_memory_handlers_support_secret_crud() -> None:
-    result = run_with_handler_map(
+    result = _run_with_handler(
         _in_memory_program(),
         in_memory_handlers(seed_data={"seed-secret": "seed-value"}),
     )
@@ -79,7 +85,7 @@ def test_in_memory_handler_delegates_when_stacked() -> None:
 
 
 def test_env_var_handlers_resolve_normalized_secret_names() -> None:
-    result = run_with_handler_map(
+    result = _run_with_handler(
         _read_secret("db-password"),
         env_var_handlers(environ={"DB_PASSWORD": "from-env"}),
     )

--- a/tests/public_api/test_api_cleanup.py
+++ b/tests/public_api/test_api_cleanup.py
@@ -8,9 +8,6 @@ import pytest
 @pytest.mark.parametrize(
     "name",
     [
-        "wrap_with_handler_map",
-        "run_with_handler_map",
-        "async_run_with_handler_map",
         "run_program",
         "ProgramRunResult",
     ],
@@ -64,9 +61,6 @@ def test_internal_helpers_not_in_all() -> None:
     import doeff
 
     internals = [
-        "wrap_with_handler_map",
-        "run_with_handler_map",
-        "async_run_with_handler_map",
         "run_program",
         "ProgramRunResult",
         "DoCtrl",


### PR DESCRIPTION
## Summary

Implements ISSUE-HANDLER-MAP-001 by removing type-keyed handler map APIs and migrating package handlers/tests/examples/docs to Koka-style `WithHandler` stacking.

### Core/API removals
- Removed `run_with_handler_map`, `async_run_with_handler_map`, and `_wrap_with_handler_map` from `doeff/rust_vm.py`.
- Updated `doeff/nonblocking_await.py` to compose handlers via `WithHandler` directly.
- Updated public API cleanup tests accordingly.

### Package migration
- Migrated handler factories across affected packages from `dict[type, handler]` to protocol handlers compatible with `WithHandler`.
- Removed/rewrote adapter helper APIs centered on handler maps (`with_handler_map`, `merge_handler_maps`, `with_handler_maps`, `HandlerMap`) in `doeff-agentic` and related examples.
- Rewrote tests/docs/examples to use explicit handler stacking.

### Enforcement
- Added semgrep rules for banning legacy handler-map patterns:
  - `doeff-no-handler-map-run-helpers`
  - `doeff-no-handler-map-param-annotation`
  - `doeff-no-handler-factory-dict-return`
  - `doeff-no-effect-keyed-handler-dict-literal`

### Follow-up fixes during validation
- Fixed `doeff-preset` forwarding regressions by using `Pass` in pass-through paths.
- Updated stale conductor test assertions to current `EffectBase`/`ProgramBase` contracts.

## Validation Evidence

### Required acceptance validation
- `make sync` ✅
  - Completed successfully and rebuilt Rust VM via `maturin develop`.
- `uv run pytest` ✅
  - `674 passed, 21 warnings`.

### Additional targeted validation
- Remaining package tests from migration checklist ✅
  - `packages/doeff-secret/tests/test_effect_handlers.py`
  - `packages/doeff-google-secret-manager/tests/unit/test_effect_handlers.py`
  - `packages/doeff-gemini/tests/unit/test_effect_handlers.py`
  - `packages/doeff-seedream/tests/test_effect_handlers.py`
  - `packages/doeff-preset/tests/test_preset_handlers.py`
  - `packages/doeff-agentic/tests/test_handlers_module.py`
  - `packages/doeff-conductor/tests/test_effects.py`
  - `packages/doeff-conductor/tests/test_workflow_e2e.py`
- Focused semgrep run using only the 4 new ISSUE-HANDLER-MAP-001 rules ✅
  - `0 findings`.
- Legacy API/reference scans ✅
  - `No legacy API references found`
  - `No handler_map references found`

### Known baseline (pre-existing)
- `make lint` fails at Ruff with unrelated existing findings (`941 errors`).
- `make lint-semgrep` reports unrelated existing findings (`60 findings`).

## Issue

Closes ISSUE-HANDLER-MAP-001.
