### PR TITLE
Fix CI cloudpickle ModuleNotFoundError in Python compatibility workflow

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   pytest-matrix:
     runs-on: ubuntu-latest
+    env:
+      UV_PROJECT_ENVIRONMENT: .venv-ci
     strategy:
       fail-fast: false
       matrix:
@@ -31,13 +33,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
-        run: uv sync --group dev --python ${{ matrix.python-version }}
+        run: uv sync --group dev --package doeff --python ${{ matrix.python-version }}
 
       - name: Verify doeff-vm import
-        run: uv run --python ${{ matrix.python-version }} python -c "import doeff_vm; import doeff_vm.doeff_vm"
+        run: uv run --package doeff --python ${{ matrix.python-version }} python -c "import doeff_vm; import doeff_vm.doeff_vm"
 
       - name: Run test suite
-        run: uv run --python ${{ matrix.python-version }} pytest -q
+        run: uv run --package doeff --python ${{ matrix.python-version }} pytest -q
 
   version-probe:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- isolate Python compatibility job into a dedicated uv environment via `UV_PROJECT_ENVIRONMENT: .venv-ci`
- keep sync/run bound to the `doeff` workspace package with `--package doeff`
- this prevents nested `uv run` subprocesses in CLI tests from clobbering the active pytest environment (`.venv`) mid-run

## Why this fixes CI-CLOUDPICKLE-001
The failing test imports `cloudpickle` lazily during cache key serialization. In the matrix job, nested CLI subprocess tests run `uv run ...` and can recreate the default `.venv` during the same pytest process, leaving later imports unresolved. Running the matrix job inside `.venv-ci` isolates the active test interpreter from those nested subprocess environment mutations.

## Acceptance Criteria Evidence
### 1) `test_cache_miss_delegate_then_put_then_hit` passes across 3.10–3.14
Executed:
- `UV_PROJECT_ENVIRONMENT=.venv-ci uv sync --group dev --package doeff --python 3.10`
- `UV_PROJECT_ENVIRONMENT=.venv-ci uv run --package doeff --python 3.10 pytest tests/test_dispatch_completion.py::test_cache_miss_delegate_then_put_then_hit -v`
- repeated for `3.11`, `3.12`, `3.13`, `3.14`

Result on each version: `PASSED` and `cloudpickle 3.1.2` import verified.

### 2) No other tests regress
Executed:
- `UV_PROJECT_ENVIRONMENT=.venv-ci uv run --package doeff --python 3.14 pytest -q`

Result:
- `780 passed, 21 warnings in 32.19s`

### 3) Minimal fix, no cache/test refactor
- only file changed: `.github/workflows/python-compatibility.yml`
- no changes to cache modules or tests

## Issue
- CI-CLOUDPICKLE-001
