### PR TITLE
Replace datetime.now() in Gemini/OpenRouter API tracking

### DIFF
--- a/packages/doeff-gemini/src/doeff_gemini/client.py
+++ b/packages/doeff-gemini/src/doeff_gemini/client.py
@@ -395,6 +395,7 @@ def track_api_call(
     start_time: float,
     error: Exception | None = None,
     api_payload: Any | None = None,
+    timestamp: datetime | None = None,
 ) -> EffectGenerator[APICallMetadata]:
     """Log and persist observability metadata for a Gemini API invocation.
 
@@ -402,6 +403,8 @@ def track_api_call(
     payload passed to the Google client while the log preview remains sanitized.
     """
     end_time = time.time()
+    if timestamp is None:
+        timestamp = datetime.fromtimestamp(end_time, tz=timezone.utc)
     latency_ms = (end_time - start_time) * 1000
 
     sanitized_payload, prompt_text, prompt_images = _prepare_request_payload(request_payload)
@@ -498,7 +501,7 @@ def track_api_call(
     metadata = APICallMetadata(
         operation=operation,
         model=model,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=timestamp,
         request_id=request_id,
         latency_ms=latency_ms,
         token_usage=token_usage,

--- a/packages/doeff-openrouter/src/doeff_openrouter/client.py
+++ b/packages/doeff-openrouter/src/doeff_openrouter/client.py
@@ -235,9 +235,12 @@ def track_api_call(
     *,
     stream: bool = False,
     error: Exception | None = None,
+    timestamp: datetime | None = None,
 ) -> EffectGenerator[APICallMetadata]:
     """Track OpenRouter API call in logs, graph, and state."""
     end_time = time.time()
+    if timestamp is None:
+        timestamp = datetime.fromtimestamp(end_time, tz=timezone.utc)
     latency_ms = (end_time - start_time) * 1000
     sanitized_payload, prompt_text, prompt_images, prompt_messages = _prepare_prompt_details(
         request_payload
@@ -250,7 +253,7 @@ def track_api_call(
     metadata = APICallMetadata(
         operation=operation,
         model=model,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=timestamp,
         request_id=request_id,
         latency_ms=latency_ms,
         token_usage=token_usage,


### PR DESCRIPTION
## Summary
- Added an optional `timestamp` parameter to `track_api_call` in:
  - `packages/doeff-gemini/src/doeff_gemini/client.py`
  - `packages/doeff-openrouter/src/doeff_openrouter/client.py`
- Removed direct `datetime.now(timezone.utc)` calls from both `@do` functions.
- When `timestamp` is not provided, it is now derived from the existing `end_time` value via `datetime.fromtimestamp(end_time, tz=timezone.utc)`.

## Acceptance Criteria Evidence
1. `doeff-no-datetime-now-in-do` findings for target files
   - Command:
     - `semgrep scan --config .semgrep.yaml packages/doeff-gemini/src/doeff_gemini/client.py packages/doeff-openrouter/src/doeff_openrouter/client.py`
   - Result:
     - `Findings: 0 (0 blocking)`

2. Existing tests pass
   - Command:
     - `uv run pytest`
   - Result:
     - `767 passed, 21 warnings in 31.67s`

## Additional Validation Context
- `make lint-semgrep` currently reports unrelated pre-existing findings in other parts of the repository.

Refs: LINT-PURITY-DATETIME
