### PR TITLE
Fix nested dispatch completion for Python handlers

### DIFF
--- a/packages/doeff-vm/src/dispatch_state.rs
+++ b/packages/doeff-vm/src/dispatch_state.rs
@@ -76,7 +76,10 @@ impl DispatchState {
     }
 
     pub(crate) fn top_original_exception(&self) -> Option<(DispatchId, PyException)> {
-        self.top()
+        self.dispatch_stack
+            .iter()
+            .rev()
+            .find(|ctx| !ctx.completed)
             .and_then(|ctx| ctx.original_exception.clone().map(|exc| (ctx.dispatch_id, exc)))
     }
 


### PR DESCRIPTION
## Summary
- remove Python-handler completion guards from `check_dispatch_completion_after_activation` and `check_dispatch_completion_for_non_terminal_throw`
- fix stale Delegate/Pass effect capture by resolving top effect from the active (non-completed) dispatch context
- preserve traceback semantics for root Python dispatches that resume then throw by deferring root-depth completion in `VM::check_dispatch_completion`
- add `tests/test_dispatch_completion.py` with 5 regression tests:
  - effect-yield then Delegate reproducer
  - multiple effect yields before Delegate
  - cache miss -> Delegate -> CachePut
  - nested handler effects preserving outer dispatch context
  - Delegate without prior effect yield

## Issue Reference
- VM-DISPATCH-001

## Acceptance Criteria Evidence
- AC-1 (`test_effect_yield_then_delegate_basic`):
  - `uv run pytest tests/test_dispatch_completion.py -v`
  - result: `5 passed`
- AC-2 (all 5 new tests):
  - `uv run pytest tests/test_dispatch_completion.py -v`
  - result: `5 passed in 0.01s`
- AC-3 (Rust VM tests):
  - `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q`
  - result: `218 passed; 0 failed`
- AC-4 (full Python suite):
  - `uv run pytest -q`
  - result: `734 passed, 21 warnings`
- AC-5 (`test_with_intercept` regression guard):
  - `uv run pytest tests/test_with_intercept.py -q`
  - result: `43 passed`
- AC-6 (guard removal in target functions):
  - `rg -n "active_dispatch_handler_is_python" packages/doeff-vm/src/vm.rs packages/doeff-vm/src/dispatch_state.rs`
  - result: no matches

## Validation Commands Run
```bash
make sync
cargo test --manifest-path packages/doeff-vm/Cargo.toml -q
uv run pytest -q
uv run pytest tests/test_dispatch_completion.py -v
uv run pytest tests/test_with_intercept.py -q
rg -n "active_dispatch_handler_is_python" packages/doeff-vm/src/vm.rs packages/doeff-vm/src/dispatch_state.rs
```
