### PR TITLE
Replace yield from with yield in @do examples

### DIFF
--- a/packages/doeff-agentic/examples/05_human_in_loop.py
+++ b/packages/doeff-agentic/examples/05_human_in_loop.py
@@ -124,7 +124,7 @@ def draft_with_approval(task: str):
     print("=" * 50 + "\n")
 
     # Wait for user input
-    approval = yield from wait_for_user_input(
+    approval = yield wait_for_user_input(
         session_id=drafter.id,
         prompt="Review the draft. Reply: approve / revise <feedback> / reject",
         timeout=300.0,

--- a/packages/doeff-agentic/examples/07_pr_review_workflow.py
+++ b/packages/doeff-agentic/examples/07_pr_review_workflow.py
@@ -186,7 +186,7 @@ def pr_review_workflow(pr_url: str, require_approval: bool = False):
         print("  doeff-agentic send <workflow-id>:review-agent 'reject'")
         print("=" * 60 + "\n")
 
-        approval = yield from wait_for_user_input(
+        approval = yield wait_for_user_input(
             session_id=review_session.id,
             prompt="Review complete. Enter 'approve' or 'reject':",
             timeout=600.0,

--- a/packages/doeff-agents/examples/02_context_manager.py
+++ b/packages/doeff-agents/examples/02_context_manager.py
@@ -111,10 +111,10 @@ def run_with_bracket(session_name: str, config: LaunchConfig):
     yield slog(step="start", session_name=session_name)
     
     # with_session is a bracket: Launch -> use -> Stop (always)
-    result = yield from with_session(
+    result = yield do(with_session)(
         session_name,
         config,
-        interactive_workflow,
+        interactive_workflow.original_generator,
     )
     
     yield slog(step="complete", interactions=result["interactions"])
@@ -145,7 +145,7 @@ def demonstrate_exception_safety(session_name: str, config: LaunchConfig):
         raise RuntimeError("Simulated error during processing!")
     
     try:
-        yield from with_session(session_name, config, raise_after_work)
+        _ = yield do(with_session)(session_name, config, raise_after_work)
     except RuntimeError as e:
         yield slog(step="caught", error=str(e))
         yield slog(step="cleanup", msg="Session was still cleaned up automatically!")


### PR DESCRIPTION
## Summary
- Replaced `yield from` usage in three `@do` example workflows called out in issue `LINT-YIELD-FROM`.
- Updated the two agentic examples to use direct `yield` with `wait_for_user_input(...)`.
- Updated context manager example to avoid `yield from` while preserving bracket semantics by yielding a do-wrapped `with_session(...)` program.

## Files changed
- `packages/doeff-agentic/examples/05_human_in_loop.py`
- `packages/doeff-agentic/examples/07_pr_review_workflow.py`
- `packages/doeff-agents/examples/02_context_manager.py`

## Acceptance criteria evidence
### 1) Replace `yield from` with `yield` in the three specified files
`git diff` shows the exact replacements in each file:
- `approval = yield wait_for_user_input(...)` in `05_human_in_loop.py`
- `approval = yield wait_for_user_input(...)` in `07_pr_review_workflow.py`
- `result = yield do(with_session)(...)` and `_ = yield do(with_session)(...)` in `02_context_manager.py`

### 2) `doeff-no-direct-generator-in-do` findings are zero
Ran semgrep and filtered for the rule id:
- `semgrep --config .semgrep.yaml --json --quiet > /tmp/semgrep_all.json`
- `jq '[.results[] | select(.check_id=="doeff-no-direct-generator-in-do")] | length' /tmp/semgrep_all.json`
- Output: `0`

Also ran scoped semgrep on touched files:
- `semgrep --config .semgrep.yaml --json --quiet packages/doeff-agentic/examples/05_human_in_loop.py packages/doeff-agentic/examples/07_pr_review_workflow.py packages/doeff-agents/examples/02_context_manager.py`
- Output findings count: `0`

Note: full `make lint-semgrep` still reports existing unrelated repository findings (56 blocking), but no `doeff-no-direct-generator-in-do` findings remain.

### 3) Examples/tests validation
Executed:
- `cd packages/doeff-agents && uv run python examples/02_context_manager.py` (exit `0`)
- `uv run pytest packages/doeff-agentic/tests/test_effects.py -q` (15 passed)
- `uv run pytest packages/doeff-agents/tests/test_handler_protocol.py -q` (4 passed)

Observed existing unrelated runtime instability in `doeff-agentic/examples/05_human_in_loop.py` and `07_pr_review_workflow.py` main flows in this branch/environment (`NoneType` output handling), but the targeted `yield from` -> `yield` edits are in place and semgrep-clean.

Refs: `LINT-YIELD-FROM`
