### PR TITLE
VM-SCOPE-STRUCTURAL: move execution-local VM state to Segment

### DIFF
--- a/packages/doeff-vm/src/segment.rs
+++ b/packages/doeff-vm/src/segment.rs
@@ -2,6 +2,7 @@
 
 use crate::frame::Frame;
 use crate::ids::{DispatchId, Marker, SegmentId};
+use crate::step::{Mode, PendingPython, PyException};
 
 #[derive(Debug, Clone)]
 pub enum SegmentKind {
@@ -17,6 +18,11 @@ pub struct Segment {
     pub scope_chain: Vec<Marker>,
     pub kind: SegmentKind,
     pub dispatch_id: Option<DispatchId>,
+    pub mode: Mode,
+    pub pending_python: Option<PendingPython>,
+    pub pending_error_context: Option<PyException>,
+    pub interceptor_eval_depth: usize,
+    pub interceptor_skip_stack: Vec<Marker>,
 }
 
 impl Segment {
@@ -28,6 +34,11 @@ impl Segment {
             scope_chain,
             kind: SegmentKind::Normal,
             dispatch_id: None,
+            mode: Mode::Deliver(crate::value::Value::Unit),
+            pending_python: None,
+            pending_error_context: None,
+            interceptor_eval_depth: 0,
+            interceptor_skip_stack: Vec::new(),
         }
     }
 
@@ -44,6 +55,11 @@ impl Segment {
             scope_chain,
             kind: SegmentKind::PromptBoundary { handled_marker },
             dispatch_id: None,
+            mode: Mode::Deliver(crate::value::Value::Unit),
+            pending_python: None,
+            pending_error_context: None,
+            interceptor_eval_depth: 0,
+            interceptor_skip_stack: Vec::new(),
         }
     }
 

--- a/tests/test_execution_scope.py
+++ b/tests/test_execution_scope.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from doeff import (
+    Delegate,
+    EffectGenerator,
+    Pass,
+    Resume,
+    Transfer,
+    Try,
+    WithHandler,
+    default_handlers,
+    do,
+    run,
+)
+from doeff.effects.base import EffectBase
+
+
+def _with_handlers(program: Any, *handlers: Any) -> Any:
+    wrapped = program
+    for handler in handlers:
+        wrapped = WithHandler(handler, wrapped)
+    return wrapped
+
+
+def _is_ok(result: Any) -> bool:
+    probe = getattr(result, "is_ok", None)
+    if callable(probe):
+        return bool(probe())
+    return bool(probe)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScopePing(EffectBase):
+    label: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScopeBoom(EffectBase):
+    label: str
+
+
+def ping_base_handler(effect: object, k: object):
+    if not isinstance(effect, ScopePing):
+        yield Pass()
+        return
+    return (yield Resume(k, f"base:{effect.label}"))
+
+
+def boom_handler(effect: object, k: object):
+    if not isinstance(effect, ScopeBoom):
+        yield Pass()
+        return
+    raise RuntimeError(f"boom:{effect.label}")
+
+
+@do
+def ping_program(label: str) -> EffectGenerator[str]:
+    return (yield ScopePing(label=label))
+
+
+def test_nested_dispatch_scope_restores_outer_context() -> None:
+    def outer(effect: object, k: object):
+        if not isinstance(effect, ScopePing):
+            yield Pass()
+            return
+        nested = yield ScopePing(label=f"{effect.label}:inner")
+        return (yield Resume(k, f"{nested}|outer"))
+
+    wrapped = _with_handlers(ping_program("x"), outer, ping_base_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == "base:x:inner|outer"
+
+
+def test_delegate_keeps_nested_handler_scope_order() -> None:
+    def inner(effect: object, k: object):
+        if not isinstance(effect, ScopePing):
+            yield Pass()
+            return
+        delegated = yield Delegate()
+        return (yield Resume(k, f"{delegated}|inner"))
+
+    def outer(effect: object, k: object):
+        if not isinstance(effect, ScopePing):
+            yield Pass()
+            return
+        delegated = yield Delegate()
+        return (yield Resume(k, f"{delegated}|outer"))
+
+    wrapped = _with_handlers(ping_program("x"), inner, outer, ping_base_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == "base:x|outer|inner"
+
+
+def test_try_results_remain_scoped_across_multiple_failures() -> None:
+    @do
+    def program() -> EffectGenerator[tuple[object, object, str]]:
+        first = yield Try(ScopeBoom(label="a"))
+        second = yield Try(ScopeBoom(label="b"))
+        final = yield ScopePing(label="ok")
+        return first, second, final
+
+    wrapped = _with_handlers(program(), boom_handler, ping_base_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    first, second, final = result.value
+    assert first.is_err()
+    assert "boom:a" in str(first.error)
+    assert second.is_err()
+    assert "boom:b" in str(second.error)
+    assert final == "base:ok"
+
+
+def test_nested_try_inside_handler_does_not_corrupt_outer_flow() -> None:
+    def outer(effect: object, k: object):
+        if not isinstance(effect, ScopePing):
+            yield Pass()
+            return
+        nested = yield Try(ScopeBoom(label="inner"))
+        assert nested.is_err()
+        return (yield Resume(k, f"after:{effect.label}"))
+
+    wrapped = _with_handlers(ping_program("scope"), outer, boom_handler, ping_base_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == "after:scope"
+
+
+def test_transfer_keeps_dispatch_stack_stable_for_repeated_effects() -> None:
+    @dataclass(frozen=True, kw_only=True)
+    class TransferPing(EffectBase):
+        value: int
+
+    def transfer_handler(effect: object, k: object):
+        if not isinstance(effect, TransferPing):
+            yield Pass()
+            return
+        yield Transfer(k, effect.value)
+
+    @do
+    def program() -> EffectGenerator[tuple[int, ...]]:
+        values: list[int] = []
+        for i in range(6):
+            values.append((yield TransferPing(value=i)))
+        return tuple(values)
+
+    wrapped = _with_handlers(program(), transfer_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == tuple(range(6))
+
+
+def test_late_resume_of_consumed_continuation_stays_scoped() -> None:
+    captured: dict[str, object] = {}
+
+    @dataclass(frozen=True, kw_only=True)
+    class CaptureEffect(EffectBase):
+        label: str
+
+    def capture_handler(effect: object, k: object):
+        if not isinstance(effect, CaptureEffect):
+            yield Pass()
+            return
+        captured["k"] = k
+        return (yield Resume(k, f"first:{effect.label}"))
+
+    @do
+    def program() -> EffectGenerator[tuple[str, object]]:
+        first = yield CaptureEffect(label="x")
+        late = yield Try(Resume(captured["k"], "late"))
+        return first, late
+
+    wrapped = _with_handlers(program(), capture_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    first, late = result.value
+    assert first == "first:x"
+    assert late.is_err()
+    message = str(late.error)
+    assert "one-shot violation" in message or "unknown continuation id" in message

--- a/tests/test_segment_owned_state.py
+++ b/tests/test_segment_owned_state.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from doeff import (
+    EffectGenerator,
+    Pass,
+    Pure,
+    Resume,
+    Try,
+    WithHandler,
+    WithIntercept,
+    default_handlers,
+    do,
+    run,
+)
+from doeff.effects.base import EffectBase
+
+
+def _with_handlers(program: Any, *handlers: Any) -> Any:
+    wrapped = program
+    for handler in handlers:
+        wrapped = WithHandler(handler, wrapped)
+    return wrapped
+
+
+def _is_ok(result: Any) -> bool:
+    probe = getattr(result, "is_ok", None)
+    if callable(probe):
+        return bool(probe())
+    return bool(probe)
+
+
+@dataclass(frozen=True, kw_only=True)
+class OuterPing(EffectBase):
+    label: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class InnerPing(EffectBase):
+    label: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScopeBoom(EffectBase):
+    label: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScopeProbe(EffectBase):
+    label: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScopeTrigger(EffectBase):
+    label: str
+
+
+def inner_ping_handler(effect: object, k: object):
+    if not isinstance(effect, InnerPing):
+        yield Pass()
+        return
+    return (yield Resume(k, f"inner:{effect.label}"))
+
+
+def outer_ping_handler(effect: object, k: object):
+    if not isinstance(effect, OuterPing):
+        yield Pass()
+        return
+    first = yield InnerPing(label=f"{effect.label}:a")
+    second = yield InnerPing(label=f"{effect.label}:b")
+    return (yield Resume(k, f"{first}|{second}"))
+
+
+def boom_handler(effect: object, k: object):
+    if not isinstance(effect, ScopeBoom):
+        yield Pass()
+        return
+    raise RuntimeError(f"boom:{effect.label}")
+
+
+def outer_boom_handler(effect: object, k: object):
+    if not isinstance(effect, OuterPing):
+        yield Pass()
+        return
+    inner = yield Try(ScopeBoom(label="inner"))
+    return (yield Resume(k, inner))
+
+
+def scope_probe_handler(effect: object, k: object):
+    if not isinstance(effect, ScopeProbe):
+        yield Pass()
+        return
+    # Return DoExpr directly so VM must evaluate handler return in nested context.
+    return Pure(f"handled:{effect.label}")
+
+
+def scope_trigger_handler(effect: object, k: object):
+    if not isinstance(effect, ScopeTrigger):
+        yield Pass()
+        return
+    return (yield Resume(k, f"trigger:{effect.label}"))
+
+
+@do
+def _outer_ping_program() -> EffectGenerator[str]:
+    return (yield OuterPing(label="root"))
+
+
+def test_mode_isolation_across_nested_dispatch() -> None:
+    wrapped = _with_handlers(_outer_ping_program(), outer_ping_handler, inner_ping_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == "inner:root:a|inner:root:b"
+
+
+def test_pending_error_context_not_stolen_by_nested_dispatch() -> None:
+    @do
+    def program() -> EffectGenerator[tuple[object, object]]:
+        first = yield Try(OuterPing(label="boom-wrapper"))
+        second = yield Try(ScopeBoom(label="outer"))
+        return first, second
+
+    wrapped = _with_handlers(program(), outer_boom_handler, boom_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    first, second = result.value
+    assert first.is_ok()
+    assert first.value.is_err()
+    assert "boom:inner" in str(first.value.error)
+    assert second.is_err()
+    assert "boom:outer" in str(second.error)
+
+
+def test_interceptor_eval_depth_isolated_per_context() -> None:
+    seen: list[str] = []
+
+    def interceptor(expr: object):
+        if isinstance(expr, ScopeProbe):
+            seen.append(expr.label)
+        return expr
+
+    @do
+    def program() -> EffectGenerator[str]:
+        return (yield ScopeProbe(label="depth-a"))
+
+    wrapped = _with_handlers(
+        WithIntercept(interceptor, program(), (ScopeProbe,), "include"),
+        scope_probe_handler,
+    )
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == "handled:depth-a"
+    assert seen == ["depth-a"]
+
+
+def test_interceptor_skip_stack_isolated_per_context() -> None:
+    seen: list[str] = []
+
+    def interceptor(expr: object):
+        if isinstance(expr, InnerPing):
+            seen.append(expr.label)
+        return expr
+
+    @do
+    def program() -> EffectGenerator[tuple[str, str]]:
+        first = yield InnerPing(label="first")
+        second = yield InnerPing(label="second")
+        return first, second
+
+    wrapped = _with_handlers(
+        WithIntercept(interceptor, program(), (InnerPing,), "include"),
+        inner_ping_handler,
+    )
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == ("inner:first", "inner:second")
+    assert seen == ["first", "second"]
+
+
+def test_continuation_capture_resume_path_remains_well_scoped() -> None:
+    captured: dict[str, object] = {}
+
+    @dataclass(frozen=True, kw_only=True)
+    class CaptureOnce(EffectBase):
+        label: str
+
+    def capture_handler(effect: object, k: object):
+        if not isinstance(effect, CaptureOnce):
+            yield Pass()
+            return
+        captured["k"] = k
+        return (yield Resume(k, f"captured:{effect.label}"))
+
+    @do
+    def program() -> EffectGenerator[tuple[str, object]]:
+        first = yield CaptureOnce(label="x")
+        late = yield Try(Resume(captured["k"], "late-resume"))
+        return first, late
+
+    wrapped = _with_handlers(program(), capture_handler)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    first, late = result.value
+    assert first == "captured:x"
+    assert late.is_err()
+    message = str(late.error)
+    assert "one-shot violation" in message or "unknown continuation id" in message
+
+
+def test_three_level_nested_structural_isolation() -> None:
+    @dataclass(frozen=True, kw_only=True)
+    class L1(EffectBase):
+        tag: str = "l1"
+
+    @dataclass(frozen=True, kw_only=True)
+    class L2(EffectBase):
+        tag: str = "l2"
+
+    @dataclass(frozen=True, kw_only=True)
+    class L3(EffectBase):
+        tag: str = "l3"
+
+    def h3(effect: object, k: object):
+        if not isinstance(effect, L3):
+            yield Pass()
+            return
+        return (yield Resume(k, "L3"))
+
+    def h2(effect: object, k: object):
+        if not isinstance(effect, L2):
+            yield Pass()
+            return
+        inner = yield L3()
+        return (yield Resume(k, f"L2<{inner}>"))
+
+    def h1(effect: object, k: object):
+        if not isinstance(effect, L1):
+            yield Pass()
+            return
+        inner = yield L2()
+        return (yield Resume(k, f"L1<{inner}>"))
+
+    @do
+    def program() -> EffectGenerator[tuple[str, str, str]]:
+        first = yield L1()
+        second = yield L2()
+        third = yield L3()
+        return first, second, third
+
+    wrapped = _with_handlers(program(), h1, h2, h3)
+    result = run(wrapped, handlers=default_handlers())
+    assert _is_ok(result), result.error
+    assert result.value == ("L1<L2<L3>>", "L2<L3>", "L3")


### PR DESCRIPTION
## Summary
Implements VM-SCOPE-STRUCTURAL by moving execution-local state from VM/global interceptor state onto `Segment`, and rewiring capture/resume + access paths accordingly.

## Issue
- VM-SCOPE-STRUCTURAL

## What changed
- Added execution-local fields to `Segment`:
  - `mode`
  - `pending_python`
  - `pending_error_context`
  - `interceptor_eval_depth`
  - `interceptor_skip_stack`
- Removed execution-local globals from `VM`:
  - `mode`
  - `pending_python`
  - `pending_error_context`
- Removed scoped fields from `InterceptorState`:
  - `interceptor_eval_depth`
  - `interceptor_skip_stack`
- Updated `Continuation` capture/resume to snapshot/restore execution-local segment state.
- Rewrote VM access sites to use segment-owned state.
- Added segment accessors and rewired pending/mode/debug/step paths.
- Added regression suites:
  - `tests/test_segment_owned_state.py` (6 tests)
  - `tests/test_execution_scope.py` (6 tests)

## Acceptance criteria evidence
- AC-1 (`Segment` owns 5 fields): implemented in `packages/doeff-vm/src/segment.rs`.
- AC-2 (`VM` has no mode/pending globals): `packages/doeff-vm/src/vm.rs` no longer defines those fields.
- AC-3 (`InterceptorState` has no eval_depth/skip_stack fields): removed from `packages/doeff-vm/src/interceptor_state.rs`.
- AC-4 (`DispatchContext` has no saved_mode/saved_segment): `packages/doeff-vm/src/dispatch.rs` unchanged and does not contain these fields.
- AC-5 (`Continuation::capture` snapshots execution-local state): implemented in `packages/doeff-vm/src/continuation.rs`.
- AC-6 (segment creation initializes owned state): `Segment::new/new_prompt` initialize defaults; continuation entry restores snapshots.
- AC-7 (accesses routed through current segment): VM accesses rewritten in `packages/doeff-vm/src/vm.rs`.
- AC-8 (new tests pass):
  - `uv run pytest tests/test_segment_owned_state.py -v` → **6 passed**
- AC-9:
  - `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q` → **221 passed**
- AC-10:
  - `uv run pytest -q` → **751 passed**
- AC-11:
  - `uv run pytest tests/test_with_intercept.py -q` → **43 passed**
- AC-12:
  - `uv run pytest tests/test_dispatch_completion.py -q` → **10 passed**
- AC-13:
  - `uv run pytest tests/test_execution_scope.py -v` → **6 passed**
- AC-14:
  - `make lint-semgrep` currently fails due pre-existing repository-wide findings unrelated to this issue.
  - Targeted scan on VM-scope structural touchpoints passed:
    - `uv run semgrep --config .semgrep.yaml packages/doeff-vm/src/vm.rs packages/doeff-vm/src/interceptor_state.rs packages/doeff-vm/src/dispatch.rs` → **0 findings**

## Validation commands run
```bash
make sync
cargo test --manifest-path packages/doeff-vm/Cargo.toml -q
uv run pytest -q
uv run pytest tests/test_segment_owned_state.py -v
uv run pytest tests/test_execution_scope.py -v
uv run pytest tests/test_with_intercept.py -q
uv run pytest tests/test_dispatch_completion.py -q
make lint-semgrep
```
