### PR TITLE
Unify Expand into Eval(Apply) macro-expansion path

### DIFF
--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -72,7 +72,7 @@ class KleisliProgram(Generic[P, T]):
         return types.MethodType(self, instance)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Program[T]:
-        from doeff_vm import Apply, DoCtrlBase, Expand, Perform, Pure
+        from doeff_vm import Apply, DoCtrlBase, Perform, Pure
 
         from doeff.types import EffectBase
 
@@ -117,7 +117,7 @@ class KleisliProgram(Generic[P, T]):
                 raise TypeError(
                     "@do KleisliProgram is missing _doeff_generator_factory (DoeffGeneratorFn)"
                 )
-            return Expand(Pure(generator_factory), positional_args, keyword_args, metadata)
+            return Apply(Pure(generator_factory), positional_args, keyword_args, metadata)
         return Apply(Pure(self.func), positional_args, keyword_args, metadata)
 
     def partial(self, /, *args: P.args, **kwargs: P.kwargs) -> PartiallyAppliedKleisliProgram[P, T]:

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -97,6 +97,7 @@ pub enum DoCtrl {
         args: Vec<CallArg>,
         kwargs: Vec<(String, CallArg)>,
         metadata: CallMetadata,
+        evaluate_result: bool,
     },
     Expand {
         factory: CallArg,
@@ -229,11 +230,13 @@ impl DoCtrl {
                 args,
                 kwargs,
                 metadata,
+                evaluate_result,
             } => DoCtrl::Apply {
                 f: f.clone(),
                 args: args.clone(),
                 kwargs: kwargs.clone(),
                 metadata: metadata.clone(),
+                evaluate_result: *evaluate_result,
             },
             DoCtrl::Expand {
                 factory,

--- a/packages/doeff-vm/src/handler.rs
+++ b/packages/doeff-vm/src/handler.rs
@@ -164,6 +164,7 @@ fn rust_program_apply_expr(
         args: vec![],
         kwargs: vec![],
         metadata,
+        evaluate_result: false,
     }
 }
 

--- a/packages/doeff-vm/src/python_call.rs
+++ b/packages/doeff-vm/src/python_call.rs
@@ -39,6 +39,7 @@ pub enum PendingPython {
     },
     CallFuncReturn {
         metadata: Option<CallMetadata>,
+        evaluate_result: bool,
     },
     StepUserGenerator {
         stream: ASTStreamRef,

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -1372,6 +1372,7 @@ pub(crate) fn doctrl_to_pyexpr_for_vm(yielded: &DoCtrl) -> Result<Option<Py<PyAn
                 args,
                 kwargs,
                 metadata,
+                evaluate_result,
             } => {
                 let py_args = PyList::empty(py);
                 for arg in args {
@@ -1397,6 +1398,7 @@ pub(crate) fn doctrl_to_pyexpr_for_vm(yielded: &DoCtrl) -> Result<Option<Py<PyAn
                                 args: py_args.into_any().unbind(),
                                 kwargs: py_kwargs.into_any().unbind(),
                                 meta: Some(call_metadata_to_dict(py, metadata)?),
+                                evaluate_result: *evaluate_result,
                             }),
                     )
                     .map_err(|err| PyException::runtime_error(format!("{err}")))?
@@ -1625,6 +1627,7 @@ pub(crate) fn classify_yielded_bound(
                     args,
                     kwargs,
                     metadata: call_metadata_from_pyapply(py, &a)?,
+                    evaluate_result: a.evaluate_result,
                 })
             }
             DoExprTag::Expand => {
@@ -2447,6 +2450,8 @@ pub struct PyApply {
     pub kwargs: Py<PyAny>,
     #[pyo3(get)]
     pub meta: Option<Py<PyAny>>,
+    #[pyo3(get)]
+    pub evaluate_result: bool,
 }
 
 #[pymethods]
@@ -2481,6 +2486,7 @@ Program/Kleisli call sites must pass {'function_name', 'source_file', 'source_li
                 args,
                 kwargs,
                 meta,
+                evaluate_result: true,
             }))
     }
 }

--- a/tests/public_api/test_kpc_macro_expansion.py
+++ b/tests/public_api/test_kpc_macro_expansion.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from typing import Any
 
 from doeff import Ask, Effect, Program, do
-from doeff_vm import Expand, Perform, Pure
+from doeff_vm import Apply, Perform, Pure
 
 
 @do
@@ -34,15 +34,15 @@ def inner_program() -> Generator[Program[Any], Any, int]:
     return 7
 
 
-def test_do_call_returns_expand_doctrl() -> None:
+def test_do_call_returns_apply_doctrl() -> None:
     result = takes_plain(1)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
 
 
 def test_effect_arg_with_unwrap_yes_becomes_perform() -> None:
     effect = Ask("name")
     result = takes_plain(effect)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Perform), (
         f"expected Perform for effect arg, got {type(first).__name__}"
@@ -51,7 +51,7 @@ def test_effect_arg_with_unwrap_yes_becomes_perform() -> None:
 
 def test_plain_value_arg_becomes_pure() -> None:
     result = takes_plain(10)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Pure), f"expected Pure for plain value arg, got {type(first).__name__}"
     assert first.value == 10
@@ -60,7 +60,7 @@ def test_plain_value_arg_becomes_pure() -> None:
 def test_program_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
     prog = inner_program()
     result = takes_program(prog)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Pure), (
         f"expected Pure for Program-annotated arg, got {type(first).__name__}"
@@ -71,7 +71,7 @@ def test_program_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
 def test_effect_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
     effect = Ask("token")
     result = takes_effect(effect)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Pure), (
         f"expected Pure for Effect-annotated arg, got {type(first).__name__}"
@@ -79,13 +79,13 @@ def test_effect_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
     assert first.value is effect
 
 
-def test_generator_factory_is_exposed_from_expand_factory_as_pure() -> None:
+def test_generator_factory_is_exposed_from_apply_f_as_pure() -> None:
     result = takes_plain(3)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
-    assert isinstance(result.factory, Pure), (
-        f"expected Pure factory wrapper, got {type(result.factory).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
+    assert isinstance(result.f, Pure), (
+        f"expected Pure callable wrapper, got {type(result.f).__name__}"
     )
-    assert callable(result.factory.value)
+    assert callable(result.f.value)
 
 
 def test_strategy_is_cached_on_kleisli_instance() -> None:

--- a/tests/public_api/test_types_001_doctrl_exports.py
+++ b/tests/public_api/test_types_001_doctrl_exports.py
@@ -7,6 +7,7 @@ from doeff import (
     Ask,
     Eval,
     Expand,
+    Program,
     Perform,
     Pure,
     ResumeContinuation,
@@ -45,10 +46,21 @@ def test_pure_apply_eval_execute() -> None:
 
     @do
     def identity(x: int):
+        if False:  # pragma: no cover
+            yield Program.pure(None)
         return x
 
     expand_result = run(identity(4))
     assert expand_result.value == 4
+
+    generator_factory = getattr(identity, "_doeff_generator_factory")
+    eval_apply_result = run(
+        Eval(
+            Apply(Pure(generator_factory), [Pure(5)], {}, _meta()),
+            default_handlers(),
+        )
+    )
+    assert eval_apply_result.value == 5
 
     eval_result = run(Eval(Perform(Ask("k")), default_handlers()), env={"k": "value"})
     assert eval_result.value == "value"


### PR DESCRIPTION
## Summary
Implements SPEC-008 R16-B macro-expansion unification by routing `@do` call sites through `Apply` and teaching the VM to re-enter DoExpr evaluation when `Apply` returns an expression value.

### What changed
- Switched `KleisliProgram.__call__` for `@do` functions from `Expand(...)` emission to `Apply(...)` emission.
- Added `evaluate_result` flag to `DoCtrl::Apply` and `PendingPython::CallFuncReturn`.
- `PyApply` now carries `evaluate_result` (default `True` for Python-created `Apply`).
- VM `receive_call_func_result` now classifies `Apply` return values that are expression-like (`DoExpr`, `DoeffGenerator`, `EffectBase`) and continues evaluation via `Mode::HandleYield(...)`.
- Kept legacy `Expand` path intact for compatibility.
- Updated public API tests to assert `@do` returns `Apply`, and added direct `Eval(Apply(...))` execution coverage.

## Acceptance evidence
Issue file did not contain a concrete Acceptance Criteria section, so verification was mapped to R16-B behavior:

1. `@do` macro call emits `Apply`:
- Verified by tests in `tests/public_api/test_kpc_macro_expansion.py`.

2. `Eval(Apply(...))` executes callable-returned DoExpr/ASTStream correctly:
- Added/verified in `tests/public_api/test_types_001_doctrl_exports.py`.
- Direct runtime probe:
  - `is_ok True value 2`
  - `p(1) doctrl type Apply`

3. Regression checks pass for touched areas:
- `uv run pytest tests/public_api/test_kpc_macro_expansion.py tests/public_api/test_types_001_doctrl_exports.py -q`
  - `12 passed in 0.03s`
- `uv run pytest tests/public_api -q`
  - `124 passed in 0.34s`
- `uv run pytest tests/core/test_sa003_spec_gaps.py -q`
  - `7 passed in 0.02s`
- `uv run pyright doeff/kleisli.py tests/public_api/test_kpc_macro_expansion.py tests/public_api/test_types_001_doctrl_exports.py`
  - `0 errors, 0 warnings, 0 informations`
- Focused Rust VM tests:
  - `cargo test test_apply_return_delivers_value_without_pushing_frame` ✅
  - `cargo test test_r13i_tag_matches_variant` ✅
  - `cargo test test_r13i_classify_yielded_uses_tag_dispatch` ✅
  - `cargo test test_expand_requires_doeff_generator_or_errors` ✅

## Issue reference
- VM-EXPAND-UNIFY-001
