### PR TITLE
VM-KLEISLI-PHASE2: @do handlers work with WithHandler (doeff-13 fix)

### DIFF
--- a/doeff/do.py
+++ b/doeff/do.py
@@ -16,6 +16,11 @@ from doeff.kleisli import KleisliProgram
 from doeff.program import Program, _build_auto_unwrap_strategy
 from doeff.types import Effect, EffectGenerator
 
+try:
+    from doeff_vm import PyKleisli as _PyKleisli
+except ImportError:
+    _PyKleisli = None
+
 P = ParamSpec("P")
 T = TypeVar("T")
 
@@ -273,6 +278,17 @@ class DoYieldFunction(KleisliProgram[P, T]):
 
         self.__doeff_do_decorated__ = True
         object.__setattr__(self, "_is_do_decorated", True)
+
+        if _PyKleisli is not None:
+            source_file = code.co_filename
+            source_line_num = code.co_firstlineno
+            pykleisli = _PyKleisli(
+                func=generator_factory,
+                name=func.__qualname__,
+                file=source_file,
+                line=source_line_num,
+            )
+            object.__setattr__(self, "_pykleisli", pykleisli)
 
         strategy = _build_auto_unwrap_strategy(self)
         object.__setattr__(self, "_auto_unwrap_strategy", strategy)

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -39,6 +39,16 @@ def _coerce_handler(handler):
         return handler
     if isinstance(handler, _ext.DoeffGeneratorFn):
         return handler
+    if isinstance(handler, _ext.PyKleisli):
+        return handler
+
+    # @do-decorated handlers have a _doeff_generator_factory attribute (DoeffGeneratorFn)
+    # that wraps the raw generator factory. Extract it to avoid calling
+    # DoYieldFunction.__call__ (which returns a DoExpr, not a generator).
+    dgfn = getattr(handler, "_doeff_generator_factory", None)
+    if dgfn is not None and isinstance(dgfn, _ext.DoeffGeneratorFn):
+        return dgfn
+
     if not callable(handler):
         return handler
 
@@ -129,6 +139,7 @@ ResultErr = Err
 K = _ext.K
 DoeffGenerator = _ext.DoeffGenerator
 DoeffGeneratorFn = _ext.DoeffGeneratorFn
+PyKleisli = _ext.PyKleisli
 
 
 WithHandler = _ext.WithHandler
@@ -295,6 +306,7 @@ __all__ = [
     "ResumeContinuation",
     "RunResult",
     "DoeffTracebackData",
+    "PyKleisli",
     "RustHandler",
     "Transfer",
     "WithHandler",

--- a/packages/doeff-vm/src/kleisli.rs
+++ b/packages/doeff-vm/src/kleisli.rs
@@ -1,11 +1,15 @@
 //! Kleisli arrow types for IR-level callables (SPEC-VM-017).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
 
 use crate::do_ctrl::DoCtrl;
 use crate::error::VMError;
+use crate::frame::CallMetadata;
+use crate::handler::IRStreamFactoryRef;
+use crate::ir_stream::{IRStreamRef, PythonGeneratorStream};
 use crate::py_shared::PyShared;
 use crate::value::Value;
 
@@ -39,3 +43,191 @@ pub trait Kleisli: std::fmt::Debug + Send + Sync {
 
 /// Shared reference to a Kleisli arrow.
 pub type KleisliRef = Arc<dyn Kleisli>;
+
+// ---------------------------------------------------------------------------
+// PyKleisli — Python-callable Kleisli arrow (#[pyclass])
+// ---------------------------------------------------------------------------
+
+/// Wraps a Python callable (the @do-decorated generator factory function)
+/// and implements the Kleisli trait. When the VM calls kleisli.apply(py, args),
+/// it calls the Python callable with args to get a generator, wraps it in a
+/// PythonGeneratorStream, and returns DoCtrl::IRStream.
+#[pyclass(name = "PyKleisli")]
+#[derive(Debug, Clone)]
+pub struct PyKleisli {
+    pub(crate) func: PyShared,
+    pub(crate) name: String,
+    pub(crate) file: Option<String>,
+    pub(crate) line: Option<u32>,
+}
+
+#[pymethods]
+impl PyKleisli {
+    #[new]
+    fn new(func: Py<PyAny>, name: String, file: Option<String>, line: Option<u32>) -> Self {
+        PyKleisli {
+            func: PyShared::new(func),
+            name,
+            file,
+            line,
+        }
+    }
+
+    /// __call__ makes it callable from Python — calling PyKleisli(*args) invokes the
+    /// wrapped function. This is needed so PyKleisli can be used as a drop-in replacement
+    /// for KleisliProgram in Python code.
+    #[pyo3(signature = (*args, **kwargs))]
+    fn __call__(
+        &self,
+        py: Python<'_>,
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        self.func.bind(py).call(args, kwargs).map(|r| r.unbind())
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PyKleisli({}, {}:{})",
+            self.name,
+            self.file.as_deref().unwrap_or("?"),
+            self.line.unwrap_or(0)
+        )
+    }
+
+    /// Expose the wrapped function for Python introspection.
+    #[getter]
+    fn func(&self, py: Python<'_>) -> Py<PyAny> {
+        self.func.clone_ref(py)
+    }
+
+    #[getter]
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[getter]
+    fn file(&self) -> Option<&str> {
+        self.file.as_deref()
+    }
+
+    #[getter]
+    fn line(&self) -> Option<u32> {
+        self.line
+    }
+}
+
+impl PyKleisli {
+    /// Create a PyKleisli from a Python handler callable (used by PythonHandler migration).
+    pub fn from_handler(callable: Py<PyAny>, name: String, file: Option<String>, line: Option<u32>) -> Self {
+        PyKleisli {
+            func: PyShared::new(callable),
+            name,
+            file,
+            line,
+        }
+    }
+
+    /// Get a reference to the inner function as PyShared.
+    pub fn func_shared(&self) -> &PyShared {
+        &self.func
+    }
+}
+
+impl Kleisli for PyKleisli {
+    fn apply(&self, py: Python<'_>, args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        let py_args: Vec<Bound<'_, PyAny>> = args
+            .iter()
+            .map(|v| v.to_pyobject(py))
+            .collect::<PyResult<Vec<_>>>()
+            .map_err(|e| VMError::python_error(format!("{e}")))?;
+        let tuple = PyTuple::new(py, &py_args)
+            .map_err(|e| VMError::python_error(format!("{e}")))?;
+
+        let generator = self
+            .func
+            .bind(py)
+            .call1(tuple)
+            .map_err(|e| VMError::python_error(format!("{e}")))?;
+
+        let get_frame_fn = py
+            .eval(
+                c"lambda gen: getattr(gen, 'gi_frame', None)",
+                None,
+                None,
+            )
+            .map_err(|e| VMError::python_error(format!("failed to create get_frame: {e}")))?;
+
+        let stream = PythonGeneratorStream::new(
+            PyShared::new(generator.unbind()),
+            PyShared::new(get_frame_fn.unbind()),
+        );
+        let stream_ref: IRStreamRef = Arc::new(Mutex::new(Box::new(stream)));
+
+        let metadata = CallMetadata::new(
+            self.name.clone(),
+            self.file.clone().unwrap_or_default(),
+            self.line.unwrap_or(0),
+            None,
+            None,
+        );
+
+        Ok(DoCtrl::IRStream {
+            stream: stream_ref,
+            metadata: Some(metadata),
+        })
+    }
+
+    fn debug_info(&self) -> KleisliDebugInfo {
+        KleisliDebugInfo {
+            name: self.name.clone(),
+            file: self.file.clone(),
+            line: self.line,
+        }
+    }
+
+    fn py_identity(&self) -> Option<PyShared> {
+        Some(self.func.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RustKleisli — Rust handler factory Kleisli arrow
+// ---------------------------------------------------------------------------
+
+/// Wraps an IRStreamFactory (Rust handler program factory) and implements Kleisli.
+/// This allows Rust built-in handlers to be represented as Value::Kleisli in future phases.
+#[derive(Debug, Clone)]
+pub struct RustKleisli {
+    factory: IRStreamFactoryRef,
+    name: String,
+}
+
+impl RustKleisli {
+    pub fn new(factory: IRStreamFactoryRef, name: String) -> Self {
+        RustKleisli { factory, name }
+    }
+
+    pub fn factory(&self) -> &IRStreamFactoryRef {
+        &self.factory
+    }
+}
+
+impl Kleisli for RustKleisli {
+    fn apply(&self, _py: Python<'_>, _args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        // RustKleisli expects (effect: DispatchEffect, k: Continuation) as args.
+        // For now, this is a placeholder — actual integration happens in Phase 3
+        // when WithHandler uses Kleisli for dispatch.
+        Err(VMError::internal(
+            "RustKleisli.apply() not yet wired — use IRStreamFactory directly until Phase 3",
+        ))
+    }
+
+    fn debug_info(&self) -> KleisliDebugInfo {
+        KleisliDebugInfo {
+            name: self.name.clone(),
+            file: None,
+            line: None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Bridge Rust `PyKleisli` to Python handler dispatch so `@do`-decorated handlers work with `WithHandler`
- Fix doeff-13 bug: `@do` handlers no longer raise TypeError or hang
- `PyKleisli` #[pyclass] with full `Kleisli` trait implementation (Phase 1 continuation)
- `RustKleisli` placeholder for future Phase 3 handler unification

## Key Changes
- **`doeff_vm/__init__.py`**: `_coerce_handler` extracts `_doeff_generator_factory` from `@do` handlers, bypassing `DoYieldFunction.__call__` which returns DoExpr instead of generator
- **`pyvm.rs`**: `classify_handler_object` and `PyWithHandler::new` accept `PyKleisli` as handler type
- **`kleisli.rs`**: Fields made `pub(crate)` for cross-module access
- **Tests**: Updated 6 tests from asserting TypeError to asserting correct handler behavior

## Validation
- `cargo test`: 220 passed
- `make sync`: succeeds
- `uv run pytest -m "not slow and not cli and not semgrep" -q`: 727 passed, 0 failed

## Deferred
- Step 4 (PythonHandler.invoke migration to Value::Kleisli) deferred — Kleisli path in VM's handle_yield_expand doesn't support handler_return dispatch context needed for handler completion semantics. This is Phase 3 work.

Ref: VM-KLEISLI-PHASE2