### PR TITLE
VM-KLEISLI-PHASE2: migrate @do handlers to PyKleisli

### DIFF
--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -7,6 +7,7 @@ unwrapping of Program arguments for natural composition.
 
 from __future__ import annotations
 
+from abc import ABC
 import inspect
 import types
 import warnings
@@ -29,7 +30,7 @@ U = TypeVar("U")
 
 
 @dataclass(frozen=True)
-class KleisliProgram(Generic[P, T]):
+class KleisliProgram(ABC, Generic[P, T]):
     """
     Thin wrapper around a callable representing a Kleisli arrow.
 
@@ -222,6 +223,21 @@ def validate_do_handler_effect_annotation(handler: Any) -> None:
         raise TypeError("@do handler first parameter must be annotated as Effect")
 
 
+def _register_vm_kleisli_types() -> None:
+    try:
+        import doeff_vm as vm
+    except Exception:
+        return
+
+    py_kleisli = getattr(vm, "PyKleisli", None)
+    if py_kleisli is None:
+        return
+    try:
+        KleisliProgram.register(py_kleisli)
+    except Exception:
+        return
+
+
 __all__ = ["KleisliProgram", "PartiallyAppliedKleisliProgram"]
 
 
@@ -238,3 +254,4 @@ def _hydrate_future_annotations() -> None:
 
 
 _hydrate_future_annotations()
+_register_vm_kleisli_types()

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -44,6 +44,10 @@ def _coerce_handler(handler: Any) -> Any:
     if rust_handler_type is not None and isinstance(handler, rust_handler_type):
         return handler
 
+    py_kleisli_type = getattr(vm, "PyKleisli", None)
+    if py_kleisli_type is not None and isinstance(handler, py_kleisli_type):
+        return handler
+
     doeff_generator_fn_type = getattr(vm, "DoeffGeneratorFn", None)
     if doeff_generator_fn_type is not None and isinstance(handler, doeff_generator_fn_type):
         return handler

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -37,6 +37,8 @@ def _handler_registration_metadata(handler):
 def _coerce_handler(handler):
     if isinstance(handler, _ext.RustHandler):
         return handler
+    if hasattr(_ext, "PyKleisli") and isinstance(handler, _ext.PyKleisli):
+        return handler
     if isinstance(handler, _ext.DoeffGeneratorFn):
         return handler
     if not callable(handler):
@@ -129,6 +131,14 @@ ResultErr = Err
 K = _ext.K
 DoeffGenerator = _ext.DoeffGenerator
 DoeffGeneratorFn = _ext.DoeffGeneratorFn
+PyKleisli = _ext.PyKleisli
+
+try:
+    from doeff.kleisli import KleisliProgram
+
+    KleisliProgram.register(PyKleisli)
+except Exception:
+    pass
 
 
 WithHandler = _ext.WithHandler
@@ -253,6 +263,7 @@ __all__ = [
     "DoExpr",
     "DoeffGenerator",
     "DoeffGeneratorFn",
+    "PyKleisli",
     "DoThunkBase",
     "EffectBase",
     "PyAsk",

--- a/packages/doeff-vm/src/kleisli.rs
+++ b/packages/doeff-vm/src/kleisli.rs
@@ -1,11 +1,17 @@
 //! Kleisli arrow types for IR-level callables (SPEC-VM-017).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
 
 use crate::do_ctrl::DoCtrl;
+use crate::doeff_generator::{DoeffGenerator, DoeffGeneratorFn};
 use crate::error::VMError;
+use crate::frame::CallMetadata;
+use crate::handler::IRStreamFactoryRef;
+use crate::ir_stream::{IRStreamRef, PythonGeneratorStream};
 use crate::py_shared::PyShared;
 use crate::value::Value;
 
@@ -39,3 +45,317 @@ pub trait Kleisli: std::fmt::Debug + Send + Sync {
 
 /// Shared reference to a Kleisli arrow.
 pub type KleisliRef = Arc<dyn Kleisli>;
+
+/// Python-backed Kleisli arrow.
+///
+/// `func` remains callable from Python (`__call__`) so this can serve as a
+/// drop-in replacement for `KleisliProgram` at call sites.
+#[pyclass(name = "PyKleisli", dict)]
+#[derive(Debug, Clone)]
+pub struct PyKleisli {
+    func: PyShared,
+    name: String,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+#[pymethods]
+impl PyKleisli {
+    #[new]
+    #[pyo3(signature = (func, name, file=None, line=None))]
+    fn new(
+        py: Python<'_>,
+        func: Py<PyAny>,
+        name: String,
+        file: Option<String>,
+        line: Option<u32>,
+    ) -> PyResult<Self> {
+        if !func.bind(py).is_callable() {
+            return Err(PyTypeError::new_err("PyKleisli.func must be callable"));
+        }
+        Ok(Self {
+            func: PyShared::new(func),
+            name,
+            file,
+            line,
+        })
+    }
+
+    #[pyo3(signature = (*args, **kwargs))]
+    fn __call__(
+        &self,
+        py: Python<'_>,
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        self.func
+            .bind(py)
+            .call(args, kwargs)
+            .map(|result| result.unbind())
+    }
+
+    fn __get__(
+        slf: Py<Self>,
+        py: Python<'_>,
+        instance: Option<Py<PyAny>>,
+        _owner: Option<Py<PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
+        if let Some(instance_obj) = instance {
+            let method_type = py.import("types")?.getattr("MethodType")?;
+            return method_type
+                .call1((slf, instance_obj))
+                .map(|bound| bound.unbind());
+        }
+        Ok(slf.into_any())
+    }
+
+    fn __rshift__(&self, py: Python<'_>, binder: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        self.func
+            .bind(py)
+            .call_method1("__rshift__", (binder,))
+            .map(|result| result.unbind())
+    }
+
+    #[pyo3(signature = (*args, **kwargs))]
+    fn partial(
+        &self,
+        py: Python<'_>,
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        self.func
+            .bind(py)
+            .call_method("partial", args, kwargs)
+            .map(|result| result.unbind())
+    }
+
+    fn and_then_k(&self, py: Python<'_>, binder: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        self.func
+            .bind(py)
+            .call_method1("and_then_k", (binder,))
+            .map(|result| result.unbind())
+    }
+
+    fn fmap(&self, py: Python<'_>, mapper: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        self.func
+            .bind(py)
+            .call_method1("fmap", (mapper,))
+            .map(|result| result.unbind())
+    }
+
+    fn __getattr__(&self, py: Python<'_>, name: &str) -> PyResult<Py<PyAny>> {
+        self.func.bind(py).getattr(name).map(|bound| bound.unbind())
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PyKleisli({}, {}:{})",
+            self.name,
+            self.file.as_deref().unwrap_or("?"),
+            self.line.unwrap_or(0),
+        )
+    }
+}
+
+impl PyKleisli {
+    fn map_pyerr(err: PyErr) -> VMError {
+        Python::attach(|py| {
+            if err.is_instance_of::<PyTypeError>(py) {
+                VMError::type_error(err.to_string())
+            } else {
+                VMError::python_error(err.to_string())
+            }
+        })
+    }
+
+    pub fn from_handler(py: Python<'_>, func: Py<PyAny>) -> PyResult<Self> {
+        if !func.bind(py).is_callable() {
+            return Err(PyTypeError::new_err("handler callable must be callable"));
+        }
+
+        if func.bind(py).is_instance_of::<DoeffGeneratorFn>() {
+            let dgfn: PyRef<'_, DoeffGeneratorFn> = func.bind(py).extract()?;
+            return Ok(Self {
+                func: PyShared::new(func),
+                name: dgfn.function_name.clone(),
+                file: Some(dgfn.source_file.clone()),
+                line: Some(dgfn.source_line),
+            });
+        }
+
+        let callable = func.bind(py);
+        let name = callable
+            .getattr("__qualname__")
+            .ok()
+            .and_then(|bound| bound.extract::<String>().ok())
+            .or_else(|| {
+                callable
+                    .getattr("__name__")
+                    .ok()
+                    .and_then(|bound| bound.extract::<String>().ok())
+            })
+            .unwrap_or_else(|| "<python_handler>".to_string());
+        let (file, line) = Self::source_info(callable);
+
+        Ok(Self {
+            func: PyShared::new(func),
+            name,
+            file,
+            line,
+        })
+    }
+
+    fn source_info(callable: &Bound<'_, PyAny>) -> (Option<String>, Option<u32>) {
+        let maybe_code = callable.getattr("__code__").ok().or_else(|| {
+            callable
+                .getattr("__call__")
+                .ok()
+                .and_then(|method| method.getattr("__code__").ok())
+        });
+
+        let Some(code) = maybe_code else {
+            return (None, None);
+        };
+
+        let file = code
+            .getattr("co_filename")
+            .ok()
+            .and_then(|bound| bound.extract::<String>().ok());
+        let line = code
+            .getattr("co_firstlineno")
+            .ok()
+            .and_then(|bound| bound.extract::<u32>().ok());
+        (file, line)
+    }
+
+    fn resolve_apply_callable(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        if let Ok(factory) = self.func.bind(py).getattr("_doeff_generator_factory") {
+            return Ok(factory.unbind());
+        }
+        Ok(self.func.clone_ref(py))
+    }
+
+    fn default_get_frame(py: Python<'_>) -> Result<Py<PyAny>, VMError> {
+        let callable = py
+            .import("doeff.do")
+            .and_then(|mod_| mod_.getattr("_default_get_frame"))
+            .map_err(|e| {
+                VMError::python_error(format!("failed to resolve default get_frame: {e}"))
+            })?;
+        Ok(callable.unbind())
+    }
+}
+
+impl Kleisli for PyKleisli {
+    fn apply(&self, py: Python<'_>, args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        let arg_values: Vec<Bound<'_, PyAny>> = args
+            .iter()
+            .map(|value| value.to_pyobject(py))
+            .collect::<PyResult<Vec<_>>>()
+            .map_err(Self::map_pyerr)?;
+        let arg_tuple = PyTuple::new(py, &arg_values).map_err(Self::map_pyerr)?;
+        let args_repr = arg_tuple
+            .repr()
+            .ok()
+            .and_then(|repr| repr.extract::<String>().ok())
+            .map(|repr| format!("args={repr}, kwargs={{}}"));
+
+        let apply_callable = self.resolve_apply_callable(py).map_err(Self::map_pyerr)?;
+        let produced = apply_callable
+            .bind(py)
+            .call1(arg_tuple)
+            .map_err(Self::map_pyerr)?;
+
+        let (generator, get_frame) = if produced.is_instance_of::<DoeffGenerator>() {
+            let doeff_gen = produced
+                .extract::<PyRef<'_, DoeffGenerator>>()
+                .map_err(|e| VMError::python_error(e.to_string()))?;
+            (
+                doeff_gen.generator.clone_ref(py),
+                doeff_gen.get_frame.clone_ref(py),
+            )
+        } else {
+            let is_generator_like = produced.hasattr("__next__").unwrap_or(false)
+                && produced.hasattr("send").unwrap_or(false)
+                && produced.hasattr("throw").unwrap_or(false);
+            if !is_generator_like {
+                let found = produced
+                    .get_type()
+                    .name()
+                    .map(|name| name.to_string())
+                    .unwrap_or_else(|_| "<unknown>".to_string());
+                return Err(VMError::type_error(format!(
+                    "Kleisli {} must return a generator-like object, got {found}",
+                    self.name
+                )));
+            }
+            (produced.unbind(), Self::default_get_frame(py)?)
+        };
+
+        let stream = PythonGeneratorStream::new(PyShared::new(generator), PyShared::new(get_frame));
+        let stream_ref: IRStreamRef = Arc::new(Mutex::new(Box::new(stream)));
+        let metadata = CallMetadata::new(
+            self.name.clone(),
+            self.file.clone().unwrap_or_else(|| "<unknown>".to_string()),
+            self.line.unwrap_or(0),
+            args_repr,
+            None,
+        );
+
+        Ok(DoCtrl::IRStream {
+            stream: stream_ref,
+            metadata: Some(metadata),
+        })
+    }
+
+    fn debug_info(&self) -> KleisliDebugInfo {
+        KleisliDebugInfo {
+            name: self.name.clone(),
+            file: self.file.clone(),
+            line: self.line,
+        }
+    }
+
+    fn py_identity(&self) -> Option<PyShared> {
+        Python::attach(|py| {
+            if let Ok(factory) = self.func.bind(py).getattr("_doeff_generator_factory") {
+                if let Ok(callable) = factory.getattr("callable") {
+                    return Some(PyShared::new(callable.unbind()));
+                }
+            }
+            Some(self.func.clone())
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RustKleisli {
+    factory: IRStreamFactoryRef,
+    name: String,
+}
+
+impl RustKleisli {
+    pub fn new(factory: IRStreamFactoryRef, name: String) -> Self {
+        Self { factory, name }
+    }
+
+    pub fn factory(&self) -> &IRStreamFactoryRef {
+        &self.factory
+    }
+}
+
+impl Kleisli for RustKleisli {
+    fn apply(&self, _py: Python<'_>, _args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        Err(VMError::internal(
+            "RustKleisli.apply() not yet wired - use IRStreamFactory directly until Phase 3",
+        ))
+    }
+
+    fn debug_info(&self) -> KleisliDebugInfo {
+        KleisliDebugInfo {
+            name: self.name.clone(),
+            file: None,
+            line: None,
+        }
+    }
+}

--- a/packages/doeff-vm/src/value.rs
+++ b/packages/doeff-vm/src/value.rs
@@ -2,6 +2,8 @@
 //!
 //! Values can be either Rust-native (for optimization) or Python objects.
 
+use std::sync::Arc;
+
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyList, PyString};
 
@@ -433,6 +435,9 @@ impl Value {
         }
         if let Ok(s) = obj.extract::<String>() {
             return Value::String(s);
+        }
+        if let Ok(kleisli) = obj.extract::<PyRef<'_, crate::kleisli::PyKleisli>>() {
+            return Value::Kleisli(Arc::new(kleisli.clone()));
         }
         Value::Python(obj.clone().unbind())
     }

--- a/tests/public_api/test_types_001_handler_protocol.py
+++ b/tests/public_api/test_types_001_handler_protocol.py
@@ -492,7 +492,4 @@ class TestHP11DoDecoratedHandler:
             return result
 
         result = run(_prog(main), handlers=default_handlers())
-        assert result.is_err()
-        assert isinstance(result.error, TypeError)
-        assert "must return a generator" in str(result.error)
-        assert "Did you forget 'yield'?" in str(result.error)
+        assert result.value == "wrapped:x"


### PR DESCRIPTION
## Summary
- implement `PyKleisli` as a Rust `#[pyclass]` and `Kleisli` impl (callable, descriptor-aware, metadata-aware)
- add `RustKleisli` placeholder type per Phase 2 scope
- register `PyKleisli` in `doeff_vm` module and wire `Value::from_pyobject` detection
- add `KleisliHandler` and migrate `PythonHandler.invoke()` to use `Value::Kleisli`
- update `PyVM::classify_handler_object` and `WithHandler` validation to accept `PyKleisli`
- switch `@do` to return `PyKleisli` while preserving existing metadata/signature behavior
- preserve `isinstance(x, KleisliProgram)` via virtual subclass registration
- keep Python runtime coercion paths from downgrading `PyKleisli` to `DoeffGeneratorFn`
- update characterization + public API tests to assert post-fix behavior for doeff-13/PreKleisli paths

## Issue
- VM-KLEISLI-PHASE2

## Acceptance Criteria Evidence
- `[x] PyKleisli is a #[pyclass] accessible from Python`
  - `uv run python - <<'PY' ... from doeff_vm import PyKleisli ...` prints `<class 'builtins.PyKleisli'>`
- `[x] RustKleisli exists with placeholder apply()`
  - added in `packages/doeff-vm/src/kleisli.rs`
- `[x] @do decorator returns PyKleisli instance`
  - `uv run python` probe prints `type(f).__name__ == 'PyKleisli'`
- `[x] isinstance(x, KleisliProgram) still works for PyKleisli`
  - same probe prints `True`
- `[x] @do handlers work with WithHandler (no TypeError)`
  - `uv run pytest tests/core/test_kleisli_characterization.py -v` passed
  - `uv run pytest tests/public_api/test_doeff13_hang_regression.py -v` passed
- `[x] TestDoHandlerPreKleisli updated to assert correct behavior`
  - updated in `tests/core/test_kleisli_characterization.py`
- `[x] Full fast suite passes`
  - `uv run pytest -m "not slow and not cli and not semgrep" -q` -> `727 passed, 53 deselected`
- `[x] make sync succeeds`
  - `make sync` completed successfully (including `maturin develop`)
- `[x] cargo test succeeds`
  - `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q` -> `220 passed`

## Validation Commands Run
- `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q`
- `make sync`
- `uv run python - <<'PY' ... from doeff_vm import PyKleisli ...` (plus `@do` type/isinstance probe)
- `uv run pytest tests/core/test_kleisli_characterization.py -v`
- `uv run pytest tests/public_api/test_doeff13_hang_regression.py -v`
- `uv run pytest tests/public_api/test_types_001_handler_protocol.py -q`
- `uv run pytest -m "not slow and not cli and not semgrep" -q`
- `uv run semgrep --config .semgrep.yaml packages/doeff-vm/src/ --error 2>/dev/null || true`
