### PR TITLE
VM-KLEISLI-PHASE4: remove legacy handler/callable types

### DIFF
--- a/packages/doeff-vm/src/continuation.rs
+++ b/packages/doeff-vm/src/continuation.rs
@@ -7,8 +7,8 @@ use pyo3::types::{PyDict, PyList};
 
 use crate::frame::CallMetadata;
 use crate::frame::Frame;
-use crate::handler::Handler;
 use crate::ids::{ContId, DispatchId, Marker, SegmentId};
+use crate::kleisli::KleisliRef;
 use crate::py_shared::PyShared;
 use crate::segment::{ScopeStore, Segment};
 use crate::step::{Mode, PendingPython, PyException};
@@ -49,7 +49,7 @@ pub struct Continuation {
 
     /// Handlers to install when started=false (innermost first).
     /// Empty for captured (started=true) continuations.
-    pub handlers: Vec<Handler>,
+    pub handlers: Vec<KleisliRef>,
 
     /// Optional Python identities corresponding to handlers by index.
     /// Used to preserve Rust sentinel identity across continuation round-trips.
@@ -116,13 +116,13 @@ impl Continuation {
         }
     }
 
-    pub fn create_unstarted(expr: PyShared, handlers: Vec<Handler>) -> Self {
+    pub fn create_unstarted(expr: PyShared, handlers: Vec<KleisliRef>) -> Self {
         Self::create_unstarted_with_metadata(expr, handlers, None)
     }
 
     pub fn create_unstarted_with_metadata(
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         metadata: Option<CallMetadata>,
     ) -> Self {
         let handler_identities = vec![None; handlers.len()];
@@ -149,7 +149,7 @@ impl Continuation {
 
     pub fn create_unstarted_with_identities(
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
     ) -> Self {
         Self::create_unstarted_with_identities_and_metadata(
@@ -162,7 +162,7 @@ impl Continuation {
 
     pub fn create_unstarted_with_identities_and_metadata(
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
         metadata: Option<CallMetadata>,
     ) -> Self {

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -7,7 +7,6 @@ use crate::continuation::Continuation;
 use crate::driver::PyException;
 use crate::effect::DispatchEffect;
 use crate::frame::CallMetadata;
-use crate::handler::Handler;
 use crate::kleisli::KleisliRef;
 use crate::py_shared::PyShared;
 use crate::value::Value;
@@ -72,7 +71,7 @@ pub enum DoCtrl {
     },
     CreateContinuation {
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
     },
     ResumeContinuation {
@@ -101,7 +100,7 @@ pub enum DoCtrl {
     },
     Eval {
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         metadata: Option<CallMetadata>,
     },
     GetCallStack,

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -58,11 +58,10 @@ pub use effect::{Effect, PyAsk, PyCancelEffect, PyGet, PyLocal, PyModify, PyPut,
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{
-    Handler, HandlerDebugInfo, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
-    ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
+    LazyAskHandlerFactory, ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
 };
 pub use ids::{ContId, DispatchId, Marker, RunnableId, SegmentId};
-pub use kleisli::{Kleisli, KleisliDebugInfo, KleisliRef};
+pub use kleisli::{Kleisli, KleisliDebugInfo, KleisliRef, PyKleisli, RustKleisli};
 pub use py_key::HashedPyKey;
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
 pub use pyvm::{DoExprTag, PyStdlib, PyVM};

--- a/packages/doeff-vm/src/scheduler.rs
+++ b/packages/doeff-vm/src/scheduler.rs
@@ -18,7 +18,7 @@ use crate::doeff_generator::DoeffGeneratorFn;
 #[cfg(test)]
 use crate::effect::Effect;
 use crate::effect::{
-    dispatch_from_shared, dispatch_into_python, dispatch_ref_as_python,
+    dispatch_from_shared, dispatch_into_python, dispatch_ref_as_python, dispatch_to_pyobject,
     make_execution_context_object, DispatchEffect, PyAcquireSemaphore, PyCancelEffect,
     PyCompletePromise, PyCreateExternalPromise, PyCreatePromise, PyCreateSemaphore, PyFailPromise,
     PyGather, PyGetExecutionContext, PyRace, PyReleaseSemaphore, PySpawn, PyTaskCompleted,
@@ -26,10 +26,10 @@ use crate::effect::{
 use crate::error::VMError;
 use crate::frame::CallMetadata;
 use crate::handler::{
-    IRStreamFactory, IRStreamProgram, IRStreamProgramRef, Handler, HandlerInvoke, PythonHandler,
-    RustProgramInvocation,
+    IRStreamFactory, IRStreamProgram, IRStreamProgramRef,
 };
 use crate::ids::{ContId, DispatchId, PromiseId, TaskId};
+use crate::kleisli::{DgfnKleisli, KleisliRef, PyKleisli, RustKleisli};
 use crate::py_shared::PyShared;
 use crate::pyvm::{PyResultErr, PyResultOk, PyRustHandlerSentinel};
 use crate::segment::ScopeStore;
@@ -47,7 +47,7 @@ pub const PRIORITY_HIGH: u32 = 20;
 pub enum SchedulerEffect {
     Spawn {
         program: Py<PyAny>,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         store_mode: StoreMode,
         priority: u32,
         creation_site: Option<SpawnSite>,
@@ -731,33 +731,39 @@ fn extract_task_id(obj: &Bound<'_, PyAny>) -> Option<TaskId> {
     None
 }
 
-fn extract_handlers_from_python(obj: &Bound<'_, PyAny>) -> Result<Vec<Handler>, String> {
+fn extract_handlers_from_python(obj: &Bound<'_, PyAny>) -> Result<Vec<KleisliRef>, String> {
     if obj.is_none() {
         return Ok(vec![]);
     }
-    let mut handlers = Vec::new();
+    let mut handlers: Vec<KleisliRef> = Vec::new();
     for item in obj.try_iter().map_err(|e| e.to_string())? {
         let item = item.map_err(|e| e.to_string())?;
         if item.is_instance_of::<PyRustHandlerSentinel>() {
-            let sentinel: PyRef<'_, PyRustHandlerSentinel> = item
-                .extract::<PyRef<'_, PyRustHandlerSentinel>>()
-                .map_err(|e| format!("{e:?}"))?;
-            handlers.push(sentinel.factory_ref());
-            continue;
+            return Err("Spawn handlers no longer accept RustHandler sentinels".to_string());
         }
 
         if item.is_instance_of::<DoeffGeneratorFn>() {
+            let py = item.py();
             let dgfn = item
-                .extract::<Py<DoeffGeneratorFn>>()
+                .extract::<PyRef<'_, DoeffGeneratorFn>>()
                 .map_err(|e| format!("{e:?}"))?;
-            handlers.push(Arc::new(PythonHandler::from_dgfn(dgfn)));
+            let callable_identity = dgfn.callable.clone_ref(py);
+            let kleisli = DgfnKleisli::from_dgfn(py, item.clone().unbind(), callable_identity)
+                .map_err(|e| format!("{e:?}"))?;
+            handlers.push(Arc::new(kleisli) as KleisliRef);
+            continue;
+        }
+
+        if item.is_instance_of::<PyKleisli>() {
+            let kleisli = item
+                .extract::<PyRef<'_, PyKleisli>>()
+                .map_err(|e| format!("{e:?}"))?;
+            handlers.push(Arc::new(kleisli.clone()) as KleisliRef);
             continue;
         }
 
         if item.is_callable() {
-            return Err(
-                "Spawn handlers must be DoeffGeneratorFn or RustHandler sentinel".to_string(),
-            );
+            return Err("Spawn handlers must be DoeffGeneratorFn or PyKleisli".to_string());
         }
 
         let ty = item
@@ -766,7 +772,7 @@ fn extract_handlers_from_python(obj: &Bound<'_, PyAny>) -> Result<Vec<Handler>, 
             .map(|name| name.to_string())
             .unwrap_or_else(|_| "<unknown>".to_string());
         return Err(format!(
-            "Spawn handlers must be DoeffGeneratorFn or RustHandler sentinel, got {ty}"
+            "Spawn handlers must be DoeffGeneratorFn or PyKleisli, got {ty}"
         ));
     }
     Ok(handlers)
@@ -2909,56 +2915,13 @@ impl IRStreamFactory for SchedulerHandler {
         SCHEDULER_HANDLER_NAME
     }
 
-    fn on_run_end(&self, run_token: u64) {
-        let mut states = self.run_states.lock().expect("Scheduler lock poisoned");
-        states.remove(&run_token);
-    }
-}
-
-impl HandlerInvoke for SchedulerHandler {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoCtrl {
-        DoCtrl::Expand {
-            factory: Box::new(DoCtrl::Pure {
-                value: Value::RustProgramInvocation(RustProgramInvocation {
-                    factory: Arc::new(self.clone()),
-                    effect: Box::new(effect),
-                    continuation: k,
-                }),
-            }),
-            args: vec![],
-            kwargs: vec![],
-            metadata: CallMetadata::new(
-                <Self as IRStreamFactory>::handler_name(self).to_string(),
-                "<rust>".to_string(),
-                0,
-                None,
-                None,
-            ),
-        }
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> crate::handler::HandlerDebugInfo {
-        crate::handler::HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
-    }
-
     fn supports_error_context_conversion(&self) -> bool {
         true
     }
 
     fn on_run_end(&self, run_token: u64) {
-        <Self as IRStreamFactory>::on_run_end(self, run_token);
+        let mut states = self.run_states.lock().expect("Scheduler lock poisoned");
+        states.remove(&run_token);
     }
 }
 
@@ -4472,13 +4435,15 @@ mod tests {
     #[test]
     fn test_scheduler_handler_can_handle() {
         let handler = SchedulerHandler::new();
-        assert!(!HandlerInvoke::can_handle(
-            &handler,
-            &Effect::Get {
-                key: "x".to_string()
-            }
-        )
-        .unwrap());
+        assert!(
+            !<SchedulerHandler as IRStreamFactory>::can_handle(
+                &handler,
+                &Effect::Get {
+                    key: "x".to_string()
+                }
+            )
+            .unwrap()
+        );
     }
 
     #[test]

--- a/packages/doeff-vm/src/value.rs
+++ b/packages/doeff-vm/src/value.rs
@@ -12,7 +12,7 @@ use crate::capture::{
     HandlerStatus, TraceEntry, TraceHop,
 };
 use crate::frame::CallMetadata;
-use crate::handler::{Handler, RustProgramInvocation};
+use crate::kleisli::KleisliRef;
 use crate::pyvm::{PyTraceFrame, PyTraceHop};
 use crate::scheduler::{ExternalPromise, PromiseHandle, TaskHandle};
 
@@ -29,9 +29,7 @@ pub enum Value {
     Bool(bool),
     None,
     Continuation(crate::continuation::Continuation),
-    Handlers(Vec<Handler>),
-    RustProgramInvocation(RustProgramInvocation),
-    PythonHandlerCallable(Py<PyAny>),
+    Handlers(Vec<KleisliRef>),
     Kleisli(crate::kleisli::KleisliRef),
     Task(TaskHandle),
     Promise(PromiseHandle),
@@ -329,7 +327,8 @@ impl Value {
             Value::Handlers(handlers) => {
                 let list = PyList::empty(py);
                 for h in handlers {
-                    if let Some(identity) = h.py_identity() {
+                    if h.expects_python_k() && h.py_identity().is_some() {
+                        let identity = h.py_identity().expect("checked is_some above");
                         list.append(identity.bind(py))?;
                     } else {
                         list.append(py.None().into_bound(py))?;
@@ -337,8 +336,6 @@ impl Value {
                 }
                 Ok(list.into_any())
             }
-            Value::RustProgramInvocation(_) => Ok(py.None().into_bound(py)),
-            Value::PythonHandlerCallable(callable) => Ok(callable.bind(py).clone()),
             Value::Kleisli(_) => Ok(py.None().into_bound(py)),
             Value::Task(handle) => {
                 let dict = pyo3::types::PyDict::new(py);
@@ -482,7 +479,7 @@ impl Value {
     }
 
     /// Try to get as handlers slice.
-    pub fn as_handlers(&self) -> Option<&[Handler]> {
+    pub fn as_handlers(&self) -> Option<&[KleisliRef]> {
         match self {
             Value::Handlers(h) => Some(h),
             _ => None,
@@ -507,12 +504,6 @@ impl Value {
             Value::None => Value::None,
             Value::Continuation(k) => Value::Continuation(k.clone()),
             Value::Handlers(handlers) => Value::Handlers(handlers.clone()),
-            Value::RustProgramInvocation(invocation) => {
-                Value::RustProgramInvocation(invocation.clone())
-            }
-            Value::PythonHandlerCallable(callable) => {
-                Value::PythonHandlerCallable(callable.clone_ref(py))
-            }
             Value::Kleisli(kleisli) => Value::Kleisli(kleisli.clone()),
             Value::Task(h) => Value::Task(*h),
             Value::Promise(h) => Value::Promise(*h),
@@ -595,7 +586,14 @@ mod tests {
 
     #[test]
     fn test_value_handlers() {
-        let handlers = vec![std::sync::Arc::new(crate::handler::StateHandlerFactory) as Handler];
+        let factory: crate::handler::IRStreamFactoryRef =
+            std::sync::Arc::new(crate::handler::StateHandlerFactory);
+        let handlers = vec![
+            std::sync::Arc::new(crate::kleisli::RustKleisli::new(
+                factory,
+                "StateHandler".to_string(),
+            )) as KleisliRef,
+        ];
         let val = Value::Handlers(handlers);
         assert!(val.as_handlers().is_some());
         assert_eq!(val.as_handlers().unwrap().len(), 1);


### PR DESCRIPTION
## Summary
Implements VM-KLEISLI-PHASE4 by removing legacy handler/callable paths and making Kleisli the sole dispatch mechanism in the Rust VM.

## What changed
- Removed legacy types and adapters from Rust VM:
  - `Value::PythonHandlerCallable`
  - `Value::RustProgramInvocation`
  - `HandlerInvoke`, `HandlerRef`/`Handler` aliases
  - `RustProgramInvocation`, `PythonHandler`, `KleisliHandler`, `HandlerSentinelKleisli`
  - `as_any()` downcast hook on `Kleisli`
- Unified handler storage and dispatch on `KleisliRef`:
  - `Value::Handlers(Vec<KleisliRef>)`
  - `DoCtrl::{CreateContinuation, Eval}` handler vectors now `Vec<KleisliRef>`
  - `Continuation.handlers` now `Vec<KleisliRef>`
  - `SegmentKind::PromptBoundary` now stores only `handler: KleisliRef` (no dual storage / `py_identity` field)
- Implemented working `RustKleisli.apply()`:
  - Builds deferred-start Rust IR stream and returns `DoCtrl::IRStream`
  - Supports optional run token forwarding
- Unified runtime dispatch to Kleisli-only path:
  - Removed fallback `Handler::invoke()` dispatch
  - `VM` dispatch/forward flows now invoke `kleisli.apply()` only
- Preserved matching semantics:
  - Added/used `Kleisli::can_handle(...)`
  - Added/used `Kleisli::supports_error_context_conversion()` and `on_run_end(...)`
- Preserved identity semantics without PromptBoundary dual storage:
  - Added `IdentityKleisli` wrapper (`with_py_identity(...)`) for continuation/sentinel identity preservation
  - Added `Kleisli::expects_python_k()` to decouple invocation protocol from identity
- Updated scheduler and pyvm integration to Kleisli wrappers (`RustKleisli`) end-to-end
- Updated VM tests to construct Rust handlers through Kleisli wrappers and PromptBoundary API
- Updated test-mode effect conversion to maintain built-in effect behavior through Kleisli apply round-trip

## Acceptance criteria mapping
- [x] `Value::PythonHandlerCallable` removed
- [x] `Value::RustProgramInvocation` removed
- [x] `RustProgramInvocation` removed
- [x] `HandlerInvoke` removed
- [x] `Handler` / `HandlerRef` aliases removed
- [x] `PythonHandler` removed
- [x] `KleisliHandler` removed
- [x] `HandlerSentinelKleisli` removed
- [x] `as_any()` removed from `Kleisli`
- [x] PromptBoundary stores single `handler: KleisliRef`
- [x] `RustKleisli.apply()` implemented and active
- [x] All dispatch uses `kleisli.apply()` (no legacy invoke fallback)
- [x] `can_handle` preserved on Kleisli path
- [x] Rust built-in handlers work via `RustKleisli`
- [x] Scheduler handler works on Kleisli path
- [x] `isinstance(x, KleisliProgram)` remains true for `@do` output (`PyKleisli`)

## Validation
Executed in this branch:

```bash
cargo test --manifest-path packages/doeff-vm/Cargo.toml -q
# result: 220 passed

make sync
# result: success (uv sync + maturin develop)

uv run pytest -m "not slow and not cli and not semgrep" -q
# result: 733 passed, 53 deselected

uv run pyright doeff/ 2>&1 | head -50
# result: existing pyright diagnostics present in repository baseline

grep -r "PythonHandlerCallable\|RustProgramInvocation\|HandlerInvoke" packages/doeff-vm/src/ --include="*.rs" | grep -v "test" | grep -v "//" || echo "Clean!"
# result: Clean!
```

Issue: VM-KLEISLI-PHASE4
