### PR TITLE
Rewrite WithIntercept IR: remove types/mode, move filtering to Python wrapper

### DIFF
--- a/doeff/__init__.py
+++ b/doeff/__init__.py
@@ -128,6 +128,7 @@ from doeff.graph_snapshot import (
 from doeff.kleisli import KleisliProgram
 from doeff.program import Program, ProgramBase
 from doeff.rust_vm import (
+    WithIntercept,
     async_run,
     default_async_handlers,
     default_handlers,
@@ -162,7 +163,6 @@ capture = capture_graph
 # G8: lazy re-exports of VM dispatch primitives from doeff_vm
 _VM_LAZY_EXPORTS = {
     "WithHandler",
-    "WithIntercept",
     "Pure",
     "Apply",
     "Expand",

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -17,12 +17,6 @@ pub enum CallArg {
     Expr(PyShared),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InterceptMode {
-    Include,
-    Exclude,
-}
-
 #[derive(Debug, Clone)]
 pub enum DoCtrl {
     Pure {
@@ -65,9 +59,7 @@ pub enum DoCtrl {
     WithIntercept {
         interceptor: PyShared,
         expr: Py<PyAny>,
-        types: PyShared,
-        mode: InterceptMode,
-        metadata: CallMetadata,
+        metadata: Option<CallMetadata>,
     },
     Delegate {
         effect: DispatchEffect,
@@ -185,14 +177,10 @@ impl DoCtrl {
             DoCtrl::WithIntercept {
                 interceptor,
                 expr,
-                types,
-                mode,
                 metadata,
             } => DoCtrl::WithIntercept {
                 interceptor: interceptor.clone(),
                 expr: expr.clone_ref(py),
-                types: types.clone(),
-                mode: *mode,
                 metadata: metadata.clone(),
             },
             DoCtrl::Delegate { effect } => DoCtrl::Delegate {

--- a/tests/effects/test_local_handler_ask.py
+++ b/tests/effects/test_local_handler_ask.py
@@ -12,6 +12,7 @@ from doeff import (
     Local,
     Pass,
     Resume,
+    WithIntercept,
     async_run,
     default_async_handlers,
     default_handlers,
@@ -148,7 +149,7 @@ async def test_handler_ask_with_intercept_and_local(parameterized_interpreter) -
     def body():
         return (yield Ping())
 
-    program = doeff_vm.WithIntercept(
+    program = WithIntercept(
         observer,
         Local({"key": "intercepted_local"}, body()),
         (),

--- a/tests/test_with_intercept.py
+++ b/tests/test_with_intercept.py
@@ -5,7 +5,16 @@ from dataclasses import dataclass
 import doeff_vm
 import pytest
 
-from doeff import EffectBase, Listen, Tell, WriterTellEffect, default_handlers, do, run
+from doeff import (
+    EffectBase,
+    Listen,
+    Tell,
+    WithIntercept,
+    WriterTellEffect,
+    default_handlers,
+    do,
+    run,
+)
 
 
 @dataclass(frozen=True)
@@ -88,7 +97,7 @@ async def test_with_intercept_observes_user_tell(parameterized_interpreter) -> N
         yield Tell("user")
         return "ok"
 
-    wrapped = doeff_vm.WithIntercept(observe, body(), (WriterTellEffect,), "include")
+    wrapped = WithIntercept(observe, body(), (WriterTellEffect,), "include")
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
     assert result.value == "ok"
@@ -104,7 +113,7 @@ async def test_with_intercept_observes_handler_tell_cross_cutting(parameterized_
             seen.append(expr.message)
         return expr
 
-    wrapped = doeff_vm.WithIntercept(
+    wrapped = WithIntercept(
         observe,
         doeff_vm.WithHandler(ping_with_tell_handler, _ping_program("inner")),
         (WriterTellEffect,),
@@ -132,7 +141,7 @@ async def test_with_intercept_type_filter_include(parameterized_interpreter) -> 
 
     wrapped = doeff_vm.WithHandler(
         ping_handler,
-        doeff_vm.WithIntercept(observe, body(), (WriterTellEffect,), "include"),
+        WithIntercept(observe, body(), (WriterTellEffect,), "include"),
     )
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
@@ -156,7 +165,7 @@ async def test_with_intercept_type_filter_exclude(parameterized_interpreter) -> 
 
     wrapped = doeff_vm.WithHandler(
         ping_handler,
-        doeff_vm.WithIntercept(observe, body(), (WriterTellEffect,), "exclude"),
+        WithIntercept(observe, body(), (WriterTellEffect,), "exclude"),
     )
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
@@ -179,7 +188,7 @@ async def test_with_intercept_can_filter_doctrl_withhandler(parameterized_interp
     def body():
         return (yield doeff_vm.WithHandler(ping_handler, _ping_program("x")))
 
-    wrapped = doeff_vm.WithIntercept(
+    wrapped = WithIntercept(
         observe,
         body(),
         (with_handler_type,),
@@ -200,7 +209,7 @@ async def test_with_intercept_can_filter_doctrl_resume(parameterized_interpreter
             seen.append("resume")
         return expr
 
-    wrapped = doeff_vm.WithIntercept(
+    wrapped = WithIntercept(
         observe,
         doeff_vm.WithHandler(ping_handler, _ping_program("x")),
         (doeff_vm.Resume,),
@@ -234,7 +243,7 @@ async def test_with_intercept_no_reentrancy_same_interceptor(parameterized_inter
     @do
     def main():
         return (
-            yield Listen(doeff_vm.WithIntercept(observe, body(), (WriterTellEffect,), "include"))
+            yield Listen(WithIntercept(observe, body(), (WriterTellEffect,), "include"))
         )
 
     result = await parameterized_interpreter.run_async(main())
@@ -269,9 +278,9 @@ async def test_with_intercept_nested_interceptors_compose(parameterized_interpre
         yield Tell("body")
         return "ok"
 
-    wrapped = doeff_vm.WithIntercept(
+    wrapped = WithIntercept(
         outer,
-        doeff_vm.WithIntercept(inner, body(), (WriterTellEffect,), "include"),
+        WithIntercept(inner, body(), (WriterTellEffect,), "include"),
         (WriterTellEffect,),
         "include",
     )
@@ -297,7 +306,7 @@ async def test_with_intercept_effect_transformation(parameterized_interpreter) -
     @do
     def main():
         return (
-            yield Listen(doeff_vm.WithIntercept(transform, body(), (WriterTellEffect,), "include"))
+            yield Listen(WithIntercept(transform, body(), (WriterTellEffect,), "include"))
         )
 
     result = await parameterized_interpreter.run_async(main())
@@ -319,7 +328,7 @@ async def test_with_intercept_pure_observation_passthrough(parameterized_interpr
     @do
     def main():
         return (
-            yield Listen(doeff_vm.WithIntercept(observe, body(), (WriterTellEffect,), "include"))
+            yield Listen(WithIntercept(observe, body(), (WriterTellEffect,), "include"))
         )
 
     result = await parameterized_interpreter.run_async(main())
@@ -346,7 +355,7 @@ async def test_with_intercept_effectful_interceptor(parameterized_interpreter) -
     @do
     def main():
         return (
-            yield Listen(doeff_vm.WithIntercept(effectful, body(), (WriterTellEffect,), "include"))
+            yield Listen(WithIntercept(effectful, body(), (WriterTellEffect,), "include"))
         )
 
     result = await parameterized_interpreter.run_async(main())
@@ -369,7 +378,7 @@ async def test_with_intercept_empty_types_include_never_matches(parameterized_in
         yield Tell("body")
         return "ok"
 
-    wrapped = doeff_vm.WithIntercept(observe, body(), (), "include")
+    wrapped = WithIntercept(observe, body(), (), "include")
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
     assert result.value == "ok"
@@ -389,7 +398,7 @@ async def test_with_intercept_empty_types_exclude_matches_everything(parameteriz
         yield Tell("body")
         return "ok"
 
-    wrapped = doeff_vm.WithIntercept(observe, body(), (), "exclude")
+    wrapped = WithIntercept(observe, body(), (), "exclude")
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
     assert result.value == "ok"
@@ -407,7 +416,7 @@ def test_with_intercept_trace_contains_interceptor_frame() -> None:
         return "ok"
 
     result = run(
-        doeff_vm.WithIntercept(trace_observer, body(), (WriterTellEffect,), "include"),
+        WithIntercept(trace_observer, body(), (WriterTellEffect,), "include"),
         handlers=default_handlers(),
         trace=True,
     )
@@ -429,7 +438,7 @@ async def test_with_intercept_deep_handler_nesting_cross_cutting(parameterized_i
             seen.append(expr.message)
         return expr
 
-    wrapped = doeff_vm.WithIntercept(
+    wrapped = WithIntercept(
         observe,
         doeff_vm.WithHandler(handler_b, doeff_vm.WithHandler(handler_a, _ping_program("deep"))),
         (WriterTellEffect,),
@@ -450,7 +459,7 @@ async def test_with_intercept_observes_delegate_path(parameterized_interpreter) 
         seen_types.append(type(expr).__name__)
         return expr
 
-    wrapped = doeff_vm.WithIntercept(
+    wrapped = WithIntercept(
         observe,
         doeff_vm.WithHandler(ping_handler, doeff_vm.WithHandler(always_delegate, _ping_program("x"))),
         (),
@@ -492,7 +501,7 @@ async def test_with_intercept_delegate_resume_no_leak(parameterized_interpreter)
 
     wrapped = doeff_vm.WithHandler(
         outer_handler,
-        doeff_vm.WithIntercept(
+        WithIntercept(
             observe,
             doeff_vm.WithHandler(inner_handler, body()),
             (WriterTellEffect,),
@@ -521,7 +530,7 @@ async def test_with_intercept_withhandler_outside_scope(parameterized_interprete
 
     wrapped = doeff_vm.WithHandler(
         ping_with_tell_handler,
-        doeff_vm.WithIntercept(observe, body(), (WriterTellEffect,), "include"),
+        WithIntercept(observe, body(), (WriterTellEffect,), "include"),
     )
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
@@ -553,9 +562,9 @@ async def test_with_intercept_nested_filters_match_spec_example(parameterized_in
 
     wrapped = doeff_vm.WithHandler(
         ping_handler,
-        doeff_vm.WithIntercept(
+        WithIntercept(
             f1,
-            doeff_vm.WithIntercept(f2, body(), (Ping,), "include"),
+            WithIntercept(f2, body(), (Ping,), "include"),
             (WriterTellEffect,),
             "include",
         ),
@@ -587,7 +596,7 @@ async def test_with_intercept_long_sequence_ordered_observation(parameterized_in
 
     wrapped = doeff_vm.WithHandler(
         ping_handler,
-        doeff_vm.WithIntercept(observe, chatty_program(), (WriterTellEffect,), "include"),
+        WithIntercept(observe, chatty_program(), (WriterTellEffect,), "include"),
     )
     result = await parameterized_interpreter.run_async(wrapped)
     assert result.is_ok
@@ -607,7 +616,7 @@ async def test_with_intercept_observer_raises_propagates_and_cleans_state(
         yield Tell("boom")
         return "ok"
 
-    wrapped = doeff_vm.WithIntercept(bad_observer, body(), (WriterTellEffect,), "include")
+    wrapped = WithIntercept(bad_observer, body(), (WriterTellEffect,), "include")
     result = await parameterized_interpreter.run_async(wrapped)
     assert _run_result_is_err(result)
     assert isinstance(result.error, RuntimeError)
@@ -627,7 +636,7 @@ async def test_with_intercept_observer_raises_propagates_and_cleans_state(
         return "after-ok"
 
     after_result = await parameterized_interpreter.run_async(
-        doeff_vm.WithIntercept(observe_after, after(), (WriterTellEffect,), "include")
+        WithIntercept(observe_after, after(), (WriterTellEffect,), "include")
     )
     assert _run_result_is_ok(after_result)
     assert after_result.value == "after-ok"
@@ -650,7 +659,7 @@ async def test_with_intercept_program_error_propagates_after_prior_observation(
         yield Tell("before_error")
         raise ValueError("program failed")
 
-    wrapped = doeff_vm.WithIntercept(observe, failing_program(), (WriterTellEffect,), "include")
+    wrapped = WithIntercept(observe, failing_program(), (WriterTellEffect,), "include")
     result = await parameterized_interpreter.run_async(wrapped)
     assert _run_result_is_err(result)
     assert isinstance(result.error, ValueError)


### PR DESCRIPTION
## Summary
- Simplify DoCtrl::WithIntercept to { interceptor, expr, metadata }
- Delete InterceptMode enum and interceptor_call_arg from VM
- Remove __code__/__name__/__qualname__ probing from VM runtime (fixes proto-007 C7)
- Add Python-side WithIntercept wrapper in doeff/rust_vm.py

## Verification
- cargo test: 215 passed (including proto-007 C7 test)
- uv run pytest: 729 passed
- Zero InterceptMode/interceptor_call_arg/dunder references in VM

Closes VM-WITHINTERCEPT-002