### PR TITLE
VM-HANDLER-SEG-001: Handler-on-segment — move handlers onto PromptBoundary, eliminate scope_chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,19 @@ lint-packages:
 # Testing
 # =============================================================================
 
+PYTEST_MEM_GUARD_MB ?= 8192
+PYTEST_MEM_GUARD_POLL_INTERVAL ?= 1.0
+PYTEST_MEMORY_ENV := PYTEST_MEM_GUARD_MB=$(PYTEST_MEM_GUARD_MB) \
+	PYTEST_MEM_GUARD_POLL_INTERVAL=$(PYTEST_MEM_GUARD_POLL_INTERVAL)
+
 test:
-	uv run pytest -n auto
+	$(PYTEST_MEMORY_ENV) uv run pytest
 
 test-unit:
-	uv run pytest -n auto -m "not e2e and not slow"
+	$(PYTEST_MEMORY_ENV) uv run pytest -m "not e2e and not slow"
 
 test-e2e:
-	uv run pytest -m "e2e"
+	$(PYTEST_MEMORY_ENV) uv run pytest -m "e2e"
 
 # Run tests in all subpackages that have tests/ directories
 test-packages:

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -57,7 +57,7 @@ pub use effect::{Effect, PyAsk, PyCancelEffect, PyGet, PyLocal, PyModify, PyPut,
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{
-    Handler, HandlerDebugInfo, HandlerEntry, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
+    Handler, HandlerDebugInfo, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
     ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
 };
 pub use ids::{ContId, DispatchId, Marker, RunnableId, SegmentId};

--- a/packages/doeff-vm/src/scheduler.rs
+++ b/packages/doeff-vm/src/scheduler.rs
@@ -2910,7 +2910,7 @@ mod tests {
         use crate::segment::Segment;
 
         let marker = Marker::fresh();
-        let seg = Segment::new(marker, None, vec![marker]);
+        let seg = Segment::new(marker, None);
         let seg_id = SegmentId::from_index(0);
         Continuation::capture(&seg, seg_id, None)
     }
@@ -4913,7 +4913,7 @@ mod tests {
         use crate::ids::Marker;
         use crate::segment::Segment;
         let marker = Marker::fresh();
-        let seg = Segment::new(marker, None, vec![]);
+        let seg = Segment::new(marker, None);
         let seg_id = crate::ids::SegmentId::from_index(0);
         let cont = Continuation::capture(&seg, seg_id, None);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,13 @@
+from __future__ import annotations
+
+import _thread
+import os
+import subprocess
+import threading
+import warnings
+from collections import defaultdict, deque
+from contextlib import suppress
+from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol, TypeVar
 
 import pytest
@@ -7,6 +17,9 @@ from doeff import Program, async_run, default_async_handlers, default_handlers, 
 T = TypeVar("T")
 
 RunnerMode = Literal["sync", "async"]
+
+_MEM_GUARD_TRIGGER_LOCK = threading.Lock()
+_MEM_GUARD_TRIGGER: dict[str, str | None] = {"message": None}
 
 
 class Interpreter(Protocol):
@@ -48,6 +61,198 @@ class RuntimeAdapter:
         if self.mode == "sync":
             return run(program, handlers=default_handlers(), env=env, store=state)
         return await async_run(program, handlers=default_async_handlers(), env=env, store=state)
+
+
+def _read_process_table() -> tuple[dict[int, list[int]], dict[int, int]]:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,rss="],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    children_by_parent: dict[int, list[int]] = defaultdict(list)
+    rss_kib: dict[int, int] = {}
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) != 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+            rss = int(parts[2])
+        except ValueError:
+            continue
+        children_by_parent[ppid].append(pid)
+        rss_kib[pid] = rss
+    return children_by_parent, rss_kib
+
+
+def _collect_process_tree(root_pid: int) -> tuple[set[int], dict[int, int]]:
+    children_by_parent, rss_kib = _read_process_table()
+    seen: set[int] = set()
+    queue: deque[int] = deque([root_pid])
+    while queue:
+        pid = queue.popleft()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        for child in children_by_parent.get(pid, []):
+            queue.append(child)
+    return seen, rss_kib
+
+
+def _rss_tree_mib(root_pid: int) -> float:
+    process_tree, rss_kib = _collect_process_tree(root_pid)
+    total_kib = sum(rss_kib.get(pid, 0) for pid in process_tree)
+    return total_kib / 1024.0
+
+
+def _set_mem_guard_trigger(message: str) -> None:
+    with _MEM_GUARD_TRIGGER_LOCK:
+        if _MEM_GUARD_TRIGGER["message"] is None:
+            _MEM_GUARD_TRIGGER["message"] = message
+
+
+def _get_mem_guard_trigger() -> str | None:
+    with _MEM_GUARD_TRIGGER_LOCK:
+        return _MEM_GUARD_TRIGGER["message"]
+
+
+def _apply_rlimit_as(limit_mb: int) -> None:
+    if limit_mb <= 0:
+        return
+    try:
+        import resource
+    except ImportError:
+        warnings.warn(
+            "resource module unavailable; skipping --rlimit-as-mb memory guard",
+            stacklevel=2,
+        )
+        return
+
+    if not hasattr(resource, "RLIMIT_AS"):
+        warnings.warn(
+            "resource.RLIMIT_AS unavailable on this platform; skipping --rlimit-as-mb",
+            stacklevel=2,
+        )
+        return
+
+    limit_bytes = int(limit_mb) * 1024 * 1024
+    try:
+        _soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+        if hard != resource.RLIM_INFINITY:
+            limit_bytes = min(limit_bytes, int(hard))
+        resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, hard))
+    except (ValueError, OSError) as exc:
+        warnings.warn(
+            f"Failed to apply RLIMIT_AS={limit_mb} MiB: {exc}",
+            stacklevel=2,
+        )
+
+
+@dataclass
+class _SessionMemoryGuard:
+    limit_mb: int
+    poll_interval: float
+    stop_event: threading.Event = field(default_factory=threading.Event)
+    thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self.thread is not None:
+            return
+        self.thread = threading.Thread(target=self._watch_loop, daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join(timeout=1.0)
+
+    def _watch_loop(self) -> None:
+        while not self.stop_event.wait(max(self.poll_interval, 0.1)):
+            rss_mib = _rss_tree_mib(os.getpid())
+            if rss_mib > self.limit_mb:
+                message = (
+                    "[pytest-mem-guard] RSS "
+                    f"{rss_mib:.0f} MiB exceeded limit {self.limit_mb} MiB. "
+                    "Requesting immediate pytest abort."
+                )
+                with suppress(OSError):
+                    os.write(2, f"{message}\n".encode("utf-8", errors="replace"))
+                _set_mem_guard_trigger(message)
+                self.stop_event.set()
+                _thread.interrupt_main()
+                return
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("doeff-memory-guard")
+    group.addoption(
+        "--mem-guard-mb",
+        action="store",
+        type=int,
+        default=int(os.environ.get("PYTEST_MEM_GUARD_MB", "8192")),
+        help=(
+            "Max RSS (MiB) for the full pytest process tree before failing fast. "
+            "Set 0 to disable."
+        ),
+    )
+    group.addoption(
+        "--mem-guard-poll-interval",
+        action="store",
+        type=float,
+        default=float(os.environ.get("PYTEST_MEM_GUARD_POLL_INTERVAL", "1.0")),
+        help="Seconds between RSS checks for --mem-guard-mb.",
+    )
+    group.addoption(
+        "--rlimit-as-mb",
+        action="store",
+        type=int,
+        default=int(os.environ.get("PYTEST_RLIMIT_AS_MB", "0")),
+        help=(
+            "Apply OS RLIMIT_AS (MiB) at session start when supported. "
+            "Set 0 to disable."
+        ),
+    )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    with _MEM_GUARD_TRIGGER_LOCK:
+        _MEM_GUARD_TRIGGER["message"] = None
+    config = session.config
+
+    rlimit_as_mb = int(config.getoption("--rlimit-as-mb"))
+    _apply_rlimit_as(rlimit_as_mb)
+
+    mem_guard_mb = int(config.getoption("--mem-guard-mb"))
+    if mem_guard_mb <= 0:
+        return
+
+    guard = _SessionMemoryGuard(
+        limit_mb=mem_guard_mb,
+        poll_interval=float(config.getoption("--mem-guard-poll-interval")),
+    )
+    guard.start()
+    config._doeff_mem_guard = guard  # type: ignore[attr-defined]
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    guard = getattr(session.config, "_doeff_mem_guard", None)
+    if isinstance(guard, _SessionMemoryGuard):
+        guard.stop()
+
+
+def pytest_terminal_summary(
+    terminalreporter: pytest.TerminalReporter,
+    exitstatus: int,
+    config: pytest.Config,
+) -> None:
+    message = _get_mem_guard_trigger()
+    if message:
+        terminalreporter.write_sep("!", message)
 
 
 @pytest.fixture

--- a/tests/core/test_spec_trace_001_examples.py
+++ b/tests/core/test_spec_trace_001_examples.py
@@ -264,7 +264,8 @@ def test_example_4_missing_env_key() -> None:
         effect_fragment="Ask(",
         detail_fragment="database_url",
     )
-    assert "LazyAskHandler✗" in stack_line
+    assert "LazyAskHandler⇆" in stack_line
+    assert "ReaderHandler✗" in stack_line
     assert "MissingEnvKeyError" in rendered
     assert "database_url" in rendered
 


### PR DESCRIPTION
## Summary

- **PromptBoundary** now carries `handler: HandlerRef`, `return_clause: Option<PyShared>`, `py_identity: Option<PyShared>` directly on the segment — no separate `HandlerEntry` struct or `VM.handlers` HashMap
- **scope_chain** removed from `Segment` and `Continuation` — handler lookup walks the caller chain
- **MaskBoundary** and **FinallyBoundary** stub variants added to `SegmentKind` (data-only, no behavior yet)
- Handler lookup rewritten to walk segment caller chain via `handlers_in_caller_chain()`
- `start_dispatch()`, `GetHandlers`, Forward/Delegate paths all updated to caller-chain walk
- Pre-registered handlers (State/Reader/Writer/Scheduler) materialized into PromptBoundary segments at run start via `instantiate_installed_handlers()`

## Spec Reference

- SPEC-008 R17-A (handler-on-segment), R17-B (scope_chain elimination), R17-C (new SegmentKind variants)
- Issue: VM-HANDLER-SEG-001

## Additional Changes (bundled)

- `LazyAskHandlerProgram`: `DoCtrl::Perform` → `DoCtrl::Delegate` (fixes delegation semantics)
- `check_dispatch_completion()`: walks parent chain — only root continuation completion closes dispatch
- `tests/conftest.py`: memory guard for pytest (OOM protection)
- `Makefile` / `pyproject.toml`: removed `-n auto` parallel test execution
- `doeff/traceback.py`: active dispatch renders as warning instead of raising

## Known Deviation (follow-up: VM-ANCHOR-FIX-001)

`handler_lookup_anchor` on Segment/Continuation redirects handler walk to the effect site instead of walking from the handler execution segment's position. This preserves old scope_chain-snapshot semantics but diverges from SPEC-008 R17 INV-4/INV-6 caller-chain model. Tracked in VM-ANCHOR-FIX-001, scoped into VM-REENTRANT-001.

## Verification

- `cargo test --manifest-path packages/doeff-vm/Cargo.toml` — 218/218 passed
- `make sync && uv run pytest -q` — 754/754 passed