### PR TITLE
Rewrite WithIntercept IR to Eval(Apply) and drop VM filter fields

### DIFF
--- a/doeff/__init__.py
+++ b/doeff/__init__.py
@@ -132,6 +132,7 @@ from doeff.rust_vm import (
     default_async_handlers,
     default_handlers,
     run,
+    with_intercept,
 )
 from doeff.types import (
     DEFAULT_REPR_LIMIT,
@@ -375,4 +376,5 @@ __all__ = [
     "wait",
     "write_graph_html",
     "write_graph_html_async",
+    "with_intercept",
 ]

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -17,12 +17,6 @@ pub enum CallArg {
     Expr(PyShared),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InterceptMode {
-    Include,
-    Exclude,
-}
-
 #[derive(Debug, Clone)]
 pub enum DoCtrl {
     Pure {
@@ -65,9 +59,6 @@ pub enum DoCtrl {
     WithIntercept {
         interceptor: PyShared,
         expr: Py<PyAny>,
-        types: PyShared,
-        mode: InterceptMode,
-        metadata: CallMetadata,
     },
     Delegate {
         effect: DispatchEffect,
@@ -181,18 +172,9 @@ impl DoCtrl {
                 expr: expr.clone_ref(py),
                 py_identity: py_identity.clone(),
             },
-            DoCtrl::WithIntercept {
-                interceptor,
-                expr,
-                types,
-                mode,
-                metadata,
-            } => DoCtrl::WithIntercept {
+            DoCtrl::WithIntercept { interceptor, expr } => DoCtrl::WithIntercept {
                 interceptor: interceptor.clone(),
                 expr: expr.clone_ref(py),
-                types: types.clone(),
-                mode: *mode,
-                metadata: metadata.clone(),
             },
             DoCtrl::Delegate { effect } => DoCtrl::Delegate {
                 effect: effect.clone(),

--- a/tests/effects/test_local_handler_ask.py
+++ b/tests/effects/test_local_handler_ask.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-import doeff_vm
 import pytest
 
 from doeff import (
@@ -17,6 +16,7 @@ from doeff import (
     default_handlers,
     do,
     run,
+    with_intercept,
 )
 
 
@@ -148,11 +148,11 @@ async def test_handler_ask_with_intercept_and_local(parameterized_interpreter) -
     def body():
         return (yield Ping())
 
-    program = doeff_vm.WithIntercept(
+    program = with_intercept(
         observer,
         Local({"key": "intercepted_local"}, body()),
-        (),
-        "exclude",
+        types=(),
+        mode="exclude",
     )
     result = await _run_with_handlers(
         parameterized_interpreter.mode,


### PR DESCRIPTION
## Summary
- Rewrite VM `WithIntercept` IR to two fields: `(interceptor, expr)`.
- Remove VM-level `types`/`mode` filtering and `InterceptMode` from Rust VM/Python boundary.
- Invoke interceptors through `Eval(Apply(f, [effect]))` path.
- Add Python sugar `with_intercept(f, expr, types=..., mode=...)` that applies filtering in Python before constructing `WithIntercept(filtered, expr)`.
- Update tests to use the wrapper and add raw two-arg IR coverage.

## Files Changed
- `doeff/__init__.py`
- `doeff/rust_vm.py`
- `packages/doeff-vm/src/do_ctrl.rs`
- `packages/doeff-vm/src/pyvm.rs`
- `packages/doeff-vm/src/vm.rs`
- `tests/effects/test_local_handler_ask.py`
- `tests/test_with_intercept.py`

## Acceptance Evidence
### R2-A: `WithIntercept` constructor is 2-arg IR (`f`, `expr`)
Command:
```bash
uv run python - <<'PY'
import doeff_vm

def body():
    return doeff_vm.Pure("ok")

try:
    doeff_vm.WithIntercept(lambda e: e, body(), (), "include")
except TypeError as e:
    print("old_signature_typeerror=YES")
    print("old_signature_message=", str(e).splitlines()[0])
else:
    print("old_signature_typeerror=NO")

node = doeff_vm.WithIntercept(lambda e: doeff_vm.Pure(e), body())
print("new_signature_constructed=", type(node).__name__)
PY
```
Output:
```text
old_signature_typeerror=YES
old_signature_message= WithIntercept.__new__() takes 2 positional arguments but 4 were given
new_signature_constructed= WithIntercept
```

### R3-A: Interceptor invocation path uses `Eval(Apply(...))`
Command:
```bash
uv run python - <<'PY'
from doeff import Tell, WriterTellEffect, default_handlers, do, run, with_intercept

def observe(effect):
    return effect

@do
def body():
    yield Tell("body")
    return "ok"

result = run(
    with_intercept(observe, body(), types=(WriterTellEffect,), mode="include"),
    handlers=default_handlers(),
    trace=True,
)
print("is_ok=", result.is_ok())
print("value=", result.value)
trace_entries = result.trace or []
has_eval = any(isinstance(entry, dict) and "HandleYield(Eval)" in str(entry.get("mode", "")) for entry in trace_entries)
has_apply = any(isinstance(entry, dict) and "HandleYield(Apply)" in str(entry.get("mode", "")) for entry in trace_entries)
print("trace_has_HandleYield(Eval)=", has_eval)
print("trace_has_HandleYield(Apply)=", has_apply)
PY
```
Output:
```text
is_ok= True
value= ok
trace_has_HandleYield(Eval)= True
trace_has_HandleYield(Apply)= True
```

### Test Verification
Command:
```bash
uv run pytest tests/test_with_intercept.py tests/effects/test_local_handler_ask.py -q
```
Output:
```text
57 passed in 0.31s
```

Command:
```bash
uv run pytest -q
```
Output:
```text
731 passed, 21 warnings in 37.50s
```

## Issue
- VM-WITHINTERCEPT-002