### PR TITLE
Full CEK frame refactor: typed VM continuation frames

### DIFF
--- a/packages/doeff-vm/src/arena.rs
+++ b/packages/doeff-vm/src/arena.rs
@@ -143,8 +143,7 @@ mod tests {
         {
             let seg_mut = arena.get_mut(id).unwrap();
             use crate::frame::Frame;
-            use crate::ids::CallbackId;
-            seg_mut.push_frame(Frame::rust_return(CallbackId::fresh()));
+            seg_mut.push_frame(Frame::FlatMapBindResult);
         }
 
         let seg_ref = arena.get(id).unwrap();
@@ -166,6 +165,9 @@ mod tests {
         assert_eq!(rewired, 2);
         assert_eq!(arena.get(child_a).and_then(|seg| seg.caller), Some(caller));
         assert_eq!(arena.get(child_b).and_then(|seg| seg.caller), Some(caller));
-        assert_eq!(arena.get(unrelated).and_then(|seg| seg.caller), Some(caller));
+        assert_eq!(
+            arena.get(unrelated).and_then(|seg| seg.caller),
+            Some(caller)
+        );
     }
 }

--- a/packages/doeff-vm/src/continuation.rs
+++ b/packages/doeff-vm/src/continuation.rs
@@ -259,13 +259,12 @@ mod tests {
         let mut seg = Segment::new(marker, None, vec![marker]);
         let seg_id = SegmentId::from_index(0);
 
-        use crate::ids::CallbackId;
-        seg.push_frame(Frame::rust_return(CallbackId::fresh()));
+        seg.push_frame(Frame::FlatMapBindResult);
 
         let cont = Continuation::capture(&seg, seg_id, None);
         assert_eq!(cont.frames_snapshot.len(), 1);
 
-        seg.push_frame(Frame::rust_return(CallbackId::fresh()));
+        seg.push_frame(Frame::FlatMapBindResult);
         assert_eq!(cont.frames_snapshot.len(), 1);
         assert_eq!(seg.frame_count(), 2);
     }

--- a/packages/doeff-vm/src/debug_state.rs
+++ b/packages/doeff-vm/src/debug_state.rs
@@ -119,10 +119,7 @@ impl DebugState {
         Self::truncate_repr(repr)
     }
 
-    pub(crate) fn format_do_ctrl(
-        yielded: &DoCtrl,
-        verbosity: ModeFormatVerbosity,
-    ) -> &'static str {
+    pub(crate) fn format_do_ctrl(yielded: &DoCtrl, verbosity: ModeFormatVerbosity) -> &'static str {
         let formatted = match yielded {
             DoCtrl::Pure { .. } => "HandleYield(Pure)",
             DoCtrl::Map { .. } => "HandleYield(Map)",
@@ -154,11 +151,7 @@ impl DebugState {
         }
     }
 
-    pub(crate) fn format_mode(
-        &self,
-        mode: &Mode,
-        verbosity: ModeFormatVerbosity,
-    ) -> &'static str {
+    pub(crate) fn format_mode(&self, mode: &Mode, verbosity: ModeFormatVerbosity) -> &'static str {
         match mode {
             Mode::Deliver(_) => "Deliver",
             Mode::Throw(_) => "Throw",
@@ -260,16 +253,27 @@ impl DebugState {
 
         crate::vm_debug_log!(
             "[step {}] mode={} {} dispatch_depth={} pending={}",
-            self.step_counter, mode_kind, seg_info, dispatch_depth, pending
+            self.step_counter,
+            mode_kind,
+            seg_info,
+            dispatch_depth,
+            pending
         );
 
         if self.config.level == DebugLevel::Trace && self.config.show_frames {
             if let Some(seg) = current_segment.and_then(|id| segments.get(id)) {
                 for (i, frame) in seg.frames.iter().enumerate() {
                     let frame_kind = match frame {
-                        Frame::RustReturn { .. } => "RustReturn",
                         Frame::Program { metadata, .. } if metadata.is_some() => "Program(meta)",
                         Frame::Program { .. } => "Program",
+                        Frame::InterceptorApply(_) => "InterceptorApply",
+                        Frame::InterceptorEval(_) => "InterceptorEval",
+                        Frame::HandlerDispatch { .. } => "HandlerDispatch",
+                        Frame::EvalReturn(_) => "EvalReturn",
+                        Frame::MapReturn { .. } => "MapReturn",
+                        Frame::FlatMapBindResult => "FlatMapBindResult",
+                        Frame::FlatMapBindSource { .. } => "FlatMapBindSource",
+                        Frame::InterceptBodyReturn { .. } => "InterceptBodyReturn",
                     };
                     crate::vm_debug_log!("  frame[{}]: {}", i, frame_kind);
                 }

--- a/packages/doeff-vm/src/dispatch_state.rs
+++ b/packages/doeff-vm/src/dispatch_state.rs
@@ -68,18 +68,12 @@ impl DispatchState {
             .find(|ctx| ctx.dispatch_id == dispatch_id)
     }
 
-    pub(crate) fn effect_for_dispatch(
-        &self,
-        dispatch_id: DispatchId,
-    ) -> Option<DispatchEffect> {
+    pub(crate) fn effect_for_dispatch(&self, dispatch_id: DispatchId) -> Option<DispatchEffect> {
         self.find_by_dispatch_id(dispatch_id)
             .map(|ctx| ctx.effect.clone())
     }
 
-    pub(crate) fn dispatch_is_execution_context_effect(
-        &self,
-        dispatch_id: DispatchId,
-    ) -> bool {
+    pub(crate) fn dispatch_is_execution_context_effect(&self, dispatch_id: DispatchId) -> bool {
         self.find_by_dispatch_id(dispatch_id)
             .is_some_and(|ctx| ctx.is_execution_context_effect)
     }

--- a/packages/doeff-vm/src/ids.rs
+++ b/packages/doeff-vm/src/ids.rs
@@ -2,7 +2,7 @@
 //!
 //! All IDs are lightweight Copy types using newtype pattern for type safety.
 
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Unique identifier for prompts/handlers.
 ///
@@ -33,13 +33,6 @@ pub struct DispatchId(pub u64);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct RunnableId(pub u64);
 
-/// Unique identifier for callbacks stored in VM's callback table.
-///
-/// Callbacks are stored separately from Frames to allow Frame to be Clone.
-/// The callback is consumed when executed.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct CallbackId(pub u32);
-
 /// Unique identifier for spawned tasks.
 ///
 /// Tasks are managed by the scheduler which maintains its own internal counter.
@@ -57,7 +50,6 @@ static MARKER_COUNTER: AtomicU64 = AtomicU64::new(1);
 static CONT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 static DISPATCH_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 static RUNNABLE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
-static CALLBACK_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
 
 impl Marker {
     /// Create a fresh unique Marker.
@@ -131,16 +123,6 @@ impl SegmentId {
     }
 }
 
-impl CallbackId {
-    pub fn fresh() -> Self {
-        CallbackId(CALLBACK_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
-    }
-
-    pub fn raw(&self) -> u32 {
-        self.0
-    }
-}
-
 impl TaskId {
     /// Get the raw value.
     pub fn raw(&self) -> u64 {
@@ -187,13 +169,6 @@ mod tests {
     fn test_segment_id_index_roundtrip() {
         let id = SegmentId::from_index(42);
         assert_eq!(id.index(), 42);
-    }
-
-    #[test]
-    fn test_callback_id_fresh_is_unique() {
-        let c1 = CallbackId::fresh();
-        let c2 = CallbackId::fresh();
-        assert_ne!(c1, c2);
     }
 
     #[test]

--- a/packages/doeff-vm/src/interceptor_state.rs
+++ b/packages/doeff-vm/src/interceptor_state.rs
@@ -1,6 +1,6 @@
 //! Interceptor-domain state and helper logic for VM composition.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use pyo3::prelude::*;
 
@@ -10,7 +10,7 @@ use crate::doeff_generator::DoeffGenerator;
 use crate::error::VMError;
 use crate::frame::CallMetadata;
 use crate::handler::HandlerEntry;
-use crate::ids::{CallbackId, DispatchId, Marker, SegmentId};
+use crate::ids::{DispatchId, Marker, SegmentId};
 use crate::py_shared::PyShared;
 use crate::pyvm::{PyDoCtrlBase, PyDoExprBase, PyEffectBase};
 use crate::segment::Segment;
@@ -19,17 +19,11 @@ use crate::vm::InterceptorEntry;
 #[derive(Clone, Default)]
 pub(crate) struct InterceptorState {
     interceptors: HashMap<Marker, InterceptorEntry>,
-    interceptor_callbacks: HashMap<CallbackId, Marker>,
-    interceptor_call_metadata: HashMap<CallbackId, CallMetadata>,
-    interceptor_eval_callbacks: HashSet<CallbackId>,
 }
 
 impl InterceptorState {
     pub(crate) fn clear_for_run(&mut self) {
         self.interceptors.clear();
-        self.interceptor_callbacks.clear();
-        self.interceptor_call_metadata.clear();
-        self.interceptor_eval_callbacks.clear();
     }
 
     pub(crate) fn current_chain(&self, scope_chain: &[Marker]) -> Vec<Marker> {
@@ -154,30 +148,6 @@ impl InterceptorState {
 
     pub(crate) fn get_entry(&self, marker: Marker) -> Option<InterceptorEntry> {
         self.interceptors.get(&marker).cloned()
-    }
-
-    pub(crate) fn register_callback(&mut self, cb: CallbackId, marker: Marker) {
-        self.interceptor_callbacks.insert(cb, marker);
-    }
-
-    pub(crate) fn unregister_callback(&mut self, cb: CallbackId) -> Option<Marker> {
-        self.interceptor_callbacks.remove(&cb)
-    }
-
-    pub(crate) fn set_call_metadata(&mut self, cb: CallbackId, metadata: CallMetadata) {
-        self.interceptor_call_metadata.insert(cb, metadata);
-    }
-
-    pub(crate) fn take_call_metadata(&mut self, cb: CallbackId) -> Option<CallMetadata> {
-        self.interceptor_call_metadata.remove(&cb)
-    }
-
-    pub(crate) fn register_eval_callback(&mut self, cb: CallbackId) {
-        self.interceptor_eval_callbacks.insert(cb);
-    }
-
-    pub(crate) fn unregister_eval_callback(&mut self, cb: CallbackId) -> bool {
-        self.interceptor_eval_callbacks.remove(&cb)
     }
 
     pub(crate) fn prepare_with_intercept(

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -13,9 +13,9 @@ pub mod arena;
 pub mod ast_stream;
 pub mod capture;
 pub mod continuation;
-mod dispatch_state;
 mod debug_state;
 pub mod dispatch;
+mod dispatch_state;
 pub mod do_ctrl;
 pub mod doeff_generator;
 pub mod driver;
@@ -24,6 +24,7 @@ pub mod error;
 pub mod frame;
 mod handler;
 pub mod ids;
+mod interceptor_state;
 pub mod py_key;
 pub mod py_shared;
 pub mod python_call;
@@ -32,11 +33,10 @@ pub mod rust_store;
 pub mod scheduler;
 pub mod segment;
 mod step;
-mod interceptor_state;
 mod trace_state;
-mod vm_logging;
 pub mod value;
 mod vm;
+mod vm_logging;
 
 // Re-exports for convenience
 pub use arena::SegmentArena;
@@ -60,7 +60,7 @@ pub use handler::{
     Handler, HandlerDebugInfo, HandlerEntry, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
     ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
 };
-pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
+pub use ids::{ContId, DispatchId, Marker, RunnableId, SegmentId};
 pub use py_key::HashedPyKey;
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
 pub use pyvm::{DoExprTag, PyStdlib, PyVM};
@@ -68,4 +68,4 @@ pub use rust_store::RustStore;
 pub use segment::{Segment, SegmentKind};
 pub use step::PyException;
 pub use value::Value;
-pub use vm::{Callback, VM};
+pub use vm::VM;

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -3077,7 +3077,10 @@ mod tests {
             .into_any();
 
             let yielded = pyvm.classify_yielded(py, &with_handler).unwrap();
-            let seg = pyvm.vm.current_segment_mut().expect("current segment missing");
+            let seg = pyvm
+                .vm
+                .current_segment_mut()
+                .expect("current segment missing");
             seg.mode = Mode::HandleYield(yielded);
 
             let event = pyvm.vm.step();

--- a/packages/doeff-vm/src/trace_state.rs
+++ b/packages/doeff-vm/src/trace_state.rs
@@ -829,7 +829,8 @@ impl TraceState {
         dispatch_stack: &[DispatchContext],
     ) -> Vec<ActiveChainEntry> {
         let raw_events = self.collect_raw_events();
-        let entries = self.events_to_entries(&raw_events, segments, current_segment, dispatch_stack);
+        let entries =
+            self.events_to_entries(&raw_events, segments, current_segment, dispatch_stack);
         let entries = Self::dedup_adjacent(entries);
         Self::inject_context(entries, exception)
     }
@@ -925,8 +926,10 @@ impl TraceState {
                 if let Some(frame_id) = effect_frame_id {
                     if visible_effect {
                         state.frame_dispatch.insert(*frame_id, *dispatch_id);
-                        if let Some(frame) =
-                            state.frame_stack.iter_mut().find(|f| f.frame_id == *frame_id)
+                        if let Some(frame) = state
+                            .frame_stack
+                            .iter_mut()
+                            .find(|f| f.frame_id == *frame_id)
                         {
                             if let Some(line) = effect_source_line {
                                 frame.source_line = *line;
@@ -1080,7 +1083,11 @@ impl TraceState {
     ) {
         self.merge_frame_lines_from_segments(&mut state.frame_stack, segments, current_segment);
         let (frame_stack, dispatches) = (&mut state.frame_stack, &state.dispatches);
-        self.merge_frame_lines_from_visible_dispatch_snapshot(frame_stack, dispatches, dispatch_stack);
+        self.merge_frame_lines_from_visible_dispatch_snapshot(
+            frame_stack,
+            dispatches,
+            dispatch_stack,
+        );
     }
 
     fn merge_frame_lines_from_segments(
@@ -1179,7 +1186,12 @@ impl TraceState {
     ) -> Vec<ActiveChainEntry> {
         let mut active_chain = self.entries_from_frame_stack(state);
         if active_chain.is_empty() {
-            self.fallback_entries_when_chain_empty(state, raw_events, dispatch_stack, &mut active_chain);
+            self.fallback_entries_when_chain_empty(
+                state,
+                raw_events,
+                dispatch_stack,
+                &mut active_chain,
+            );
         }
         active_chain
     }
@@ -1189,7 +1201,8 @@ impl TraceState {
         for (index, frame) in state.frame_stack.iter().enumerate() {
             let dispatch_id = state.frame_dispatch.get(&frame.frame_id).copied();
             let dispatch = dispatch_id.and_then(|id| state.dispatches.get(&id));
-            if let Some(dispatch) = dispatch.filter(|dispatch| Self::is_visible_dispatch(dispatch)) {
+            if let Some(dispatch) = dispatch.filter(|dispatch| Self::is_visible_dispatch(dispatch))
+            {
                 Self::push_effect_yield_entry(&mut active_chain, dispatch, Some(frame));
                 continue;
             }
@@ -1499,5 +1512,4 @@ impl TraceState {
     fn is_visible_dispatch(dispatch: &ActiveChainDispatchState) -> bool {
         !dispatch.is_execution_context_effect
     }
-
 }

--- a/packages/doeff-vm/src/vm.rs
+++ b/packages/doeff-vm/src/vm.rs
@@ -27,9 +27,9 @@ use crate::effect::{
 #[cfg(test)]
 use crate::effect::{Effect, PySpawn};
 use crate::error::VMError;
-use crate::frame::{CallMetadata, Frame};
+use crate::frame::{CallMetadata, EvalReturnContinuation, Frame, InterceptorContinuation};
 use crate::handler::{Handler, HandlerEntry, RustProgramInvocation};
-use crate::ids::{CallbackId, ContId, DispatchId, Marker, SegmentId};
+use crate::ids::{ContId, DispatchId, Marker, SegmentId};
 use crate::interceptor_state::InterceptorState;
 use crate::py_shared::PyShared;
 use crate::python_call::{PendingPython, PyCallOutcome, PythonCall};
@@ -41,7 +41,6 @@ use crate::value::Value;
 pub use crate::dispatch::DispatchContext;
 pub use crate::rust_store::RustStore;
 
-pub type Callback = Box<dyn FnOnce(Value, &mut VM) -> Mode + Send + Sync>;
 static NEXT_RUN_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug)]
@@ -243,7 +242,6 @@ impl DebugConfig {
 pub struct VM {
     pub segments: SegmentArena,
     pub(crate) dispatch_state: DispatchState,
-    pub callbacks: HashMap<CallbackId, Callback>,
     pub consumed_cont_ids: HashSet<ContId>,
     pub handlers: HashMap<Marker, HandlerEntry>,
     pub(crate) interceptor_state: InterceptorState,
@@ -261,7 +259,6 @@ impl VM {
         VM {
             segments: SegmentArena::new(),
             dispatch_state: DispatchState::default(),
-            callbacks: HashMap::new(),
             consumed_cont_ids: HashSet::new(),
             handlers: HashMap::new(),
             interceptor_state: InterceptorState::default(),
@@ -380,10 +377,9 @@ impl VM {
     ///    segment's frame stack during forwarding, but guard state must survive so
     ///    the next handler segment inherits the correct interceptor context.
     ///
-    /// 3. **Global callback maps are unstable.** `interceptor_state` maps are
-    ///    cleared on run boundaries, so deriving guard state from
-    ///    `interceptor_callbacks` / `interceptor_eval_callbacks` would break across
-    ///    continuation capture/resume spanning different runs.
+    /// 3. **Typed continuation frames are local.** Interceptor guard state must
+    ///    survive continuation capture/resume and segment topology rewrites even
+    ///    when relevant continuation frames are no longer present locally.
     #[inline]
     fn copy_interceptor_guard_state(
         &self,
@@ -400,12 +396,6 @@ impl VM {
         child_seg.interceptor_skip_stack = source_seg.interceptor_skip_stack.clone();
     }
 
-    pub fn register_callback(&mut self, callback: Callback) -> CallbackId {
-        let id = CallbackId::fresh();
-        self.callbacks.insert(id, callback);
-        id
-    }
-
     /// Set mode to Throw with a RuntimeError and return Continue.
     fn throw_runtime_error(&mut self, message: &str) -> StepEvent {
         let Some(seg) = self.current_segment_mut() else {
@@ -417,13 +407,16 @@ impl VM {
         StepEvent::Continue
     }
 
-    fn eval_then_reenter_call(&mut self, expr: PyShared, cb: Callback) -> StepEvent {
+    fn eval_then_reenter_call(
+        &mut self,
+        expr: PyShared,
+        continuation: EvalReturnContinuation,
+    ) -> StepEvent {
         let handlers = self.current_visible_handlers();
-        let cb_id = self.register_callback(cb);
         let Some(seg) = self.current_segment_mut() else {
             return StepEvent::Error(VMError::internal("Call evaluation outside current segment"));
         };
-        seg.push_frame(Frame::RustReturn { cb: cb_id });
+        seg.push_frame(Frame::EvalReturn(Box::new(continuation)));
         seg.mode = Mode::HandleYield(DoCtrl::Eval {
             expr,
             handlers,
@@ -665,11 +658,10 @@ impl VM {
                             | GenErrorSite::StepUserGeneratorDirect
                     )
             });
-        let in_get_execution_context_dispatch =
-            current_dispatch_id.is_some_and(|dispatch_id| {
-                self.dispatch_state
-                    .dispatch_is_execution_context_effect(dispatch_id)
-            });
+        let in_get_execution_context_dispatch = current_dispatch_id.is_some_and(|dispatch_id| {
+            self.dispatch_state
+                .dispatch_is_execution_context_effect(dispatch_id)
+        });
 
         if !site.allows_error_conversion() && !allow_handler_context_conversion {
             if let Some(original) = self.active_error_dispatch_original_exception() {
@@ -729,7 +721,9 @@ impl VM {
         let handler_identity = self
             .current_handler_identity_for_dispatch(dispatch_id)
             .or_else(|| {
-                let seg = self.current_segment.and_then(|seg_id| self.segments.get(seg_id))?;
+                let seg = self
+                    .current_segment
+                    .and_then(|seg_id| self.segments.get(seg_id))?;
                 if seg.dispatch_id != Some(dispatch_id) {
                     return None;
                 }
@@ -885,7 +879,8 @@ impl VM {
 
             if !segment.has_frames() {
                 let caller = segment.caller;
-                let mode = std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit));
+                let mode =
+                    std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit));
                 match mode {
                     Mode::Deliver(value) => {
                         // Don't free here — step_return reads the segment's caller.
@@ -927,37 +922,6 @@ impl VM {
         let mode = std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit));
 
         match frame {
-            Frame::RustReturn { cb } => {
-                let callback = match self.callbacks.remove(&cb) {
-                    Some(cb) => cb,
-                    None => return StepEvent::Error(VMError::internal("callback not found")),
-                };
-
-                match mode {
-                    Mode::Deliver(value) => {
-                        if let Some(metadata) = self.interceptor_state.take_call_metadata(cb) {
-                            self.maybe_emit_frame_exited(&metadata);
-                        }
-                        self.unregister_interceptor_eval_callback(cb);
-                        self.interceptor_state.unregister_callback(cb);
-                        self.current_seg_mut().mode = callback(value, self);
-                        StepEvent::Continue
-                    }
-                    Mode::Throw(exc) => {
-                        if let Some(metadata) = self.interceptor_state.take_call_metadata(cb) {
-                            self.maybe_emit_frame_exited(&metadata);
-                        }
-                        self.unregister_interceptor_eval_callback(cb);
-                        if let Some(marker) = self.interceptor_state.unregister_callback(cb) {
-                            self.pop_interceptor_skip(marker);
-                        }
-                        self.current_seg_mut().mode = Mode::Throw(exc);
-                        StepEvent::Continue
-                    }
-                    _ => unreachable!(),
-                }
-            }
-
             Frame::Program { stream, metadata } => {
                 let step = {
                     let mut guard = stream.lock().expect("ASTStream lock poisoned");
@@ -969,6 +933,295 @@ impl VM {
                 };
                 self.apply_stream_step(step, stream, metadata)
             }
+            Frame::InterceptorApply(cont) => self.step_interceptor_apply_frame(*cont, mode),
+            Frame::InterceptorEval(cont) => self.step_interceptor_eval_frame(*cont, mode),
+            Frame::HandlerDispatch { dispatch_id } => {
+                self.step_handler_dispatch_frame(dispatch_id, mode)
+            }
+            Frame::EvalReturn(continuation) => self.step_eval_return_frame(*continuation, mode),
+            Frame::MapReturn {
+                mapper,
+                mapper_meta,
+            } => self.step_map_return_frame(mapper, mapper_meta, mode),
+            Frame::FlatMapBindResult => self.step_flat_map_bind_result_frame(mode),
+            Frame::FlatMapBindSource {
+                binder,
+                binder_meta,
+            } => self.step_flat_map_bind_source_frame(binder, binder_meta, mode),
+            Frame::InterceptBodyReturn { marker } => {
+                self.step_intercept_body_return_frame(marker, mode)
+            }
+        }
+    }
+
+    fn step_interceptor_apply_frame(
+        &mut self,
+        continuation: InterceptorContinuation,
+        mode: Mode,
+    ) -> StepEvent {
+        if let Some(metadata) = continuation.interceptor_metadata.as_ref() {
+            self.maybe_emit_frame_exited(metadata);
+        }
+        match mode {
+            Mode::Deliver(value) => {
+                self.current_seg_mut().mode =
+                    self.handle_interceptor_apply_result(continuation, value);
+                StepEvent::Continue
+            }
+            Mode::Throw(exc) => {
+                self.pop_interceptor_skip(continuation.marker);
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn step_interceptor_eval_frame(
+        &mut self,
+        continuation: InterceptorContinuation,
+        mode: Mode,
+    ) -> StepEvent {
+        let seg = self.current_seg_mut();
+        seg.interceptor_eval_depth = seg.interceptor_eval_depth.saturating_sub(1);
+        match mode {
+            Mode::Deliver(value) => {
+                self.current_seg_mut().mode =
+                    self.handle_interceptor_eval_result(continuation, value);
+                StepEvent::Continue
+            }
+            Mode::Throw(exc) => {
+                self.pop_interceptor_skip(continuation.marker);
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn step_handler_dispatch_frame(&mut self, dispatch_id: DispatchId, mode: Mode) -> StepEvent {
+        let _ = dispatch_id;
+        match mode {
+            Mode::Deliver(value) => self.handle_handler_return(value),
+            Mode::Throw(exc) => {
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn step_eval_return_frame(
+        &mut self,
+        continuation: EvalReturnContinuation,
+        mode: Mode,
+    ) -> StepEvent {
+        match mode {
+            Mode::Deliver(value) => {
+                self.current_seg_mut().mode =
+                    self.mode_from_eval_return_continuation(continuation, value);
+                StepEvent::Continue
+            }
+            Mode::Throw(exc) => {
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn mode_from_eval_return_continuation(
+        &mut self,
+        continuation: EvalReturnContinuation,
+        value: Value,
+    ) -> Mode {
+        match continuation {
+            EvalReturnContinuation::ApplyResolveFunction {
+                args,
+                kwargs,
+                metadata,
+                evaluate_result,
+            } => Mode::HandleYield(DoCtrl::Apply {
+                f: CallArg::Value(value),
+                args,
+                kwargs,
+                metadata,
+                evaluate_result,
+            }),
+            EvalReturnContinuation::ApplyResolveArg {
+                f,
+                mut args,
+                kwargs,
+                arg_idx,
+                metadata,
+                evaluate_result,
+            } => {
+                let Some(slot) = args.get_mut(arg_idx) else {
+                    return Mode::Throw(PyException::runtime_error(
+                        "apply continuation arg index out of bounds",
+                    ));
+                };
+                *slot = CallArg::Value(value);
+                Mode::HandleYield(DoCtrl::Apply {
+                    f,
+                    args,
+                    kwargs,
+                    metadata,
+                    evaluate_result,
+                })
+            }
+            EvalReturnContinuation::ApplyResolveKwarg {
+                f,
+                args,
+                mut kwargs,
+                kwarg_idx,
+                metadata,
+                evaluate_result,
+            } => {
+                let Some((_, slot)) = kwargs.get_mut(kwarg_idx) else {
+                    return Mode::Throw(PyException::runtime_error(
+                        "apply continuation kwarg index out of bounds",
+                    ));
+                };
+                *slot = CallArg::Value(value);
+                Mode::HandleYield(DoCtrl::Apply {
+                    f,
+                    args,
+                    kwargs,
+                    metadata,
+                    evaluate_result,
+                })
+            }
+            EvalReturnContinuation::ExpandResolveFactory {
+                args,
+                kwargs,
+                metadata,
+            } => Mode::HandleYield(DoCtrl::Expand {
+                factory: CallArg::Value(value),
+                args,
+                kwargs,
+                metadata,
+            }),
+            EvalReturnContinuation::ExpandResolveArg {
+                factory,
+                mut args,
+                kwargs,
+                arg_idx,
+                metadata,
+            } => {
+                let Some(slot) = args.get_mut(arg_idx) else {
+                    return Mode::Throw(PyException::runtime_error(
+                        "expand continuation arg index out of bounds",
+                    ));
+                };
+                *slot = CallArg::Value(value);
+                Mode::HandleYield(DoCtrl::Expand {
+                    factory,
+                    args,
+                    kwargs,
+                    metadata,
+                })
+            }
+            EvalReturnContinuation::ExpandResolveKwarg {
+                factory,
+                args,
+                mut kwargs,
+                kwarg_idx,
+                metadata,
+            } => {
+                let Some((_, slot)) = kwargs.get_mut(kwarg_idx) else {
+                    return Mode::Throw(PyException::runtime_error(
+                        "expand continuation kwarg index out of bounds",
+                    ));
+                };
+                *slot = CallArg::Value(value);
+                Mode::HandleYield(DoCtrl::Expand {
+                    factory,
+                    args,
+                    kwargs,
+                    metadata,
+                })
+            }
+        }
+    }
+
+    fn step_map_return_frame(
+        &mut self,
+        mapper: PyShared,
+        mapper_meta: CallMetadata,
+        mode: Mode,
+    ) -> StepEvent {
+        match mode {
+            Mode::Deliver(value) => {
+                self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::Apply {
+                    f: CallArg::Value(Value::Python(mapper.into_inner())),
+                    args: vec![CallArg::Value(value)],
+                    kwargs: vec![],
+                    metadata: mapper_meta,
+                    evaluate_result: false,
+                });
+                StepEvent::Continue
+            }
+            Mode::Throw(exc) => {
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn step_flat_map_bind_result_frame(&mut self, mode: Mode) -> StepEvent {
+        match mode {
+            Mode::Deliver(value) => {
+                self.current_seg_mut().mode = Mode::Deliver(value);
+                StepEvent::Continue
+            }
+            Mode::Throw(exc) => {
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn step_flat_map_bind_source_frame(
+        &mut self,
+        binder: PyShared,
+        binder_meta: CallMetadata,
+        mode: Mode,
+    ) -> StepEvent {
+        match mode {
+            Mode::Deliver(value) => {
+                let Some(seg) = self.current_segment_mut() else {
+                    return StepEvent::Error(VMError::internal(
+                        "flat_map binder callback outside current segment",
+                    ));
+                };
+                seg.push_frame(Frame::FlatMapBindResult);
+                seg.mode = Mode::HandleYield(DoCtrl::Expand {
+                    factory: CallArg::Value(Value::Python(binder.into_inner())),
+                    args: vec![CallArg::Value(value)],
+                    kwargs: vec![],
+                    metadata: binder_meta,
+                });
+                StepEvent::Continue
+            }
+            Mode::Throw(exc) => {
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn step_intercept_body_return_frame(&mut self, _marker: Marker, mode: Mode) -> StepEvent {
+        match mode {
+            Mode::Deliver(value) => self.handle_handler_return(value),
+            Mode::Throw(exc) => {
+                self.current_seg_mut().mode = Mode::Throw(exc);
+                StepEvent::Continue
+            }
+            _ => unreachable!(),
         }
     }
 
@@ -1038,7 +1291,8 @@ impl VM {
                     .copied()
                     .unwrap_or_else(Marker::fresh);
                 let k = ctx.k_user.clone();
-                self.current_seg_mut().pending_python = Some(PendingPython::RustProgramContinuation { marker, k });
+                self.current_seg_mut().pending_python =
+                    Some(PendingPython::RustProgramContinuation { marker, k });
                 StepEvent::NeedsPython(call)
             }
         }
@@ -1051,7 +1305,8 @@ impl VM {
         metadata: Option<CallMetadata>,
     ) -> StepEvent {
         let chain = Arc::new(self.current_interceptor_chain());
-        self.current_seg_mut().mode = self.continue_interceptor_chain_mode(yielded, stream, metadata, chain, 0);
+        self.current_seg_mut().mode =
+            self.continue_interceptor_chain_mode(yielded, stream, metadata, chain, 0);
         StepEvent::Continue
     }
 
@@ -1109,21 +1364,6 @@ impl VM {
         InterceptorState::push_skip(self.current_seg_mut(), marker);
     }
 
-    fn register_interceptor_eval_callback(&mut self, cb: CallbackId) {
-        self.interceptor_state.register_eval_callback(cb);
-        let seg = self.current_seg_mut();
-        seg.interceptor_eval_depth = seg.interceptor_eval_depth.saturating_add(1);
-    }
-
-    fn unregister_interceptor_eval_callback(&mut self, cb: CallbackId) -> bool {
-        let removed = self.interceptor_state.unregister_eval_callback(cb);
-        if removed {
-            let seg = self.current_seg_mut();
-            seg.interceptor_eval_depth = seg.interceptor_eval_depth.saturating_sub(1);
-        }
-        removed
-    }
-
     fn is_interceptor_eval_idle(&self) -> bool {
         self.current_seg().interceptor_eval_depth == 0
     }
@@ -1131,7 +1371,7 @@ impl VM {
     fn classify_interceptor_result_object(
         &self,
         result_obj: Py<PyAny>,
-        original_obj: &Py<PyAny>,
+        original_obj: &PyShared,
         original_yielded: DoCtrl,
     ) -> Result<DoCtrl, PyException> {
         Python::attach(|py| {
@@ -1211,49 +1451,38 @@ impl VM {
     ) -> Mode {
         let interceptor_callable = entry.interceptor.into_inner();
         let interceptor_meta = entry.metadata.clone();
-        let yielded_obj_for_callback = Python::attach(|py| yielded_obj.clone_ref(py));
+        let yielded_obj_for_continuation = Python::attach(|py| yielded_obj.clone_ref(py));
         let apply_metadata = interceptor_meta
             .clone()
             .unwrap_or_else(Self::fallback_interceptor_metadata);
-
-        let cb = self.register_callback(Box::new(move |value, vm| {
-            vm.handle_interceptor_apply_result(
-                marker,
-                value,
-                yielded,
-                yielded_obj_for_callback,
-                stream,
-                metadata,
-                chain,
-                next_idx,
-            )
-        }));
-
-        self.interceptor_state.register_callback(cb, marker);
         self.push_interceptor_skip(marker);
 
         if self.current_segment.is_none() {
             self.pop_interceptor_skip(marker);
-            self.interceptor_state.unregister_callback(cb);
-            self.callbacks.remove(&cb);
             return Mode::Throw(PyException::runtime_error(
                 "current_segment_mut() returned None while invoking interceptor",
             ));
         }
         if let Some(meta) = interceptor_meta.as_ref() {
             self.maybe_emit_frame_entered(meta);
-            self.interceptor_state.set_call_metadata(cb, meta.clone());
         }
+        let continuation = InterceptorContinuation {
+            marker,
+            original_yielded: yielded,
+            original_obj: PyShared::new(yielded_obj_for_continuation),
+            emitter_stream: stream,
+            emitter_metadata: metadata,
+            chain,
+            next_idx,
+            interceptor_metadata: interceptor_meta,
+        };
         let Some(seg) = self.current_segment_mut() else {
-            self.interceptor_state.take_call_metadata(cb);
             self.pop_interceptor_skip(marker);
-            self.interceptor_state.unregister_callback(cb);
-            self.callbacks.remove(&cb);
             return Mode::Throw(PyException::runtime_error(
                 "current_segment_mut() returned None while invoking interceptor",
             ));
         };
-        seg.push_frame(Frame::RustReturn { cb });
+        seg.push_frame(Frame::InterceptorApply(Box::new(continuation)));
 
         Mode::HandleYield(DoCtrl::Apply {
             f: CallArg::Value(Value::Python(interceptor_callable)),
@@ -1266,15 +1495,19 @@ impl VM {
 
     fn handle_interceptor_apply_result(
         &mut self,
-        marker: Marker,
+        continuation: InterceptorContinuation,
         value: Value,
-        original_yielded: DoCtrl,
-        original_obj: Py<PyAny>,
-        stream: ASTStreamRef,
-        metadata: Option<CallMetadata>,
-        chain: Arc<Vec<Marker>>,
-        next_idx: usize,
     ) -> Mode {
+        let InterceptorContinuation {
+            marker,
+            original_yielded,
+            original_obj,
+            emitter_stream,
+            emitter_metadata,
+            chain,
+            next_idx,
+            ..
+        } = continuation;
         let Value::Python(result_obj) = value else {
             self.pop_interceptor_skip(marker);
             return Mode::Throw(PyException::type_error(
@@ -1299,39 +1532,31 @@ impl VM {
             self.pop_interceptor_skip(marker);
             return self.continue_interceptor_chain_mode(
                 transformed,
-                stream,
-                metadata,
+                emitter_stream,
+                emitter_metadata,
                 chain,
                 next_idx,
             );
         }
 
         if is_doexpr {
-            let cb = self.register_callback(Box::new(move |resolved, vm| {
-                vm.handle_interceptor_eval_result(
-                    marker,
-                    resolved,
-                    original_yielded,
-                    original_obj,
-                    stream,
-                    metadata,
-                    chain,
-                    next_idx,
-                )
-            }));
-            self.interceptor_state.register_callback(cb, marker);
-            self.register_interceptor_eval_callback(cb);
-
             let Some(seg) = self.current_segment_mut() else {
                 self.pop_interceptor_skip(marker);
-                self.interceptor_state.unregister_callback(cb);
-                self.unregister_interceptor_eval_callback(cb);
-                self.callbacks.remove(&cb);
                 return Mode::Throw(PyException::runtime_error(
                     "current_segment_mut() returned None while evaluating interceptor result",
                 ));
             };
-            seg.push_frame(Frame::RustReturn { cb });
+            seg.interceptor_eval_depth = seg.interceptor_eval_depth.saturating_add(1);
+            seg.push_frame(Frame::InterceptorEval(Box::new(InterceptorContinuation {
+                marker,
+                original_yielded,
+                original_obj,
+                emitter_stream,
+                emitter_metadata,
+                chain,
+                next_idx,
+                interceptor_metadata: None,
+            })));
 
             let handlers = self.current_visible_handlers();
             return Mode::HandleYield(DoCtrl::Eval {
@@ -1349,15 +1574,19 @@ impl VM {
 
     fn handle_interceptor_eval_result(
         &mut self,
-        marker: Marker,
+        continuation: InterceptorContinuation,
         value: Value,
-        original_yielded: DoCtrl,
-        original_obj: Py<PyAny>,
-        stream: ASTStreamRef,
-        metadata: Option<CallMetadata>,
-        chain: Arc<Vec<Marker>>,
-        next_idx: usize,
     ) -> Mode {
+        let InterceptorContinuation {
+            marker,
+            original_yielded,
+            original_obj,
+            emitter_stream,
+            emitter_metadata,
+            chain,
+            next_idx,
+            ..
+        } = continuation;
         let Value::Python(result_obj) = value else {
             self.pop_interceptor_skip(marker);
             return Mode::Throw(PyException::type_error(
@@ -1377,17 +1606,24 @@ impl VM {
             }
         };
         self.pop_interceptor_skip(marker);
-        self.continue_interceptor_chain_mode(transformed, stream, metadata, chain, next_idx)
+        self.continue_interceptor_chain_mode(
+            transformed,
+            emitter_stream,
+            emitter_metadata,
+            chain,
+            next_idx,
+        )
     }
 
     fn step_handle_yield(&mut self) -> StepEvent {
-        let yielded = match std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit)) {
-            Mode::HandleYield(y) => y,
-            other => {
-                self.current_seg_mut().mode = other;
-                return StepEvent::Error(VMError::internal("invalid mode for handle_yield"));
-            }
-        };
+        let yielded =
+            match std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit)) {
+                Mode::HandleYield(y) => y,
+                other => {
+                    self.current_seg_mut().mode = other;
+                    return StepEvent::Error(VMError::internal("invalid mode for handle_yield"));
+                }
+            };
 
         self.lazy_pop_completed();
         match yielded {
@@ -1603,49 +1839,40 @@ impl VM {
             let expr = expr.clone();
             return self.eval_then_reenter_call(
                 expr,
-                Box::new(move |resolved_f, _vm| {
-                    Mode::HandleYield(DoCtrl::Apply {
-                        f: CallArg::Value(resolved_f),
-                        args,
-                        kwargs,
-                        metadata,
-                        evaluate_result,
-                    })
-                }),
+                EvalReturnContinuation::ApplyResolveFunction {
+                    args,
+                    kwargs,
+                    metadata,
+                    evaluate_result,
+                },
             );
         }
 
         if let Some((arg_idx, expr)) = Self::first_expr_arg(&args) {
             return self.eval_then_reenter_call(
                 expr,
-                Box::new(move |resolved_arg, _vm| {
-                    let mut args = args;
-                    args[arg_idx] = CallArg::Value(resolved_arg);
-                    Mode::HandleYield(DoCtrl::Apply {
-                        f,
-                        args,
-                        kwargs,
-                        metadata,
-                        evaluate_result,
-                    })
-                }),
+                EvalReturnContinuation::ApplyResolveArg {
+                    f,
+                    args,
+                    kwargs,
+                    arg_idx,
+                    metadata,
+                    evaluate_result,
+                },
             );
         }
 
         if let Some((kwargs_idx, expr)) = Self::first_expr_kwarg(&kwargs) {
             return self.eval_then_reenter_call(
                 expr,
-                Box::new(move |resolved_kwarg, _vm| {
-                    let mut kwargs = kwargs;
-                    kwargs[kwargs_idx].1 = CallArg::Value(resolved_kwarg);
-                    Mode::HandleYield(DoCtrl::Apply {
-                        f,
-                        args,
-                        kwargs,
-                        metadata,
-                        evaluate_result,
-                    })
-                }),
+                EvalReturnContinuation::ApplyResolveKwarg {
+                    f,
+                    args,
+                    kwargs,
+                    kwarg_idx: kwargs_idx,
+                    metadata,
+                    evaluate_result,
+                },
             );
         }
 
@@ -1687,46 +1914,37 @@ impl VM {
             let expr = expr.clone();
             return self.eval_then_reenter_call(
                 expr,
-                Box::new(move |resolved_factory, _vm| {
-                    Mode::HandleYield(DoCtrl::Expand {
-                        factory: CallArg::Value(resolved_factory),
-                        args,
-                        kwargs,
-                        metadata,
-                    })
-                }),
+                EvalReturnContinuation::ExpandResolveFactory {
+                    args,
+                    kwargs,
+                    metadata,
+                },
             );
         }
 
         if let Some((arg_idx, expr)) = Self::first_expr_arg(&args) {
             return self.eval_then_reenter_call(
                 expr,
-                Box::new(move |resolved_arg, _vm| {
-                    let mut args = args;
-                    args[arg_idx] = CallArg::Value(resolved_arg);
-                    Mode::HandleYield(DoCtrl::Expand {
-                        factory,
-                        args,
-                        kwargs,
-                        metadata,
-                    })
-                }),
+                EvalReturnContinuation::ExpandResolveArg {
+                    factory,
+                    args,
+                    kwargs,
+                    arg_idx,
+                    metadata,
+                },
             );
         }
 
         if let Some((kwargs_idx, expr)) = Self::first_expr_kwarg(&kwargs) {
             return self.eval_then_reenter_call(
                 expr,
-                Box::new(move |resolved_kwarg, _vm| {
-                    let mut kwargs = kwargs;
-                    kwargs[kwargs_idx].1 = CallArg::Value(resolved_kwarg);
-                    Mode::HandleYield(DoCtrl::Expand {
-                        factory,
-                        args,
-                        kwargs,
-                        metadata,
-                    })
-                }),
+                EvalReturnContinuation::ExpandResolveKwarg {
+                    factory,
+                    args,
+                    kwargs,
+                    kwarg_idx: kwargs_idx,
+                    metadata,
+                },
             );
         }
 
@@ -1791,11 +2009,17 @@ impl VM {
         while let Some(id) = seg_id {
             if let Some(seg) = self.segments.get(id) {
                 for frame in seg.frames.iter().rev() {
-                    if let Frame::Program {
-                        metadata: Some(m), ..
-                    } = frame
-                    {
-                        stack.push(m.clone());
+                    match frame {
+                        Frame::Program {
+                            metadata: Some(m), ..
+                        } => stack.push(m.clone()),
+                        Frame::InterceptorApply(continuation)
+                        | Frame::InterceptorEval(continuation) => {
+                            if let Some(metadata) = continuation.emitter_metadata.as_ref() {
+                                stack.push(metadata.clone());
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 seg_id = seg.caller;
@@ -1855,13 +2079,14 @@ impl VM {
     }
 
     fn step_return(&mut self) -> StepEvent {
-        let value = match std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit)) {
-            Mode::Return(v) => v,
-            other => {
-                self.current_seg_mut().mode = other;
-                return StepEvent::Error(VMError::internal("invalid mode for return"));
-            }
-        };
+        let value =
+            match std::mem::replace(&mut self.current_seg_mut().mode, Mode::Deliver(Value::Unit)) {
+                Mode::Return(v) => v,
+                other => {
+                    self.current_seg_mut().mode = other;
+                    return StepEvent::Error(VMError::internal("invalid mode for return"));
+                }
+            };
 
         let seg_id = match self.current_segment {
             Some(id) => id,
@@ -1934,7 +2159,8 @@ impl VM {
                 self.current_seg_mut().mode = Mode::HandleYield(yielded);
             }
             PyCallOutcome::GenError(exception) => {
-                self.current_seg_mut().mode = self.mode_after_generror(GenErrorSite::EvalExpr, exception, false);
+                self.current_seg_mut().mode =
+                    self.mode_after_generror(GenErrorSite::EvalExpr, exception, false);
             }
             PyCallOutcome::GenReturn(value) | PyCallOutcome::Value(value) => {
                 self.current_seg_mut().mode = Mode::Deliver(value);
@@ -1976,7 +2202,10 @@ impl VM {
         }
     }
 
-    fn classify_apply_result_as_doctrl(&self, value: &Value) -> Result<Option<DoCtrl>, PyException> {
+    fn classify_apply_result_as_doctrl(
+        &self,
+        value: &Value,
+    ) -> Result<Option<DoCtrl>, PyException> {
         let Value::Python(result_obj) = value else {
             return Ok(None);
         };
@@ -2022,20 +2251,21 @@ impl VM {
                 match Self::extract_doeff_generator(handler_gen, metadata, "ExpandReturn(handler)")
                 {
                     Ok((stream, metadata)) => {
-                        let handler_return_cb = self.register_callback(Box::new(|value, vm| {
-                            let _ = vm.handle_handler_return(value);
-                            std::mem::replace(
-                                &mut vm.current_seg_mut().mode,
-                                Mode::Deliver(Value::Unit),
-                            )
-                        }));
+                        let Some(dispatch_id) = self
+                            .current_dispatch_id()
+                            .or_else(|| self.current_active_handler_dispatch_id())
+                        else {
+                            self.current_seg_mut().mode = Mode::Throw(PyException::runtime_error(
+                                "handler dispatch continuation outside dispatch",
+                            ));
+                            return;
+                        };
                         let Some(seg) = self.current_segment_mut() else {
                             return;
                         };
-                        seg.push_frame(Frame::RustReturn {
-                            cb: handler_return_cb,
-                        });
-                        self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::ASTStream { stream, metadata });
+                        seg.push_frame(Frame::HandlerDispatch { dispatch_id });
+                        self.current_seg_mut().mode =
+                            Mode::HandleYield(DoCtrl::ASTStream { stream, metadata });
                     }
                     Err(exception) => {
                         self.current_seg_mut().mode = Mode::Throw(exception);
@@ -2053,7 +2283,8 @@ impl VM {
             Value::Python(generator) => {
                 match Self::extract_doeff_generator(generator, metadata, "ExpandReturn") {
                     Ok((stream, metadata)) => {
-                        self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::ASTStream { stream, metadata });
+                        self.current_seg_mut().mode =
+                            Mode::HandleYield(DoCtrl::ASTStream { stream, metadata });
                     }
                     Err(exception) => {
                         self.current_seg_mut().mode = Mode::Throw(exception);
@@ -2090,7 +2321,8 @@ impl VM {
             return;
         }
 
-        self.current_seg_mut().mode = self.mode_after_generror(GenErrorSite::ExpandReturnProgram, exception, false);
+        self.current_seg_mut().mode =
+            self.mode_after_generror(GenErrorSite::ExpandReturnProgram, exception, false);
     }
 
     fn receive_step_user_generator_result(
@@ -2192,7 +2424,8 @@ impl VM {
                 self.current_seg_mut().mode = Mode::Deliver(result);
             }
             PyCallOutcome::GenError(exception) => {
-                self.current_seg_mut().mode = self.mode_after_generror(GenErrorSite::AsyncEscape, exception, false);
+                self.current_seg_mut().mode =
+                    self.mode_after_generror(GenErrorSite::AsyncEscape, exception, false);
             }
             _ => {
                 self.receive_unexpected_outcome();
@@ -2256,7 +2489,11 @@ impl VM {
         while let Some(seg_id) = cursor {
             let seg = self.segments.get(seg_id)?;
             if let Some(dispatch_id) = seg.dispatch_id {
-                if self.dispatch_state.find_by_dispatch_id(dispatch_id).is_some() {
+                if self
+                    .dispatch_state
+                    .find_by_dispatch_id(dispatch_id)
+                    .is_some()
+                {
                     return Some(dispatch_id);
                 }
             }
@@ -2600,11 +2837,7 @@ impl VM {
                     .caller_segment(self.current_segment)
                     .and_then(|seg_id| self.segments.get(seg_id))
                     .and_then(|seg| seg.caller);
-                self.enter_continuation_segment_with_dispatch(
-                    &k,
-                    caller,
-                    None,
-                );
+                self.enter_continuation_segment_with_dispatch(&k, caller, None);
                 self.current_seg_mut().mode = Mode::Throw(enriched_exception);
                 return StepEvent::Continue;
             }
@@ -2698,15 +2931,16 @@ impl VM {
         let exec_seg_id = self.alloc_segment(exec_seg);
 
         self.current_segment = Some(exec_seg_id);
-        self.current_seg_mut().mode = if terminal_dispatch_completion && thrown_by_context_conversion_handler {
-            self.mode_after_generror(
-                GenErrorSite::RustProgramContinuation,
-                exception,
-                thrown_by_context_conversion_handler,
-            )
-        } else {
-            Mode::Throw(exception)
-        };
+        self.current_seg_mut().mode =
+            if terminal_dispatch_completion && thrown_by_context_conversion_handler {
+                self.mode_after_generror(
+                    GenErrorSite::RustProgramContinuation,
+                    exception,
+                    thrown_by_context_conversion_handler,
+                )
+            } else {
+                Mode::Throw(exception)
+            };
         StepEvent::Continue
     }
 
@@ -2978,20 +3212,14 @@ impl VM {
             if should_eval && self.is_interceptor_eval_idle() {
                 let handlers = self.current_visible_handlers();
                 let expr = Python::attach(|py| PyShared::new(obj.clone_ref(py)));
-                let cb = self.register_callback(Box::new(|resolved, vm| {
-                    let _ = vm.handle_handler_return(resolved);
-                    std::mem::replace(
-                        &mut vm.current_seg_mut().mode,
-                        Mode::Deliver(Value::Unit),
-                    )
-                }));
+                let marker = self.current_seg().marker;
                 let Some(seg) = self.current_segment_mut() else {
                     return StepEvent::Error(VMError::internal(
                         "current_segment_mut() returned None in handle_handler_return \
                          while scheduling Eval callback",
                     ));
                 };
-                seg.push_frame(Frame::RustReturn { cb });
+                seg.push_frame(Frame::InterceptBodyReturn { marker });
                 self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::Eval {
                     expr,
                     handlers,
@@ -3005,7 +3233,10 @@ impl VM {
             self.current_seg_mut().mode = Mode::Deliver(value);
             return StepEvent::Continue;
         };
-        let Some(top_snapshot) = self.dispatch_state.find_by_dispatch_id(dispatch_id).cloned()
+        let Some(top_snapshot) = self
+            .dispatch_state
+            .find_by_dispatch_id(dispatch_id)
+            .cloned()
         else {
             self.current_seg_mut().mode = Mode::Deliver(value);
             return StepEvent::Continue;
@@ -3069,10 +3300,11 @@ impl VM {
         };
 
         if let Some(original) = original_exception {
-            self.current_seg_mut().mode = match Self::enrich_original_exception_with_context(original, value) {
-                Ok(exception) => Mode::Throw(exception),
-                Err(effect_err) => Mode::Throw(effect_err),
-            };
+            self.current_seg_mut().mode =
+                match Self::enrich_original_exception_with_context(original, value) {
+                    Ok(exception) => Mode::Throw(exception),
+                    Err(effect_err) => Mode::Throw(effect_err),
+                };
             return StepEvent::Continue;
         }
 
@@ -3099,20 +3331,14 @@ impl VM {
         mapper_meta: CallMetadata,
     ) -> StepEvent {
         let handlers = self.current_visible_handlers();
-        let map_cb = self.register_callback(Box::new(move |value, _vm| {
-            Mode::HandleYield(DoCtrl::Apply {
-                f: CallArg::Value(Value::Python(mapper.into_inner())),
-                args: vec![CallArg::Value(value)],
-                kwargs: vec![],
-                metadata: mapper_meta.clone(),
-                evaluate_result: false,
-            })
-        }));
 
         let Some(seg) = self.current_segment_mut() else {
             return StepEvent::Error(VMError::internal("Map outside current segment"));
         };
-        seg.push_frame(Frame::RustReturn { cb: map_cb });
+        seg.push_frame(Frame::MapReturn {
+            mapper,
+            mapper_meta,
+        });
         self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::Eval {
             expr: source,
             handlers,
@@ -3128,28 +3354,14 @@ impl VM {
         binder_meta: CallMetadata,
     ) -> StepEvent {
         let handlers = self.current_visible_handlers();
-        let bind_result_cb =
-            self.register_callback(Box::new(move |bound_value, _vm| Mode::Deliver(bound_value)));
-
-        let bind_source_cb = self.register_callback(Box::new(move |value, vm| {
-            let Some(seg) = vm.current_segment_mut() else {
-                return Mode::Throw(PyException::runtime_error(
-                    "flat_map binder callback outside current segment",
-                ));
-            };
-            seg.push_frame(Frame::RustReturn { cb: bind_result_cb });
-            Mode::HandleYield(DoCtrl::Expand {
-                factory: CallArg::Value(Value::Python(binder.into_inner())),
-                args: vec![CallArg::Value(value)],
-                kwargs: vec![],
-                metadata: binder_meta.clone(),
-            })
-        }));
 
         let Some(seg) = self.current_segment_mut() else {
             return StepEvent::Error(VMError::internal("FlatMap outside current segment"));
         };
-        seg.push_frame(Frame::RustReturn { cb: bind_source_cb });
+        seg.push_frame(Frame::FlatMapBindSource {
+            binder,
+            binder_meta,
+        });
         self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::Eval {
             expr: source,
             handlers,
@@ -3163,9 +3375,7 @@ impl VM {
             return StepEvent::Error(VMError::internal("GetContinuation outside dispatch"));
         };
         let Some(ctx) = self.dispatch_state.find_by_dispatch_id(dispatch_id) else {
-            return StepEvent::Error(VMError::internal(
-                "GetContinuation: dispatch not found",
-            ));
+            return StepEvent::Error(VMError::internal("GetContinuation: dispatch not found"));
         };
         let k = ctx.k_user.clone();
         self.register_continuation(k.clone());


### PR DESCRIPTION
## Summary
- Removed callback-based continuation plumbing from doeff-vm (`Frame::RustReturn`, `CallbackId`, `VM::callbacks`, `Callback` alias).
- Introduced typed continuation frames with named fields:
  - `InterceptorApply(Box<InterceptorContinuation>)`
  - `InterceptorEval(Box<InterceptorContinuation>)`
  - `HandlerDispatch { dispatch_id }`
  - `EvalReturn(Box<EvalReturnContinuation>)`
  - `MapReturn { mapper, mapper_meta }`
  - `FlatMapBindResult`
  - `FlatMapBindSource { binder, binder_meta }`
  - `InterceptBodyReturn { marker }`
- Reworked VM step dispatch to match on `(Frame, Mode)` with typed handlers.
- Replaced all former callback push sites (`Eval` re-entry for Apply/Expand, handler dispatch, map/flat_map, interceptor apply/eval).
- Updated `GetCallStack` to include emitter metadata from `InterceptorApply` / `InterceptorEval` frames.
- Simplified interceptor state by removing callback-id tracking maps.
- Updated dependent tests and frame/debug helpers.

## Acceptance Criteria Evidence (VM-FRAME-001)
- Typed interceptor frames added and wired:
  - `packages/doeff-vm/src/frame.rs` now defines `InterceptorApply`/`InterceptorEval` with boxed `InterceptorContinuation` fields.
- Interceptor invocation no longer uses callback IDs/closures:
  - `packages/doeff-vm/src/vm.rs` pushes `Frame::InterceptorApply` in `start_interceptor_invocation_mode`.
  - `handle_interceptor_apply_result` pushes `Frame::InterceptorEval` directly.
- Call stack visibility fixed:
  - `handle_yield_get_call_stack` now reads emitter metadata from interceptor frames.
  - Verification script output:
    - `from-inner: ['observer_fn', 'inner', 'outer']`
    - `from-outer: ['observer_fn', 'outer']`
- Callback-based continuation system deleted:
  - `rg -n "CallbackId" packages/doeff-vm/src` => no matches.
  - `rg -n "Box<dyn FnOnce" packages/doeff-vm/src` => no matches.
  - `rg -n "RustReturn|Frame::RustReturn" packages/doeff-vm/src` => no matches.

## Validation
- `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q`
  - `218 passed; 0 failed`
- `make sync` (rebuilds doeff-vm extension)
- `uv run pytest -q`
  - `754 passed; 0 failed` (warnings only)
- Interceptor emitter visibility script from issue prompt
  - passed (see call stack output above)

## Issue
- Ref: `VM-FRAME-001`
