### PR TITLE
VM-KLEISLI-PHASE3: migrate WithHandler/WithIntercept IR to KleisliRef

### DIFF
--- a/packages/doeff-vm/src/dispatch_state.rs
+++ b/packages/doeff-vm/src/dispatch_state.rs
@@ -7,8 +7,8 @@ use crate::continuation::Continuation;
 use crate::dispatch::DispatchContext;
 use crate::effect::DispatchEffect;
 use crate::error::VMError;
-use crate::handler::Handler;
 use crate::ids::{ContId, DispatchId, Marker, SegmentId};
+use crate::kleisli::KleisliRef;
 use crate::py_shared::PyShared;
 use crate::step::PyException;
 
@@ -21,7 +21,7 @@ pub(crate) struct DispatchState {
 pub(crate) struct WithHandlerPlan {
     pub(crate) handler_marker: Marker,
     pub(crate) outside_seg_id: SegmentId,
-    pub(crate) handler: Handler,
+    pub(crate) handler: KleisliRef,
     pub(crate) py_identity: Option<PyShared>,
 }
 
@@ -222,8 +222,7 @@ impl DispatchState {
     }
 
     pub(crate) fn prepare_with_handler(
-        handler: Handler,
-        explicit_py_identity: Option<PyShared>,
+        handler: KleisliRef,
         current_segment: Option<SegmentId>,
     ) -> Result<WithHandlerPlan, VMError> {
         let handler_marker = Marker::fresh();
@@ -231,7 +230,7 @@ impl DispatchState {
             return Err(VMError::internal("no current segment for WithHandler"));
         };
 
-        let py_identity = explicit_py_identity.or_else(|| handler.py_identity());
+        let py_identity = handler.py_identity();
         Ok(WithHandlerPlan {
             handler_marker,
             outside_seg_id,

--- a/packages/doeff-vm/src/interceptor_state.rs
+++ b/packages/doeff-vm/src/interceptor_state.rs
@@ -10,7 +10,7 @@ use crate::doeff_generator::DoeffGenerator;
 use crate::error::VMError;
 use crate::frame::CallMetadata;
 use crate::ids::{DispatchId, Marker, SegmentId};
-use crate::py_shared::PyShared;
+use crate::kleisli::KleisliRef;
 use crate::pyvm::{PyDoCtrlBase, PyDoExprBase, PyEffectBase};
 use crate::segment::Segment;
 use crate::vm::InterceptorEntry;
@@ -159,7 +159,7 @@ impl InterceptorState {
     pub(crate) fn insert(
         &mut self,
         marker: Marker,
-        interceptor: PyShared,
+        interceptor: KleisliRef,
         metadata: Option<CallMetadata>,
     ) {
         self.interceptors.insert(
@@ -177,7 +177,7 @@ impl InterceptorState {
 
     pub(crate) fn prepare_with_intercept(
         &mut self,
-        interceptor: PyShared,
+        interceptor: KleisliRef,
         metadata: Option<CallMetadata>,
         current_segment: Option<SegmentId>,
         segments: &SegmentArena,

--- a/packages/doeff-vm/src/segment.rs
+++ b/packages/doeff-vm/src/segment.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::frame::Frame;
 use crate::handler::HandlerRef;
 use crate::ids::{DispatchId, Marker, SegmentId};
+use crate::kleisli::KleisliRef;
 use crate::py_key::HashedPyKey;
 use crate::py_shared::PyShared;
 use crate::step::{Mode, PendingPython, PyException};
@@ -17,6 +18,7 @@ pub enum SegmentKind {
     PromptBoundary {
         handled_marker: Marker,
         handler: HandlerRef,
+        handler_kleisli: Option<KleisliRef>,
         return_clause: Option<PyShared>,
         py_identity: Option<PyShared>,
     },
@@ -72,6 +74,7 @@ impl Segment {
         caller: Option<SegmentId>,
         handled_marker: Marker,
         handler: HandlerRef,
+        handler_kleisli: Option<KleisliRef>,
         return_clause: Option<PyShared>,
         py_identity: Option<PyShared>,
     ) -> Self {
@@ -83,6 +86,7 @@ impl Segment {
             kind: SegmentKind::PromptBoundary {
                 handled_marker,
                 handler,
+                handler_kleisli,
                 return_clause,
                 py_identity,
             },
@@ -148,6 +152,7 @@ mod tests {
             None,
             handled,
             std::sync::Arc::new(crate::handler::StateHandlerFactory),
+            None,
             None,
             None,
         );

--- a/packages/doeff-vm/src/vm_tests.rs
+++ b/packages/doeff-vm/src/vm_tests.rs
@@ -149,6 +149,7 @@ fn test_visible_handlers_no_dispatch() {
         Arc::new(crate::handler::StateHandlerFactory),
         None,
         None,
+        None,
     ));
     let body_1 = vm.alloc_segment(Segment::new(m1, Some(prompt_1)));
     let prompt_2 = vm.alloc_segment(Segment::new_prompt(
@@ -156,6 +157,7 @@ fn test_visible_handlers_no_dispatch() {
         Some(body_1),
         m2,
         Arc::new(crate::handler::ReaderHandlerFactory),
+        None,
         None,
         None,
     ));
@@ -180,6 +182,7 @@ fn test_visible_handlers_with_busy_boundary() {
         Arc::new(crate::handler::StateHandlerFactory),
         None,
         None,
+        None,
     ));
     let b1 = vm.alloc_segment(Segment::new(m1, Some(p1)));
     let p2 = vm.alloc_segment(Segment::new_prompt(
@@ -189,6 +192,7 @@ fn test_visible_handlers_with_busy_boundary() {
         Arc::new(crate::handler::ReaderHandlerFactory),
         None,
         None,
+        None,
     ));
     let b2 = vm.alloc_segment(Segment::new(m2, Some(p2)));
     let p3 = vm.alloc_segment(Segment::new_prompt(
@@ -196,6 +200,7 @@ fn test_visible_handlers_with_busy_boundary() {
         Some(b2),
         m3,
         Arc::new(crate::handler::WriterHandlerFactory),
+        None,
         None,
         None,
     ));
@@ -289,6 +294,7 @@ fn test_handler_clause_cannot_see_below_prompt_handlers() {
         Arc::new(crate::handler::ReaderHandlerFactory),
         None,
         None,
+        None,
     ));
     let outer_body = vm.alloc_segment(Segment::new(outer_marker, Some(outer_prompt)));
     let inner_prompt = vm.alloc_segment(Segment::new_prompt(
@@ -296,6 +302,7 @@ fn test_handler_clause_cannot_see_below_prompt_handlers() {
         Some(outer_body),
         inner_marker,
         Arc::new(crate::handler::StateHandlerFactory),
+        None,
         None,
         None,
     ));
@@ -333,6 +340,7 @@ fn test_visible_handlers_completed_dispatch() {
         Arc::new(crate::handler::StateHandlerFactory),
         None,
         None,
+        None,
     ));
     let b1 = vm.alloc_segment(Segment::new(m1, Some(p1)));
     let p2 = vm.alloc_segment(Segment::new_prompt(
@@ -340,6 +348,7 @@ fn test_visible_handlers_completed_dispatch() {
         Some(b1),
         m2,
         Arc::new(crate::handler::ReaderHandlerFactory),
+        None,
         None,
         None,
     ));

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ markers = [
     "semgrep: tests that invoke semgrep subprocess",
     "stress: stress tests with high concurrency or iteration count",
     "pre_kleisli_behavior: characterization tests for pre-Kleisli handler behavior",
+    "phase3_baseline: characterization tests for VM Kleisli Phase 3 behavior",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Migrate `DoCtrl::WithHandler` and `DoCtrl::WithIntercept` IR fields to typed Kleisli values and classified Rust IR bodies.
- Classify `WithHandler`/`WithIntercept` bodies at construction time in `pyvm`, removing deferred opaque `Py<PyAny>` handling in VM dispatch.
- Update VM execution paths to run Kleisli-backed interceptors and support Kleisli-backed handler prompts while preserving Rust sentinel handlers.
- Add Phase 3 characterization tests (`@pytest.mark.phase3_baseline`) for handler/interceptor behavior and register the marker.

## Issue
- Ref: **VM-KLEISLI-PHASE3**

## Key Changes
- `WithHandler`: `handler: KleisliRef`, `body: Box<DoCtrl>`, `py_identity` removed from DoCtrl.
- `WithIntercept`: `interceptor: KleisliRef`, `body: Box<DoCtrl>`.
- Added Kleisli adapters:
  - `DgfnKleisli` (preserves registration metadata + callable identity)
  - `PyCallableKleisli` (plain callable interceptors returning direct values)
  - `HandlerSentinelKleisli` (Rust sentinel compatibility)
- `SegmentKind::PromptBoundary` now carries optional `handler_kleisli` for direct Kleisli dispatch where applicable.
- `pyvm` now uses `extract_kleisli_ref(...)` for `WithHandler`/`WithIntercept` classification and round-trips typed bodies in `doctrl_to_pyexpr_for_vm`.

## Acceptance Criteria Evidence
- [x] `WithHandler.handler` is `KleisliRef` / typed body
  - `packages/doeff-vm/src/do_ctrl.rs` updated.
- [x] `WithIntercept.interceptor` is `KleisliRef` / typed body
  - `packages/doeff-vm/src/do_ctrl.rs` updated.
- [x] `WithHandler.py_identity` removed from DoCtrl
  - identity now via `Kleisli::py_identity()` and segment metadata.
- [x] `@do` handlers still work with `WithHandler`
- [x] `@do` interceptors work with `WithIntercept`
- [x] Plain generator handlers still work
- [x] Plain callable interceptors still work
- [x] Rust built-in handlers still work
- [x] `make sync` succeeds
- [x] `cargo test` succeeds
- [x] Python non-slow suite succeeds

## Validation Commands / Results
```bash
make sync
# succeeded (rebuilt doeff-vm via maturin)

cargo test --manifest-path packages/doeff-vm/Cargo.toml -q
# 220 passed, 0 failed

uv run pytest tests/core/test_kleisli_characterization.py -v
# 19 passed

uv run pytest tests/public_api/test_doeff13_hang_regression.py -v
# 4 passed

uv run pytest -m "not slow and not cli and not semgrep" -q
# 733 passed, 53 deselected, 0 failed
```
