### PR TITLE
Full CEK frames: remove RustReturn/CallbackId and type continuations

### DIFF
--- a/packages/doeff-vm/src/arena.rs
+++ b/packages/doeff-vm/src/arena.rs
@@ -143,8 +143,7 @@ mod tests {
         {
             let seg_mut = arena.get_mut(id).unwrap();
             use crate::frame::Frame;
-            use crate::ids::CallbackId;
-            seg_mut.push_frame(Frame::rust_return(CallbackId::fresh()));
+            seg_mut.push_frame(Frame::HandlerDispatch { dispatch_id: None });
         }
 
         let seg_ref = arena.get(id).unwrap();
@@ -166,6 +165,9 @@ mod tests {
         assert_eq!(rewired, 2);
         assert_eq!(arena.get(child_a).and_then(|seg| seg.caller), Some(caller));
         assert_eq!(arena.get(child_b).and_then(|seg| seg.caller), Some(caller));
-        assert_eq!(arena.get(unrelated).and_then(|seg| seg.caller), Some(caller));
+        assert_eq!(
+            arena.get(unrelated).and_then(|seg| seg.caller),
+            Some(caller)
+        );
     }
 }

--- a/packages/doeff-vm/src/continuation.rs
+++ b/packages/doeff-vm/src/continuation.rs
@@ -259,13 +259,12 @@ mod tests {
         let mut seg = Segment::new(marker, None, vec![marker]);
         let seg_id = SegmentId::from_index(0);
 
-        use crate::ids::CallbackId;
-        seg.push_frame(Frame::rust_return(CallbackId::fresh()));
+        seg.push_frame(Frame::HandlerDispatch { dispatch_id: None });
 
         let cont = Continuation::capture(&seg, seg_id, None);
         assert_eq!(cont.frames_snapshot.len(), 1);
 
-        seg.push_frame(Frame::rust_return(CallbackId::fresh()));
+        seg.push_frame(Frame::HandlerDispatch { dispatch_id: None });
         assert_eq!(cont.frames_snapshot.len(), 1);
         assert_eq!(seg.frame_count(), 2);
     }

--- a/packages/doeff-vm/src/debug_state.rs
+++ b/packages/doeff-vm/src/debug_state.rs
@@ -119,10 +119,7 @@ impl DebugState {
         Self::truncate_repr(repr)
     }
 
-    pub(crate) fn format_do_ctrl(
-        yielded: &DoCtrl,
-        verbosity: ModeFormatVerbosity,
-    ) -> &'static str {
+    pub(crate) fn format_do_ctrl(yielded: &DoCtrl, verbosity: ModeFormatVerbosity) -> &'static str {
         let formatted = match yielded {
             DoCtrl::Pure { .. } => "HandleYield(Pure)",
             DoCtrl::Map { .. } => "HandleYield(Map)",
@@ -154,11 +151,7 @@ impl DebugState {
         }
     }
 
-    pub(crate) fn format_mode(
-        &self,
-        mode: &Mode,
-        verbosity: ModeFormatVerbosity,
-    ) -> &'static str {
+    pub(crate) fn format_mode(&self, mode: &Mode, verbosity: ModeFormatVerbosity) -> &'static str {
         match mode {
             Mode::Deliver(_) => "Deliver",
             Mode::Throw(_) => "Throw",
@@ -260,16 +253,26 @@ impl DebugState {
 
         crate::vm_debug_log!(
             "[step {}] mode={} {} dispatch_depth={} pending={}",
-            self.step_counter, mode_kind, seg_info, dispatch_depth, pending
+            self.step_counter,
+            mode_kind,
+            seg_info,
+            dispatch_depth,
+            pending
         );
 
         if self.config.level == DebugLevel::Trace && self.config.show_frames {
             if let Some(seg) = current_segment.and_then(|id| segments.get(id)) {
                 for (i, frame) in seg.frames.iter().enumerate() {
                     let frame_kind = match frame {
-                        Frame::RustReturn { .. } => "RustReturn",
                         Frame::Program { metadata, .. } if metadata.is_some() => "Program(meta)",
                         Frame::Program { .. } => "Program",
+                        Frame::InterceptorApply(..) => "InterceptorApply",
+                        Frame::InterceptorEval(..) => "InterceptorEval",
+                        Frame::EvalReturn { .. } => "EvalReturn",
+                        Frame::HandlerDispatch { .. } => "HandlerDispatch",
+                        Frame::MapReturn { .. } => "MapReturn",
+                        Frame::FlatMapBindResult => "FlatMapBindResult",
+                        Frame::FlatMapBindSource { .. } => "FlatMapBindSource",
                     };
                     crate::vm_debug_log!("  frame[{}]: {}", i, frame_kind);
                 }

--- a/packages/doeff-vm/src/dispatch_state.rs
+++ b/packages/doeff-vm/src/dispatch_state.rs
@@ -68,18 +68,12 @@ impl DispatchState {
             .find(|ctx| ctx.dispatch_id == dispatch_id)
     }
 
-    pub(crate) fn effect_for_dispatch(
-        &self,
-        dispatch_id: DispatchId,
-    ) -> Option<DispatchEffect> {
+    pub(crate) fn effect_for_dispatch(&self, dispatch_id: DispatchId) -> Option<DispatchEffect> {
         self.find_by_dispatch_id(dispatch_id)
             .map(|ctx| ctx.effect.clone())
     }
 
-    pub(crate) fn dispatch_is_execution_context_effect(
-        &self,
-        dispatch_id: DispatchId,
-    ) -> bool {
+    pub(crate) fn dispatch_is_execution_context_effect(&self, dispatch_id: DispatchId) -> bool {
         self.find_by_dispatch_id(dispatch_id)
             .is_some_and(|ctx| ctx.is_execution_context_effect)
     }

--- a/packages/doeff-vm/src/frame.rs
+++ b/packages/doeff-vm/src/frame.rs
@@ -1,9 +1,11 @@
 //! Frame types for the continuation stack.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::ast_stream::ASTStreamRef;
-use crate::ids::CallbackId;
+use crate::do_ctrl::{CallArg, DoCtrl};
+use crate::ids::{DispatchId, Marker};
 use crate::py_shared::PyShared;
 
 static NEXT_FRAME_ID: AtomicU64 = AtomicU64::new(1);
@@ -59,32 +61,94 @@ impl CallMetadata {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct InterceptorContinuation {
+    pub marker: Marker,
+    pub original_yielded: Arc<DoCtrl>,
+    pub original_obj: PyShared,
+    pub emitter_stream: ASTStreamRef,
+    pub emitter_metadata: Option<CallMetadata>,
+    pub chain: Arc<Vec<Marker>>,
+    pub next_idx: usize,
+    pub interceptor_metadata: Option<CallMetadata>,
+}
+
+#[derive(Debug, Clone)]
+pub enum EvalReturnContinuation {
+    ApplyResolveFunction {
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+        evaluate_result: bool,
+    },
+    ApplyResolveArg {
+        f: CallArg,
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+        evaluate_result: bool,
+        arg_idx: usize,
+    },
+    ApplyResolveKwarg {
+        f: CallArg,
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+        evaluate_result: bool,
+        kwargs_idx: usize,
+    },
+    ExpandResolveFactory {
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+    },
+    ExpandResolveArg {
+        factory: CallArg,
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+        arg_idx: usize,
+    },
+    ExpandResolveKwarg {
+        factory: CallArg,
+        args: Vec<CallArg>,
+        kwargs: Vec<(String, CallArg)>,
+        metadata: CallMetadata,
+        kwargs_idx: usize,
+    },
+}
+
 /// A frame in the continuation stack.
 ///
 /// Frames must be Clone to allow continuation capture (Arc snapshots).
-/// Rust callbacks are stored in a separate table and referenced by CallbackId.
 #[derive(Debug, Clone)]
 pub enum Frame {
-    RustReturn {
-        cb: CallbackId,
-    },
     Program {
         stream: ASTStreamRef,
         metadata: Option<CallMetadata>,
     },
+    InterceptorApply(Box<InterceptorContinuation>),
+    InterceptorEval(Box<InterceptorContinuation>),
+    EvalReturn {
+        continuation: EvalReturnContinuation,
+    },
+    HandlerDispatch {
+        dispatch_id: Option<DispatchId>,
+    },
+    MapReturn {
+        mapper: PyShared,
+        mapper_meta: CallMetadata,
+    },
+    FlatMapBindResult,
+    FlatMapBindSource {
+        binder: PyShared,
+        binder_meta: CallMetadata,
+    },
 }
 
 impl Frame {
-    pub fn rust_return(cb: CallbackId) -> Self {
-        Frame::RustReturn { cb }
-    }
-
     pub fn program(stream: ASTStreamRef, metadata: Option<CallMetadata>) -> Self {
         Frame::Program { stream, metadata }
-    }
-
-    pub fn is_rust(&self) -> bool {
-        matches!(self, Frame::RustReturn { .. })
     }
 
     pub fn is_program(&self) -> bool {
@@ -105,31 +169,38 @@ impl Frame {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast_stream::{ASTStream, ASTStreamStep};
+    use crate::driver::PyException;
+    use crate::rust_store::RustStore;
+    use crate::value::Value;
+
+    #[derive(Debug)]
+    struct DummyProgramStream;
+
+    impl ASTStream for DummyProgramStream {
+        fn resume(&mut self, _value: Value, _store: &mut RustStore) -> ASTStreamStep {
+            ASTStreamStep::Return(Value::Unit)
+        }
+
+        fn throw(&mut self, exc: PyException, _store: &mut RustStore) -> ASTStreamStep {
+            ASTStreamStep::Throw(exc)
+        }
+    }
 
     #[test]
-    fn test_frame_rust_return() {
-        let cb_id = CallbackId::fresh();
-        let frame = Frame::rust_return(cb_id);
-        assert!(frame.is_rust());
-        assert!(!frame.is_program());
+    fn test_frame_program() {
+        let metadata = CallMetadata::anonymous();
+        let stream: ASTStreamRef = Arc::new(std::sync::Mutex::new(
+            Box::new(DummyProgramStream) as Box<dyn ASTStream>
+        ));
+        let frame = Frame::program(stream, Some(metadata));
+        assert!(frame.is_program());
     }
 
     #[test]
     fn test_frame_is_clone() {
-        let cb_id = CallbackId::fresh();
-        let frame = Frame::rust_return(cb_id);
+        let frame = Frame::HandlerDispatch { dispatch_id: None };
         let _cloned = frame.clone();
-    }
-
-    /// G13: Frame::RustReturn uses `cb` field name per spec.
-    #[test]
-    fn test_frame_rust_return_field_is_cb() {
-        let cb_id = CallbackId::fresh();
-        let frame = Frame::RustReturn { cb: cb_id };
-        match frame {
-            Frame::RustReturn { cb } => assert_eq!(cb, cb_id),
-            _ => panic!("Expected RustReturn"),
-        }
     }
 
     #[test]

--- a/packages/doeff-vm/src/ids.rs
+++ b/packages/doeff-vm/src/ids.rs
@@ -2,7 +2,7 @@
 //!
 //! All IDs are lightweight Copy types using newtype pattern for type safety.
 
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Unique identifier for prompts/handlers.
 ///
@@ -33,13 +33,6 @@ pub struct DispatchId(pub u64);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct RunnableId(pub u64);
 
-/// Unique identifier for callbacks stored in VM's callback table.
-///
-/// Callbacks are stored separately from Frames to allow Frame to be Clone.
-/// The callback is consumed when executed.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct CallbackId(pub u32);
-
 /// Unique identifier for spawned tasks.
 ///
 /// Tasks are managed by the scheduler which maintains its own internal counter.
@@ -57,7 +50,6 @@ static MARKER_COUNTER: AtomicU64 = AtomicU64::new(1);
 static CONT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 static DISPATCH_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 static RUNNABLE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
-static CALLBACK_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
 
 impl Marker {
     /// Create a fresh unique Marker.
@@ -131,16 +123,6 @@ impl SegmentId {
     }
 }
 
-impl CallbackId {
-    pub fn fresh() -> Self {
-        CallbackId(CALLBACK_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
-    }
-
-    pub fn raw(&self) -> u32 {
-        self.0
-    }
-}
-
 impl TaskId {
     /// Get the raw value.
     pub fn raw(&self) -> u64 {
@@ -187,13 +169,6 @@ mod tests {
     fn test_segment_id_index_roundtrip() {
         let id = SegmentId::from_index(42);
         assert_eq!(id.index(), 42);
-    }
-
-    #[test]
-    fn test_callback_id_fresh_is_unique() {
-        let c1 = CallbackId::fresh();
-        let c2 = CallbackId::fresh();
-        assert_ne!(c1, c2);
     }
 
     #[test]

--- a/packages/doeff-vm/src/interceptor_state.rs
+++ b/packages/doeff-vm/src/interceptor_state.rs
@@ -1,6 +1,6 @@
 //! Interceptor-domain state and helper logic for VM composition.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use pyo3::prelude::*;
 
@@ -10,7 +10,7 @@ use crate::doeff_generator::DoeffGenerator;
 use crate::error::VMError;
 use crate::frame::CallMetadata;
 use crate::handler::HandlerEntry;
-use crate::ids::{CallbackId, DispatchId, Marker, SegmentId};
+use crate::ids::{DispatchId, Marker, SegmentId};
 use crate::py_shared::PyShared;
 use crate::pyvm::{PyDoCtrlBase, PyDoExprBase, PyEffectBase};
 use crate::segment::Segment;
@@ -19,17 +19,11 @@ use crate::vm::InterceptorEntry;
 #[derive(Clone, Default)]
 pub(crate) struct InterceptorState {
     interceptors: HashMap<Marker, InterceptorEntry>,
-    interceptor_callbacks: HashMap<CallbackId, Marker>,
-    interceptor_call_metadata: HashMap<CallbackId, CallMetadata>,
-    interceptor_eval_callbacks: HashSet<CallbackId>,
 }
 
 impl InterceptorState {
     pub(crate) fn clear_for_run(&mut self) {
         self.interceptors.clear();
-        self.interceptor_callbacks.clear();
-        self.interceptor_call_metadata.clear();
-        self.interceptor_eval_callbacks.clear();
     }
 
     pub(crate) fn current_chain(&self, scope_chain: &[Marker]) -> Vec<Marker> {
@@ -154,30 +148,6 @@ impl InterceptorState {
 
     pub(crate) fn get_entry(&self, marker: Marker) -> Option<InterceptorEntry> {
         self.interceptors.get(&marker).cloned()
-    }
-
-    pub(crate) fn register_callback(&mut self, cb: CallbackId, marker: Marker) {
-        self.interceptor_callbacks.insert(cb, marker);
-    }
-
-    pub(crate) fn unregister_callback(&mut self, cb: CallbackId) -> Option<Marker> {
-        self.interceptor_callbacks.remove(&cb)
-    }
-
-    pub(crate) fn set_call_metadata(&mut self, cb: CallbackId, metadata: CallMetadata) {
-        self.interceptor_call_metadata.insert(cb, metadata);
-    }
-
-    pub(crate) fn take_call_metadata(&mut self, cb: CallbackId) -> Option<CallMetadata> {
-        self.interceptor_call_metadata.remove(&cb)
-    }
-
-    pub(crate) fn register_eval_callback(&mut self, cb: CallbackId) {
-        self.interceptor_eval_callbacks.insert(cb);
-    }
-
-    pub(crate) fn unregister_eval_callback(&mut self, cb: CallbackId) -> bool {
-        self.interceptor_eval_callbacks.remove(&cb)
     }
 
     pub(crate) fn prepare_with_intercept(

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -13,9 +13,9 @@ pub mod arena;
 pub mod ast_stream;
 pub mod capture;
 pub mod continuation;
-mod dispatch_state;
 mod debug_state;
 pub mod dispatch;
+mod dispatch_state;
 pub mod do_ctrl;
 pub mod doeff_generator;
 pub mod driver;
@@ -24,6 +24,7 @@ pub mod error;
 pub mod frame;
 mod handler;
 pub mod ids;
+mod interceptor_state;
 pub mod py_key;
 pub mod py_shared;
 pub mod python_call;
@@ -32,11 +33,10 @@ pub mod rust_store;
 pub mod scheduler;
 pub mod segment;
 mod step;
-mod interceptor_state;
 mod trace_state;
-mod vm_logging;
 pub mod value;
 mod vm;
+mod vm_logging;
 
 // Re-exports for convenience
 pub use arena::SegmentArena;
@@ -60,7 +60,7 @@ pub use handler::{
     Handler, HandlerDebugInfo, HandlerEntry, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
     ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
 };
-pub use ids::{CallbackId, ContId, DispatchId, Marker, RunnableId, SegmentId};
+pub use ids::{ContId, DispatchId, Marker, RunnableId, SegmentId};
 pub use py_key::HashedPyKey;
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
 pub use pyvm::{DoExprTag, PyStdlib, PyVM};
@@ -68,4 +68,4 @@ pub use rust_store::RustStore;
 pub use segment::{Segment, SegmentKind};
 pub use step::PyException;
 pub use value::Value;
-pub use vm::{Callback, VM};
+pub use vm::VM;

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -3077,7 +3077,10 @@ mod tests {
             .into_any();
 
             let yielded = pyvm.classify_yielded(py, &with_handler).unwrap();
-            let seg = pyvm.vm.current_segment_mut().expect("current segment missing");
+            let seg = pyvm
+                .vm
+                .current_segment_mut()
+                .expect("current segment missing");
             seg.mode = Mode::HandleYield(yielded);
 
             let event = pyvm.vm.step();

--- a/packages/doeff-vm/src/segment.rs
+++ b/packages/doeff-vm/src/segment.rs
@@ -94,7 +94,7 @@ impl Segment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ids::CallbackId;
+    use crate::ids::DispatchId;
 
     #[test]
     fn test_segment_creation() {
@@ -120,32 +120,32 @@ mod tests {
         let marker = Marker::fresh();
         let mut seg = Segment::new(marker, None, vec![]);
 
-        let cb1 = CallbackId::fresh();
-        let cb2 = CallbackId::fresh();
-        let cb3 = CallbackId::fresh();
+        let d1 = Some(DispatchId::fresh());
+        let d2 = Some(DispatchId::fresh());
+        let d3 = Some(DispatchId::fresh());
 
-        seg.push_frame(Frame::rust_return(cb1));
-        seg.push_frame(Frame::rust_return(cb2));
-        seg.push_frame(Frame::rust_return(cb3));
+        seg.push_frame(Frame::HandlerDispatch { dispatch_id: d1 });
+        seg.push_frame(Frame::HandlerDispatch { dispatch_id: d2 });
+        seg.push_frame(Frame::HandlerDispatch { dispatch_id: d3 });
 
         assert_eq!(seg.frame_count(), 3);
 
-        // Pop should return frames in LIFO order (cb3 first)
+        // Pop should return frames in LIFO order (d3 first)
         let f3 = seg.pop_frame().unwrap();
         let f2 = seg.pop_frame().unwrap();
         let f1 = seg.pop_frame().unwrap();
 
         match (f3, f2, f1) {
             (
-                Frame::RustReturn { cb: id3 },
-                Frame::RustReturn { cb: id2 },
-                Frame::RustReturn { cb: id1 },
+                Frame::HandlerDispatch { dispatch_id: id3 },
+                Frame::HandlerDispatch { dispatch_id: id2 },
+                Frame::HandlerDispatch { dispatch_id: id1 },
             ) => {
-                assert_eq!(id3, cb3);
-                assert_eq!(id2, cb2);
-                assert_eq!(id1, cb1);
+                assert_eq!(id3, d3);
+                assert_eq!(id2, d2);
+                assert_eq!(id1, d1);
             }
-            _ => panic!("Expected RustReturn frames"),
+            _ => panic!("Expected HandlerDispatch frames"),
         }
 
         assert!(!seg.has_frames());

--- a/packages/doeff-vm/src/trace_state.rs
+++ b/packages/doeff-vm/src/trace_state.rs
@@ -829,7 +829,8 @@ impl TraceState {
         dispatch_stack: &[DispatchContext],
     ) -> Vec<ActiveChainEntry> {
         let raw_events = self.collect_raw_events();
-        let entries = self.events_to_entries(&raw_events, segments, current_segment, dispatch_stack);
+        let entries =
+            self.events_to_entries(&raw_events, segments, current_segment, dispatch_stack);
         let entries = Self::dedup_adjacent(entries);
         Self::inject_context(entries, exception)
     }
@@ -925,8 +926,10 @@ impl TraceState {
                 if let Some(frame_id) = effect_frame_id {
                     if visible_effect {
                         state.frame_dispatch.insert(*frame_id, *dispatch_id);
-                        if let Some(frame) =
-                            state.frame_stack.iter_mut().find(|f| f.frame_id == *frame_id)
+                        if let Some(frame) = state
+                            .frame_stack
+                            .iter_mut()
+                            .find(|f| f.frame_id == *frame_id)
                         {
                             if let Some(line) = effect_source_line {
                                 frame.source_line = *line;
@@ -1080,7 +1083,11 @@ impl TraceState {
     ) {
         self.merge_frame_lines_from_segments(&mut state.frame_stack, segments, current_segment);
         let (frame_stack, dispatches) = (&mut state.frame_stack, &state.dispatches);
-        self.merge_frame_lines_from_visible_dispatch_snapshot(frame_stack, dispatches, dispatch_stack);
+        self.merge_frame_lines_from_visible_dispatch_snapshot(
+            frame_stack,
+            dispatches,
+            dispatch_stack,
+        );
     }
 
     fn merge_frame_lines_from_segments(
@@ -1179,7 +1186,12 @@ impl TraceState {
     ) -> Vec<ActiveChainEntry> {
         let mut active_chain = self.entries_from_frame_stack(state);
         if active_chain.is_empty() {
-            self.fallback_entries_when_chain_empty(state, raw_events, dispatch_stack, &mut active_chain);
+            self.fallback_entries_when_chain_empty(
+                state,
+                raw_events,
+                dispatch_stack,
+                &mut active_chain,
+            );
         }
         active_chain
     }
@@ -1189,7 +1201,8 @@ impl TraceState {
         for (index, frame) in state.frame_stack.iter().enumerate() {
             let dispatch_id = state.frame_dispatch.get(&frame.frame_id).copied();
             let dispatch = dispatch_id.and_then(|id| state.dispatches.get(&id));
-            if let Some(dispatch) = dispatch.filter(|dispatch| Self::is_visible_dispatch(dispatch)) {
+            if let Some(dispatch) = dispatch.filter(|dispatch| Self::is_visible_dispatch(dispatch))
+            {
                 Self::push_effect_yield_entry(&mut active_chain, dispatch, Some(frame));
                 continue;
             }
@@ -1499,5 +1512,4 @@ impl TraceState {
     fn is_visible_dispatch(dispatch: &ActiveChainDispatchState) -> bool {
         !dispatch.is_execution_context_effect
     }
-
 }


### PR DESCRIPTION
## Summary
- Replace callback-based `Frame::RustReturn` continuations with typed `Frame` variants carrying named fields.
- Remove `CallbackId`, VM callback table, and `Box<dyn FnOnce>` continuation dispatch.
- Add typed interceptor continuation frames (`InterceptorApply` / `InterceptorEval`) and expose emitter metadata in `GetCallStack`.
- Convert remaining callback sites to typed frames (`EvalReturn`, `HandlerDispatch`, `MapReturn`, `FlatMapBindSource`, `FlatMapBindResult`).
- Simplify interceptor state by deleting callback registries; continuation state now lives structurally in frames.

## Acceptance Criteria Evidence (VM-FRAME-001)
### Phase 1
1. `Frame::InterceptorApply(Box<InterceptorContinuation>)` exists with named continuation fields.
2. `Frame::InterceptorEval(Box<InterceptorContinuation>)` exists with named continuation fields.
3. `start_interceptor_invocation_mode` pushes `Frame::InterceptorApply` (no callback id / closure).
4. `handle_interceptor_apply_result` (doexpr branch) pushes `Frame::InterceptorEval` (no callback id / closure).
5. `handle_yield_get_call_stack` reads `emitter_metadata` from `InterceptorApply`/`InterceptorEval` frames.
6. Interceptor callback metadata/callback registries removed from `InterceptorState` (no emitter side-channel map).
7. Emitter visibility verified with the provided script:
   - `from-inner: ['observer_fn', 'inner', 'outer']`
   - `from-outer: ['observer_fn', 'outer']`
8. `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q` passed:
   - `218 passed; 0 failed`
9. `uv run pytest -q` passed:
   - `754 passed; 0 failed` (warnings only)

### Phase 2
10. All remaining former `RustReturn` sites converted to typed variants.
11. Step loop dispatch now matches typed frame variants directly.
12. `handle_xxx` flow now consumes typed continuation payloads instead of `FnOnce` callbacks.

### Phase 3
13. `Frame::RustReturn` deleted.
14. `CallbackId` deleted.
15. `VM::callbacks` deleted.
16. No `Box<dyn FnOnce>` in frame/continuation dispatch path.
17. Continuation state is structurally visible via frame variants and named fields.
18. Validation rerun after refactor:
   - `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q` ✅
   - `uv run pytest -q` ✅

## Validation Commands Run
- `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q`
- `make sync`
- `uv run pytest -q`
- `uv run python - <<'PY' ...` (emitter visibility script from issue)
- `rg -n "CallbackId|RustReturn|VM::callbacks|callbacks: HashMap|Box<dyn FnOnce" packages/doeff-vm/src`

Refs: VM-FRAME-001
