### PR TITLE
Unify @do call sites through Apply with VM result re-evaluation

### DIFF
--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -72,7 +72,7 @@ class KleisliProgram(Generic[P, T]):
         return types.MethodType(self, instance)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Program[T]:
-        from doeff_vm import Apply, DoCtrlBase, Expand, Perform, Pure
+        from doeff_vm import Apply, DoCtrlBase, Perform, Pure
 
         from doeff.types import EffectBase
 
@@ -117,7 +117,7 @@ class KleisliProgram(Generic[P, T]):
                 raise TypeError(
                     "@do KleisliProgram is missing _doeff_generator_factory (DoeffGeneratorFn)"
                 )
-            return Expand(Pure(generator_factory), positional_args, keyword_args, metadata)
+            return Apply(Pure(generator_factory), positional_args, keyword_args, metadata)
         return Apply(Pure(self.func), positional_args, keyword_args, metadata)
 
     def partial(self, /, *args: P.args, **kwargs: P.kwargs) -> PartiallyAppliedKleisliProgram[P, T]:

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -97,6 +97,7 @@ pub enum DoCtrl {
         args: Vec<CallArg>,
         kwargs: Vec<(String, CallArg)>,
         metadata: CallMetadata,
+        evaluate_result: bool,
     },
     Expand {
         factory: CallArg,
@@ -229,11 +230,13 @@ impl DoCtrl {
                 args,
                 kwargs,
                 metadata,
+                evaluate_result,
             } => DoCtrl::Apply {
                 f: f.clone(),
                 args: args.clone(),
                 kwargs: kwargs.clone(),
                 metadata: metadata.clone(),
+                evaluate_result: *evaluate_result,
             },
             DoCtrl::Expand {
                 factory,

--- a/packages/doeff-vm/src/handler.rs
+++ b/packages/doeff-vm/src/handler.rs
@@ -164,6 +164,7 @@ fn rust_program_apply_expr(
         args: vec![],
         kwargs: vec![],
         metadata,
+        evaluate_result: false,
     }
 }
 

--- a/packages/doeff-vm/src/interceptor_state.rs
+++ b/packages/doeff-vm/src/interceptor_state.rs
@@ -132,7 +132,9 @@ impl InterceptorState {
             let is_doexpr =
                 bound.is_instance_of::<PyDoExprBase>() || bound.is_instance_of::<DoeffGenerator>();
             let is_direct_expr = is_effect_base
-                || doctrl_tag.is_some_and(|tag| tag != crate::pyvm::DoExprTag::Expand);
+                || doctrl_tag.is_some_and(|tag| {
+                    tag != crate::pyvm::DoExprTag::Expand && tag != crate::pyvm::DoExprTag::Apply
+                });
             (is_direct_expr, is_doexpr)
         })
     }

--- a/packages/doeff-vm/src/python_call.rs
+++ b/packages/doeff-vm/src/python_call.rs
@@ -39,6 +39,7 @@ pub enum PendingPython {
     },
     CallFuncReturn {
         metadata: Option<CallMetadata>,
+        evaluate_result: bool,
     },
     StepUserGenerator {
         stream: ASTStreamRef,

--- a/packages/doeff-vm/tests/test_pyvm.py
+++ b/packages/doeff-vm/tests/test_pyvm.py
@@ -1533,6 +1533,10 @@ def test_tag_on_concrete_instances():
 
     apply = Apply(lambda x: x, [1], {}, meta)
     assert apply.tag == TAG_APPLY
+    assert apply.evaluate_result is True
+
+    apply_no_eval = Apply(lambda x: x, [1], {}, meta, False)
+    assert apply_no_eval.evaluate_result is False
 
     expand = Expand(lambda x: x, [1], {}, meta)
     assert expand.tag == TAG_EXPAND

--- a/tests/public_api/test_kpc_macro_expansion.py
+++ b/tests/public_api/test_kpc_macro_expansion.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from typing import Any
 
 from doeff import Ask, Effect, Program, do
-from doeff_vm import Expand, Perform, Pure
+from doeff_vm import Apply, Perform, Pure
 
 
 @do
@@ -34,15 +34,16 @@ def inner_program() -> Generator[Program[Any], Any, int]:
     return 7
 
 
-def test_do_call_returns_expand_doctrl() -> None:
+def test_do_call_returns_apply_doctrl() -> None:
     result = takes_plain(1)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
+    assert result.evaluate_result is True
 
 
 def test_effect_arg_with_unwrap_yes_becomes_perform() -> None:
     effect = Ask("name")
     result = takes_plain(effect)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Perform), (
         f"expected Perform for effect arg, got {type(first).__name__}"
@@ -51,7 +52,7 @@ def test_effect_arg_with_unwrap_yes_becomes_perform() -> None:
 
 def test_plain_value_arg_becomes_pure() -> None:
     result = takes_plain(10)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Pure), f"expected Pure for plain value arg, got {type(first).__name__}"
     assert first.value == 10
@@ -60,7 +61,7 @@ def test_plain_value_arg_becomes_pure() -> None:
 def test_program_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
     prog = inner_program()
     result = takes_program(prog)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Pure), (
         f"expected Pure for Program-annotated arg, got {type(first).__name__}"
@@ -71,7 +72,7 @@ def test_program_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
 def test_effect_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
     effect = Ask("token")
     result = takes_effect(effect)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
     first = list(result.args)[0]
     assert isinstance(first, Pure), (
         f"expected Pure for Effect-annotated arg, got {type(first).__name__}"
@@ -79,13 +80,13 @@ def test_effect_annotated_arg_is_pure_wrapped_not_unwrapped() -> None:
     assert first.value is effect
 
 
-def test_generator_factory_is_exposed_from_expand_factory_as_pure() -> None:
+def test_generator_factory_is_exposed_from_apply_f_as_pure() -> None:
     result = takes_plain(3)
-    assert isinstance(result, Expand), f"expected Expand DoCtrl, got {type(result).__name__}"
-    assert isinstance(result.factory, Pure), (
-        f"expected Pure factory wrapper, got {type(result.factory).__name__}"
+    assert isinstance(result, Apply), f"expected Apply DoCtrl, got {type(result).__name__}"
+    assert isinstance(result.f, Pure), (
+        f"expected Pure factory wrapper, got {type(result.f).__name__}"
     )
-    assert callable(result.factory.value)
+    assert callable(result.f.value)
 
 
 def test_strategy_is_cached_on_kleisli_instance() -> None:


### PR DESCRIPTION
## Summary
- Route @do call sites through Apply instead of Expand (SPEC-008 R16-B)
- Add evaluate_result: bool to DoCtrl::Apply and PendingPython::CallFuncReturn
- VM reclassifies Apply results as DoExpr when evaluate_result=true
- Fix interceptor routing: exclude Apply from direct-expression path
- Legacy Expand path preserved for backward compat

## Verification
- cargo test: 218 passed (including proto-007)
- uv run pytest: 729 passed, no hangs
- tests/test_with_intercept.py: 43 passed

Closes VM-EXPAND-UNIFY-001