### PR TITLE
VM-KLEISLI-PHASE4: remove legacy handler/callable paths

### DIFF
--- a/packages/doeff-vm/src/continuation.rs
+++ b/packages/doeff-vm/src/continuation.rs
@@ -7,8 +7,8 @@ use pyo3::types::{PyDict, PyList};
 
 use crate::frame::CallMetadata;
 use crate::frame::Frame;
-use crate::handler::Handler;
 use crate::ids::{ContId, DispatchId, Marker, SegmentId};
+use crate::kleisli::KleisliRef;
 use crate::py_shared::PyShared;
 use crate::segment::{ScopeStore, Segment};
 use crate::step::{Mode, PendingPython, PyException};
@@ -49,7 +49,7 @@ pub struct Continuation {
 
     /// Handlers to install when started=false (innermost first).
     /// Empty for captured (started=true) continuations.
-    pub handlers: Vec<Handler>,
+    pub handlers: Vec<KleisliRef>,
 
     /// Optional Python identities corresponding to handlers by index.
     /// Used to preserve Rust sentinel identity across continuation round-trips.
@@ -116,13 +116,13 @@ impl Continuation {
         }
     }
 
-    pub fn create_unstarted(expr: PyShared, handlers: Vec<Handler>) -> Self {
+    pub fn create_unstarted(expr: PyShared, handlers: Vec<KleisliRef>) -> Self {
         Self::create_unstarted_with_metadata(expr, handlers, None)
     }
 
     pub fn create_unstarted_with_metadata(
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         metadata: Option<CallMetadata>,
     ) -> Self {
         let handler_identities = vec![None; handlers.len()];
@@ -149,7 +149,7 @@ impl Continuation {
 
     pub fn create_unstarted_with_identities(
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
     ) -> Self {
         Self::create_unstarted_with_identities_and_metadata(
@@ -162,7 +162,7 @@ impl Continuation {
 
     pub fn create_unstarted_with_identities_and_metadata(
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
         metadata: Option<CallMetadata>,
     ) -> Self {
@@ -205,8 +205,12 @@ impl Continuation {
                     list.append(identity.bind(py))?;
                     continue;
                 }
-                if let Some(identity) = handler.py_identity() {
-                    list.append(identity.bind(py))?;
+                if handler.expects_python_effect() {
+                    if let Some(identity) = handler.py_identity() {
+                        list.append(identity.bind(py))?;
+                    } else {
+                        list.append(py.None().into_bound(py))?;
+                    }
                 } else {
                     list.append(py.None().into_bound(py))?;
                 }

--- a/packages/doeff-vm/src/dispatch_state.rs
+++ b/packages/doeff-vm/src/dispatch_state.rs
@@ -9,7 +9,6 @@ use crate::effect::DispatchEffect;
 use crate::error::VMError;
 use crate::ids::{ContId, DispatchId, Marker, SegmentId};
 use crate::kleisli::KleisliRef;
-use crate::py_shared::PyShared;
 use crate::step::PyException;
 
 #[derive(Debug, Clone, Default)]
@@ -22,7 +21,6 @@ pub(crate) struct WithHandlerPlan {
     pub(crate) handler_marker: Marker,
     pub(crate) outside_seg_id: SegmentId,
     pub(crate) handler: KleisliRef,
-    pub(crate) py_identity: Option<PyShared>,
 }
 
 impl DispatchState {
@@ -230,12 +228,10 @@ impl DispatchState {
             return Err(VMError::internal("no current segment for WithHandler"));
         };
 
-        let py_identity = handler.py_identity();
         Ok(WithHandlerPlan {
             handler_marker,
             outside_seg_id,
             handler,
-            py_identity,
         })
     }
 }

--- a/packages/doeff-vm/src/do_ctrl.rs
+++ b/packages/doeff-vm/src/do_ctrl.rs
@@ -7,7 +7,6 @@ use crate::continuation::Continuation;
 use crate::driver::PyException;
 use crate::effect::DispatchEffect;
 use crate::frame::CallMetadata;
-use crate::handler::Handler;
 use crate::kleisli::KleisliRef;
 use crate::py_shared::PyShared;
 use crate::value::Value;
@@ -72,7 +71,7 @@ pub enum DoCtrl {
     },
     CreateContinuation {
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
     },
     ResumeContinuation {
@@ -101,7 +100,7 @@ pub enum DoCtrl {
     },
     Eval {
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         metadata: Option<CallMetadata>,
     },
     GetCallStack,

--- a/packages/doeff-vm/src/handler.rs
+++ b/packages/doeff-vm/src/handler.rs
@@ -11,21 +11,18 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
 
 use crate::continuation::Continuation;
-use crate::doeff_generator::DoeffGeneratorFn;
 #[cfg(test)]
 use crate::effect::Effect;
 use crate::effect::{
-    dispatch_from_shared, dispatch_into_python, dispatch_ref_as_python, dispatch_to_pyobject,
-    DispatchEffect, PyAsk, PyGet, PyLocal, PyModify, PyPut, PyPythonAsyncioAwaitEffect,
-    PyResultSafeEffect, PyTell,
+    dispatch_from_shared, dispatch_into_python, dispatch_ref_as_python, DispatchEffect, PyAsk,
+    PyGet, PyLocal, PyModify, PyPut, PyPythonAsyncioAwaitEffect, PyResultSafeEffect, PyTell,
 };
 use crate::error::VMError;
-use crate::frame::CallMetadata;
 use crate::ir_stream::{IRStream, IRStreamStep, StreamLocation};
-use crate::kleisli::{KleisliRef, PyKleisli};
+use crate::kleisli::{Kleisli, KleisliDebugInfo, RustKleisli};
 use crate::py_key::HashedPyKey;
 use crate::py_shared::PyShared;
-use crate::pyvm::{PyDoCtrlBase, PyDoExprBase, PyEffectBase, PyK, PyResultErr, PyResultOk};
+use crate::pyvm::{PyDoCtrlBase, PyDoExprBase, PyEffectBase, PyResultErr, PyResultOk};
 use crate::segment::ScopeStore;
 use crate::step::{DoCtrl, PyException, PythonCall};
 use crate::value::Value;
@@ -64,6 +61,10 @@ pub trait IRStreamFactory: std::fmt::Debug + Send + Sync {
         std::any::type_name::<Self>()
     }
 
+    fn supports_error_context_conversion(&self) -> bool {
+        false
+    }
+
     /// Create a handler program for a specific VM run token.
     ///
     /// Handlers that keep per-run state (for example, scheduler internals)
@@ -79,291 +80,40 @@ pub trait IRStreamFactory: std::fmt::Debug + Send + Sync {
     fn on_run_end(&self, _run_token: u64) {}
 }
 
-pub type DoExpr = DoCtrl;
-
-#[derive(Debug, Clone)]
-pub struct HandlerDebugInfo {
-    pub name: String,
-    pub file: Option<String>,
-    pub line: Option<u32>,
-}
-
-pub trait HandlerInvoke: std::fmt::Debug + Send + Sync {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError>;
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr;
-    fn handler_name(&self) -> &str;
-    fn handler_debug_info(&self) -> HandlerDebugInfo;
-
-    fn supports_error_context_conversion(&self) -> bool {
-        false
-    }
-
-    fn py_identity(&self) -> Option<PyShared> {
-        None
-    }
-
-    fn on_run_end(&self, _run_token: u64) {}
-}
-
-pub type HandlerRef = Arc<dyn HandlerInvoke>;
-pub type Handler = HandlerRef;
-
 /// Shared reference to a Rust program handler factory.
 pub type IRStreamFactoryRef = Arc<dyn IRStreamFactory + Send + Sync>;
 
 /// Shared reference to a running Rust handler program (cloneable for continuations).
 pub type IRStreamProgramRef = Arc<Mutex<Box<dyn IRStreamProgram + Send>>>;
 
-#[derive(Debug, Clone)]
-pub struct RustProgramInvocation {
-    pub factory: IRStreamFactoryRef,
-    pub effect: Box<DispatchEffect>,
-    pub continuation: Continuation,
-}
-
-fn metadata_from_debug_info(debug: HandlerDebugInfo) -> CallMetadata {
-    CallMetadata::new(
-        debug.name,
-        debug.file.unwrap_or_else(|| "<unknown>".to_string()),
-        debug.line.unwrap_or(0),
-        None,
-        None,
-    )
-}
-
-fn rust_program_apply_expr(
-    factory: IRStreamFactoryRef,
-    effect: DispatchEffect,
-    continuation: Continuation,
-    metadata: CallMetadata,
-) -> DoExpr {
-    DoCtrl::Apply {
-        f: Box::new(DoCtrl::Pure {
-            value: Value::RustProgramInvocation(RustProgramInvocation {
-                factory,
-                effect: Box::new(effect),
-                continuation,
-            }),
-        }),
-        args: vec![],
-        kwargs: vec![],
-        metadata,
-        evaluate_result: false,
-    }
-}
-
-fn rust_program_expand_expr(
-    factory: IRStreamFactoryRef,
-    effect: DispatchEffect,
-    continuation: Continuation,
-    metadata: CallMetadata,
-) -> DoExpr {
-    DoCtrl::Expand {
-        factory: Box::new(DoCtrl::Pure {
-            value: Value::RustProgramInvocation(RustProgramInvocation {
-                factory,
-                effect: Box::new(effect),
-                continuation,
-            }),
-        }),
-        args: vec![],
-        kwargs: vec![],
-        metadata,
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct PythonHandler {
-    pub dgfn: Py<DoeffGeneratorFn>,
-    handler_name: String,
-    handler_file: Option<String>,
-    handler_line: Option<u32>,
-}
-
-impl PythonHandler {
-    pub fn from_dgfn(dgfn: Py<DoeffGeneratorFn>) -> Self {
-        Python::attach(|py| {
-            let borrowed = dgfn.bind(py).borrow();
-            PythonHandler {
-                dgfn,
-                handler_name: borrowed.function_name.clone(),
-                handler_file: Some(borrowed.source_file.clone()),
-                handler_line: Some(borrowed.source_line),
-            }
-        })
-    }
-}
-
-impl HandlerInvoke for PythonHandler {
-    fn can_handle(&self, _effect: &DispatchEffect) -> Result<bool, VMError> {
-        Ok(true)
+impl<T> Kleisli for T
+where
+    T: IRStreamFactory + Clone + 'static,
+{
+    fn apply(&self, py: Python<'_>, args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        let kleisli = RustKleisli::from_factory(Arc::new(self.clone()))
+            .with_error_context_conversion(self.supports_error_context_conversion());
+        kleisli.apply(py, args)
     }
 
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        let py_effect =
-            match Python::attach(|py| dispatch_to_pyobject(py, &effect).map(|obj| obj.unbind())) {
-                Ok(obj) => obj,
-                Err(err) => {
-                    return DoCtrl::TransferThrow {
-                        continuation: k,
-                        exception: PyException::type_error(format!(
-                            "PythonHandler invoke failed to convert effect: {err}"
-                        )),
-                    };
-                }
-            };
+    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
+        IRStreamFactory::can_handle(self, effect)
+    }
 
-        let kleisli = match Python::attach(|py| {
-            PyKleisli::from_handler(py, self.dgfn.clone_ref(py).into_any())
-        }) {
-            Ok(value) => value,
-            Err(err) => {
-                return DoCtrl::TransferThrow {
-                    continuation: k,
-                    exception: PyException::type_error(format!(
-                        "PythonHandler invoke failed to build PyKleisli: {err}"
-                    )),
-                };
-            }
-        };
+    fn expects_python_effect(&self) -> bool {
+        false
+    }
 
-        let py_k = match Python::attach(|py| {
-            Bound::new(py, PyK::from_cont_id(k.cont_id)).map(|bound| bound.into_any().unbind())
-        }) {
-            Ok(obj) => obj,
-            Err(err) => {
-                return DoCtrl::TransferThrow {
-                    continuation: k,
-                    exception: PyException::type_error(format!(
-                        "PythonHandler invoke failed to create continuation handle: {err}"
-                    )),
-                };
-            }
-        };
+    fn supports_error_context_conversion(&self) -> bool {
+        IRStreamFactory::supports_error_context_conversion(self)
+    }
 
-        let metadata = metadata_from_debug_info(self.handler_debug_info());
-        DoCtrl::Expand {
-            factory: Box::new(DoCtrl::Pure {
-                value: Value::Kleisli(Arc::new(kleisli)),
-            }),
-            args: vec![
-                DoCtrl::Pure {
-                    value: Value::Python(py_effect),
-                },
-                DoCtrl::Pure {
-                    value: Value::Python(py_k),
-                },
-            ],
-            kwargs: vec![],
-            metadata,
+    fn debug_info(&self) -> KleisliDebugInfo {
+        KleisliDebugInfo {
+            name: self.handler_name().to_string(),
+            file: None,
+            line: None,
         }
-    }
-
-    fn handler_name(&self) -> &str {
-        self.handler_name.as_str()
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: self.handler_name.clone(),
-            file: self.handler_file.clone(),
-            line: self.handler_line,
-        }
-    }
-
-    fn py_identity(&self) -> Option<PyShared> {
-        Some(PyShared::new(Python::attach(|py| {
-            let borrowed = self.dgfn.bind(py).borrow();
-            borrowed.callable.clone_ref(py)
-        })))
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct KleisliHandler {
-    kleisli: KleisliRef,
-    handler_name: String,
-    handler_file: Option<String>,
-    handler_line: Option<u32>,
-}
-
-impl KleisliHandler {
-    pub fn new(kleisli: KleisliRef) -> Self {
-        let debug = kleisli.debug_info();
-        KleisliHandler {
-            kleisli,
-            handler_name: debug.name,
-            handler_file: debug.file,
-            handler_line: debug.line,
-        }
-    }
-}
-
-impl HandlerInvoke for KleisliHandler {
-    fn can_handle(&self, _effect: &DispatchEffect) -> Result<bool, VMError> {
-        Ok(true)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        let py_effect =
-            match Python::attach(|py| dispatch_to_pyobject(py, &effect).map(|obj| obj.unbind())) {
-                Ok(obj) => obj,
-                Err(err) => {
-                    return DoCtrl::TransferThrow {
-                        continuation: k,
-                        exception: PyException::type_error(format!(
-                            "KleisliHandler invoke failed to convert effect: {err}"
-                        )),
-                    };
-                }
-            };
-
-        let py_k = match Python::attach(|py| {
-            Bound::new(py, PyK::from_cont_id(k.cont_id)).map(|bound| bound.into_any().unbind())
-        }) {
-            Ok(obj) => obj,
-            Err(err) => {
-                return DoCtrl::TransferThrow {
-                    continuation: k,
-                    exception: PyException::type_error(format!(
-                        "KleisliHandler invoke failed to create continuation handle: {err}"
-                    )),
-                };
-            }
-        };
-
-        let metadata = metadata_from_debug_info(self.handler_debug_info());
-        DoCtrl::Expand {
-            factory: Box::new(DoCtrl::Pure {
-                value: Value::Kleisli(self.kleisli.clone()),
-            }),
-            args: vec![
-                DoCtrl::Pure {
-                    value: Value::Python(py_effect),
-                },
-                DoCtrl::Pure {
-                    value: Value::Python(py_k),
-                },
-            ],
-            kwargs: vec![],
-            metadata,
-        }
-    }
-
-    fn handler_name(&self) -> &str {
-        self.handler_name.as_str()
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: self.handler_name.clone(),
-            file: self.handler_file.clone(),
-            line: self.handler_line,
-        }
-    }
-
-    fn py_identity(&self) -> Option<PyShared> {
-        self.kleisli.py_identity()
     }
 }
 
@@ -697,33 +447,6 @@ impl IRStreamFactory for AwaitHandlerFactory {
     }
 }
 
-impl HandlerInvoke for AwaitHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        rust_program_expand_expr(
-            Arc::new(self.clone()),
-            effect,
-            k,
-            metadata_from_debug_info(self.handler_debug_info()),
-        )
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
-    }
-}
-
 #[derive(Debug)]
 struct AwaitHandlerProgram {
     pending_k: Option<Continuation>,
@@ -884,56 +607,6 @@ impl IRStreamFactory for StateHandlerFactory {
 
     fn handler_name(&self) -> &'static str {
         "StateHandler"
-    }
-}
-
-impl HandlerInvoke for StateHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        let is_modify = {
-            #[cfg(test)]
-            if matches!(&effect, Effect::Modify { .. }) {
-                true
-            } else {
-                dispatch_ref_as_python(&effect).is_some_and(|obj| {
-                    matches!(
-                        parse_state_python_effect(obj),
-                        Ok(Some(ParsedStateEffect::Modify { .. }))
-                    )
-                })
-            }
-            #[cfg(not(test))]
-            {
-                dispatch_ref_as_python(&effect).is_some_and(|obj| {
-                    matches!(
-                        parse_state_python_effect(obj),
-                        Ok(Some(ParsedStateEffect::Modify { .. }))
-                    )
-                })
-            }
-        };
-
-        let metadata = metadata_from_debug_info(self.handler_debug_info());
-        if is_modify {
-            rust_program_expand_expr(Arc::new(self.clone()), effect, k, metadata)
-        } else {
-            rust_program_apply_expr(Arc::new(self.clone()), effect, k, metadata)
-        }
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
     }
 }
 
@@ -1222,52 +895,6 @@ impl IRStreamFactory for LazyAskHandlerFactory {
     fn on_run_end(&self, run_token: u64) {
         let mut states = self.run_states.lock().expect("LazyAsk lock poisoned");
         states.remove(&run_token);
-    }
-}
-
-impl HandlerInvoke for LazyAskHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        let is_direct_ask = {
-            #[cfg(test)]
-            if matches!(&effect, Effect::Ask { .. }) {
-                true
-            } else {
-                dispatch_ref_as_python(&effect)
-                    .is_some_and(|obj| matches!(parse_reader_python_effect(obj), Ok(Some(_))))
-            }
-            #[cfg(not(test))]
-            {
-                dispatch_ref_as_python(&effect)
-                    .is_some_and(|obj| matches!(parse_reader_python_effect(obj), Ok(Some(_))))
-            }
-        };
-
-        let metadata = metadata_from_debug_info(self.handler_debug_info());
-        if is_direct_ask {
-            rust_program_apply_expr(Arc::new(self.clone()), effect, k, metadata)
-        } else {
-            rust_program_expand_expr(Arc::new(self.clone()), effect, k, metadata)
-        }
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
-    }
-
-    fn on_run_end(&self, run_token: u64) {
-        <Self as IRStreamFactory>::on_run_end(self, run_token);
     }
 }
 
@@ -1807,48 +1434,6 @@ impl IRStreamFactory for ReaderHandlerFactory {
     }
 }
 
-impl HandlerInvoke for ReaderHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        let is_ask = {
-            #[cfg(test)]
-            if matches!(&effect, Effect::Ask { .. }) {
-                true
-            } else {
-                dispatch_ref_as_python(&effect)
-                    .is_some_and(|obj| matches!(parse_reader_python_effect(obj), Ok(Some(_))))
-            }
-            #[cfg(not(test))]
-            {
-                dispatch_ref_as_python(&effect)
-                    .is_some_and(|obj| matches!(parse_reader_python_effect(obj), Ok(Some(_))))
-            }
-        };
-
-        let metadata = metadata_from_debug_info(self.handler_debug_info());
-        if is_ask {
-            rust_program_apply_expr(Arc::new(self.clone()), effect, k, metadata)
-        } else {
-            rust_program_expand_expr(Arc::new(self.clone()), effect, k, metadata)
-        }
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
-    }
-}
-
 #[derive(Debug)]
 struct ReaderHandlerProgram;
 
@@ -2001,33 +1586,6 @@ impl IRStreamFactory for WriterHandlerFactory {
     }
 }
 
-impl HandlerInvoke for WriterHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        rust_program_apply_expr(
-            Arc::new(self.clone()),
-            effect,
-            k,
-            metadata_from_debug_info(self.handler_debug_info()),
-        )
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
-    }
-}
-
 #[derive(Debug)]
 struct WriterHandlerProgram;
 
@@ -2156,33 +1714,6 @@ impl IRStreamFactory for ResultSafeHandlerFactory {
 
     fn handler_name(&self) -> &'static str {
         "ResultSafeHandler"
-    }
-}
-
-impl HandlerInvoke for ResultSafeHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        rust_program_expand_expr(
-            Arc::new(self.clone()),
-            effect,
-            k,
-            metadata_from_debug_info(self.handler_debug_info()),
-        )
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
     }
 }
 
@@ -2376,34 +1907,6 @@ impl IRStreamFactory for DoubleCallHandlerFactory {
 
     fn handler_name(&self) -> &'static str {
         "DoubleCallHandler"
-    }
-}
-
-#[cfg(test)]
-impl HandlerInvoke for DoubleCallHandlerFactory {
-    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
-        <Self as IRStreamFactory>::can_handle(self, effect)
-    }
-
-    fn invoke(&self, effect: DispatchEffect, k: Continuation) -> DoExpr {
-        rust_program_expand_expr(
-            Arc::new(self.clone()),
-            effect,
-            k,
-            metadata_from_debug_info(self.handler_debug_info()),
-        )
-    }
-
-    fn handler_name(&self) -> &str {
-        <Self as IRStreamFactory>::handler_name(self)
-    }
-
-    fn handler_debug_info(&self) -> HandlerDebugInfo {
-        HandlerDebugInfo {
-            name: <Self as IRStreamFactory>::handler_name(self).to_string(),
-            file: None,
-            line: None,
-        }
     }
 }
 
@@ -2693,14 +2196,14 @@ mod tests {
     #[test]
     fn test_state_factory_can_handle() {
         let f = StateHandlerFactory;
-        assert!(HandlerInvoke::can_handle(
+        assert!(IRStreamFactory::can_handle(
             &f,
             &Effect::Get {
                 key: "x".to_string()
             }
         )
         .unwrap());
-        assert!(HandlerInvoke::can_handle(
+        assert!(IRStreamFactory::can_handle(
             &f,
             &Effect::Put {
                 key: "x".to_string(),
@@ -2708,14 +2211,14 @@ mod tests {
             }
         )
         .unwrap());
-        assert!(!HandlerInvoke::can_handle(
+        assert!(!IRStreamFactory::can_handle(
             &f,
             &Effect::Ask {
                 key: "x".to_string()
             }
         )
         .unwrap());
-        assert!(!HandlerInvoke::can_handle(
+        assert!(!IRStreamFactory::can_handle(
             &f,
             &Effect::Tell {
                 message: Value::Unit
@@ -2862,21 +2365,21 @@ mod tests {
     #[test]
     fn test_reader_factory_can_handle() {
         let f = ReaderHandlerFactory;
-        assert!(HandlerInvoke::can_handle(
+        assert!(IRStreamFactory::can_handle(
             &f,
             &Effect::Ask {
                 key: "x".to_string()
             }
         )
         .unwrap());
-        assert!(!HandlerInvoke::can_handle(
+        assert!(!IRStreamFactory::can_handle(
             &f,
             &Effect::Get {
                 key: "x".to_string()
             }
         )
         .unwrap());
-        assert!(!HandlerInvoke::can_handle(
+        assert!(!IRStreamFactory::can_handle(
             &f,
             &Effect::Tell {
                 message: Value::Unit
@@ -2917,21 +2420,21 @@ mod tests {
     #[test]
     fn test_writer_factory_can_handle() {
         let f = WriterHandlerFactory;
-        assert!(HandlerInvoke::can_handle(
+        assert!(IRStreamFactory::can_handle(
             &f,
             &Effect::Tell {
                 message: Value::Unit
             }
         )
         .unwrap());
-        assert!(!HandlerInvoke::can_handle(
+        assert!(!IRStreamFactory::can_handle(
             &f,
             &Effect::Get {
                 key: "x".to_string()
             }
         )
         .unwrap());
-        assert!(!HandlerInvoke::can_handle(
+        assert!(!IRStreamFactory::can_handle(
             &f,
             &Effect::Ask {
                 key: "x".to_string()
@@ -2990,7 +2493,7 @@ mod tests {
             let effect = Effect::from_shared(PyShared::new(obj));
             let f = ResultSafeHandlerFactory;
             assert!(
-                HandlerInvoke::can_handle(&f, &effect).unwrap(),
+                IRStreamFactory::can_handle(&f, &effect).unwrap(),
                 "ResultSafe handler should claim ResultSafeEffect"
             );
         });

--- a/packages/doeff-vm/src/ir_stream.rs
+++ b/packages/doeff-vm/src/ir_stream.rs
@@ -26,6 +26,9 @@ pub trait IRStream: fmt::Debug + Send {
         store: &mut RustStore,
         scope: &mut ScopeStore,
     ) -> IRStreamStep;
+    fn eager_start(&self) -> bool {
+        false
+    }
     fn debug_location(&self) -> Option<StreamLocation> {
         None
     }

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -58,8 +58,9 @@ pub use effect::{Effect, PyAsk, PyCancelEffect, PyGet, PyLocal, PyModify, PyPut,
 pub use error::VMError;
 pub use frame::Frame;
 pub use handler::{
-    Handler, HandlerDebugInfo, HandlerInvoke, HandlerRef, LazyAskHandlerFactory,
-    ReaderHandlerFactory, StateHandlerFactory, WriterHandlerFactory,
+    AwaitHandlerFactory, IRStreamFactory, IRStreamFactoryRef, IRStreamProgram, IRStreamProgramRef,
+    LazyAskHandlerFactory, ReaderHandlerFactory, ResultSafeHandlerFactory, StateHandlerFactory,
+    WriterHandlerFactory,
 };
 pub use ids::{ContId, DispatchId, Marker, RunnableId, SegmentId};
 pub use kleisli::{Kleisli, KleisliDebugInfo, KleisliRef};

--- a/packages/doeff-vm/src/segment.rs
+++ b/packages/doeff-vm/src/segment.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::frame::Frame;
-use crate::handler::HandlerRef;
 use crate::ids::{DispatchId, Marker, SegmentId};
 use crate::kleisli::KleisliRef;
 use crate::py_key::HashedPyKey;
@@ -17,10 +16,8 @@ pub enum SegmentKind {
     Normal,
     PromptBoundary {
         handled_marker: Marker,
-        handler: HandlerRef,
-        handler_kleisli: Option<KleisliRef>,
+        handler: KleisliRef,
         return_clause: Option<PyShared>,
-        py_identity: Option<PyShared>,
     },
     MaskBoundary {
         masked_effects: Vec<PyShared>,
@@ -73,10 +70,10 @@ impl Segment {
         marker: Marker,
         caller: Option<SegmentId>,
         handled_marker: Marker,
-        handler: HandlerRef,
-        handler_kleisli: Option<KleisliRef>,
+        handler: KleisliRef,
+        _legacy_handler_kleisli: Option<KleisliRef>,
         return_clause: Option<PyShared>,
-        py_identity: Option<PyShared>,
+        _legacy_py_identity: Option<PyShared>,
     ) -> Self {
         Segment {
             marker,
@@ -86,9 +83,7 @@ impl Segment {
             kind: SegmentKind::PromptBoundary {
                 handled_marker,
                 handler,
-                handler_kleisli,
                 return_clause,
-                py_identity,
             },
             dispatch_id: None,
             mode: Mode::Deliver(crate::value::Value::Unit),
@@ -151,7 +146,9 @@ mod tests {
             marker,
             None,
             handled,
-            std::sync::Arc::new(crate::handler::StateHandlerFactory),
+            std::sync::Arc::new(crate::kleisli::RustKleisli::from_factory(std::sync::Arc::new(
+                crate::handler::StateHandlerFactory,
+            ))),
             None,
             None,
             None,

--- a/packages/doeff-vm/src/trace_state.rs
+++ b/packages/doeff-vm/src/trace_state.rs
@@ -15,9 +15,8 @@ use crate::continuation::Continuation;
 use crate::dispatch::DispatchContext;
 use crate::effect::{make_execution_context_object, PyExecutionContext};
 use crate::frame::{CallMetadata, Frame};
-use crate::handler::Handler;
 use crate::ids::{DispatchId, Marker, SegmentId};
-use crate::py_shared::PyShared;
+use crate::kleisli::KleisliRef;
 use crate::step::PyException;
 use crate::value::Value;
 
@@ -204,9 +203,9 @@ impl TraceState {
         }
     }
 
-    fn handler_trace_info(handler: &Handler) -> (String, HandlerKind, Option<String>, Option<u32>) {
-        let info = handler.handler_debug_info();
-        let kind = if handler.py_identity().is_some() {
+    fn handler_trace_info(handler: &KleisliRef) -> (String, HandlerKind, Option<String>, Option<u32>) {
+        let info = handler.debug_info();
+        let kind = if handler.expects_python_effect() {
             HandlerKind::Python
         } else {
             HandlerKind::RustBuiltin
@@ -215,12 +214,10 @@ impl TraceState {
     }
 
     fn marker_handler_trace_info(
-        handlers: &HashMap<Marker, (Handler, Option<PyShared>)>,
+        handlers: &HashMap<Marker, KleisliRef>,
         marker: Marker,
     ) -> Option<(String, HandlerKind, Option<String>, Option<u32>)> {
-        handlers
-            .get(&marker)
-            .map(|(handler, _py_identity)| Self::handler_trace_info(handler))
+        handlers.get(&marker).map(Self::handler_trace_info)
     }
 
     pub(crate) fn assemble_trace(
@@ -228,7 +225,7 @@ impl TraceState {
         segments: &SegmentArena,
         current_segment: Option<SegmentId>,
         dispatch_stack: &[DispatchContext],
-        handlers: &HashMap<Marker, (Handler, Option<PyShared>)>,
+        handlers: &HashMap<Marker, KleisliRef>,
         effect_repr: impl Fn(&crate::effect::DispatchEffect) -> String,
     ) -> Vec<TraceEntry> {
         let mut trace: Vec<TraceEntry> = Vec::new();
@@ -413,7 +410,7 @@ impl TraceState {
         segments: &SegmentArena,
         current_segment: Option<SegmentId>,
         dispatch_stack: &[DispatchContext],
-        handlers: &HashMap<Marker, (Handler, Option<PyShared>)>,
+        handlers: &HashMap<Marker, KleisliRef>,
         effect_repr: impl Fn(&crate::effect::DispatchEffect) -> String,
     ) {
         let mut seg_id = current_segment;

--- a/packages/doeff-vm/src/value.rs
+++ b/packages/doeff-vm/src/value.rs
@@ -11,8 +11,9 @@ use crate::capture::{
     ActiveChainEntry, DispatchAction, EffectResult, HandlerDispatchEntry, HandlerKind,
     HandlerStatus, TraceEntry, TraceHop,
 };
+use crate::effect::DispatchEffect;
 use crate::frame::CallMetadata;
-use crate::handler::{Handler, RustProgramInvocation};
+use crate::kleisli::KleisliRef;
 use crate::pyvm::{PyTraceFrame, PyTraceHop};
 use crate::scheduler::{ExternalPromise, PromiseHandle, TaskHandle};
 
@@ -29,9 +30,8 @@ pub enum Value {
     Bool(bool),
     None,
     Continuation(crate::continuation::Continuation),
-    Handlers(Vec<Handler>),
-    RustProgramInvocation(RustProgramInvocation),
-    PythonHandlerCallable(Py<PyAny>),
+    DispatchEffect(Box<DispatchEffect>),
+    Handlers(Vec<KleisliRef>),
     Kleisli(crate::kleisli::KleisliRef),
     Task(TaskHandle),
     Promise(PromiseHandle),
@@ -326,19 +326,22 @@ impl Value {
             Value::Bool(b) => Ok(PyBool::new(py, *b).to_owned().into_any()),
             Value::None => Ok(py.None().into_bound(py)),
             Value::Continuation(k) => k.to_pyobject(py),
+            Value::DispatchEffect(_) => Ok(py.None().into_bound(py)),
             Value::Handlers(handlers) => {
                 let list = PyList::empty(py);
                 for h in handlers {
-                    if let Some(identity) = h.py_identity() {
-                        list.append(identity.bind(py))?;
+                    if h.expects_python_effect() {
+                        if let Some(identity) = h.py_identity() {
+                            list.append(identity.bind(py))?;
+                        } else {
+                            list.append(py.None().into_bound(py))?;
+                        }
                     } else {
                         list.append(py.None().into_bound(py))?;
                     }
                 }
                 Ok(list.into_any())
             }
-            Value::RustProgramInvocation(_) => Ok(py.None().into_bound(py)),
-            Value::PythonHandlerCallable(callable) => Ok(callable.bind(py).clone()),
             Value::Kleisli(_) => Ok(py.None().into_bound(py)),
             Value::Task(handle) => {
                 let dict = pyo3::types::PyDict::new(py);
@@ -482,7 +485,7 @@ impl Value {
     }
 
     /// Try to get as handlers slice.
-    pub fn as_handlers(&self) -> Option<&[Handler]> {
+    pub fn as_handlers(&self) -> Option<&[KleisliRef]> {
         match self {
             Value::Handlers(h) => Some(h),
             _ => None,
@@ -506,13 +509,8 @@ impl Value {
             Value::Bool(b) => Value::Bool(*b),
             Value::None => Value::None,
             Value::Continuation(k) => Value::Continuation(k.clone()),
+            Value::DispatchEffect(effect) => Value::DispatchEffect(Box::new((**effect).clone())),
             Value::Handlers(handlers) => Value::Handlers(handlers.clone()),
-            Value::RustProgramInvocation(invocation) => {
-                Value::RustProgramInvocation(invocation.clone())
-            }
-            Value::PythonHandlerCallable(callable) => {
-                Value::PythonHandlerCallable(callable.clone_ref(py))
-            }
             Value::Kleisli(kleisli) => Value::Kleisli(kleisli.clone()),
             Value::Task(h) => Value::Task(*h),
             Value::Promise(h) => Value::Promise(*h),
@@ -595,7 +593,9 @@ mod tests {
 
     #[test]
     fn test_value_handlers() {
-        let handlers = vec![std::sync::Arc::new(crate::handler::StateHandlerFactory) as Handler];
+        let handlers = vec![std::sync::Arc::new(crate::kleisli::RustKleisli::from_factory(
+            std::sync::Arc::new(crate::handler::StateHandlerFactory),
+        )) as KleisliRef];
         let val = Value::Handlers(handlers);
         assert!(val.as_handlers().is_some());
         assert_eq!(val.as_handlers().unwrap().len(), 1);

--- a/packages/doeff-vm/src/vm.rs
+++ b/packages/doeff-vm/src/vm.rs
@@ -29,17 +29,16 @@ use crate::error::VMError;
 use crate::frame::{
     CallMetadata, EvalReturnContinuation, FinallyOutcome, Frame, InterceptorContinuation,
 };
-use crate::handler::{Handler, KleisliHandler, RustProgramInvocation};
 use crate::ids::{ContId, DispatchId, Marker, SegmentId};
 use crate::interceptor_state::InterceptorState;
 use crate::ir_stream::{IRStream, IRStreamRef, IRStreamStep, PythonGeneratorStream};
-use crate::kleisli::{HandlerSentinelKleisli, KleisliRef};
+use crate::kleisli::{IdentityKleisli, KleisliRef};
 use crate::py_shared::PyShared;
 use crate::python_call::{PendingPython, PyCallOutcome, PythonCall};
 use crate::pyvm::{
-    classify_yielded_for_vm, doctrl_to_pyexpr_for_vm, PyDoExprBase, PyEffectBase, PyK,
+    classify_yielded_for_vm, doctrl_to_pyexpr_for_vm, PyDoExprBase, PyEffectBase,
 };
-use crate::segment::{ScopeStore, Segment, SegmentKind};
+use crate::segment::{Segment, SegmentKind};
 use crate::trace_state::TraceState;
 use crate::value::Value;
 
@@ -47,43 +46,6 @@ pub use crate::dispatch::DispatchContext;
 pub use crate::rust_store::RustStore;
 
 static NEXT_RUN_TOKEN: AtomicU64 = AtomicU64::new(1);
-
-#[derive(Debug)]
-struct RustProgramStream {
-    program: crate::handler::IRStreamProgramRef,
-}
-
-impl IRStream for RustProgramStream {
-    fn resume(
-        &mut self,
-        value: Value,
-        store: &mut RustStore,
-        scope: &mut ScopeStore,
-    ) -> IRStreamStep {
-        Python::attach(|_py| {
-            let mut guard = self.program.lock().expect("Rust program lock poisoned");
-            guard.resume(value, store, scope)
-        })
-    }
-
-    fn throw(
-        &mut self,
-        exc: PyException,
-        store: &mut RustStore,
-        scope: &mut ScopeStore,
-    ) -> IRStreamStep {
-        Python::attach(|_py| {
-            let mut guard = self.program.lock().expect("Rust program lock poisoned");
-            guard.throw(exc, store, scope)
-        })
-    }
-}
-
-fn rust_program_as_stream(program: crate::handler::IRStreamProgramRef) -> IRStreamRef {
-    Arc::new(std::sync::Mutex::new(
-        Box::new(RustProgramStream { program }) as Box<dyn IRStream>,
-    ))
-}
 
 const MISSING_UNKNOWN: &str = "[MISSING] <unknown>";
 
@@ -224,17 +186,14 @@ pub struct InterceptorEntry {
 #[derive(Clone)]
 struct InstalledHandler {
     marker: Marker,
-    handler: Handler,
-    py_identity: Option<PyShared>,
+    handler: KleisliRef,
 }
 
 #[derive(Clone)]
 struct HandlerChainEntry {
     marker: Marker,
     prompt_seg_id: SegmentId,
-    handler: Handler,
-    kleisli: Option<KleisliRef>,
-    py_identity: Option<PyShared>,
+    handler: KleisliRef,
 }
 
 impl Default for DebugConfig {
@@ -275,7 +234,7 @@ pub struct VM {
     pub(crate) dispatch_state: DispatchState,
     pub consumed_cont_ids: HashSet<ContId>,
     installed_handlers: Vec<InstalledHandler>,
-    run_handlers: Vec<Handler>,
+    run_handlers: Vec<KleisliRef>,
     pub(crate) interceptor_state: InterceptorState,
     pub rust_store: RustStore,
     pub py_store: Option<PyStore>,
@@ -413,7 +372,8 @@ impl VM {
             .expect("current segment not found in arena")
     }
 
-    fn track_run_handler(&mut self, handler: &Handler) {
+    fn track_run_handler(&mut self, handler: &KleisliRef) {
+        handler.bind_run_token(self.current_run_token());
         if !self
             .run_handlers
             .iter()
@@ -426,24 +386,15 @@ impl VM {
     fn find_prompt_boundary_by_marker(
         &self,
         marker: Marker,
-    ) -> Option<(SegmentId, Handler, Option<KleisliRef>, Option<PyShared>)> {
+    ) -> Option<(SegmentId, KleisliRef)> {
         self.segments
             .iter()
             .find_map(|(seg_id, seg)| match &seg.kind {
                 SegmentKind::PromptBoundary {
                     handled_marker,
                     handler,
-                    handler_kleisli,
-                    py_identity,
                     ..
-                } if *handled_marker == marker => {
-                    Some((
-                        seg_id,
-                        handler.clone(),
-                        handler_kleisli.clone(),
-                        py_identity.clone(),
-                    ))
-                }
+                } if *handled_marker == marker => Some((seg_id, handler.clone())),
                 _ => None,
             })
     }
@@ -458,8 +409,6 @@ impl VM {
             if let SegmentKind::PromptBoundary {
                 handled_marker,
                 handler,
-                handler_kleisli,
-                py_identity,
                 ..
             } = &seg.kind
             {
@@ -467,8 +416,6 @@ impl VM {
                     marker: *handled_marker,
                     prompt_seg_id: seg_id,
                     handler: handler.clone(),
-                    kleisli: handler_kleisli.clone(),
-                    py_identity: py_identity.clone(),
                 });
             }
             cursor = seg.caller;
@@ -515,17 +462,16 @@ impl VM {
         self.handlers_in_caller_chain(seg_id)
     }
 
-    fn prompt_boundary_handler_lookup(&self) -> HashMap<Marker, (Handler, Option<PyShared>)> {
+    fn prompt_boundary_handler_lookup(&self) -> HashMap<Marker, KleisliRef> {
         let mut handlers = HashMap::new();
         for (_seg_id, seg) in self.segments.iter() {
             if let SegmentKind::PromptBoundary {
                 handled_marker,
                 handler,
-                py_identity,
                 ..
             } = &seg.kind
             {
-                handlers.insert(*handled_marker, (handler.clone(), py_identity.clone()));
+                handlers.insert(*handled_marker, handler.clone());
             }
         }
         handlers
@@ -542,7 +488,7 @@ impl VM {
                 entry.handler.clone(),
                 None,
                 None,
-                entry.py_identity.clone(),
+                None,
             );
             self.copy_interceptor_guard_state(outside_seg_id, &mut prompt_seg);
             self.copy_scope_store_from(outside_seg_id, &mut prompt_seg);
@@ -628,31 +574,6 @@ impl VM {
         seg.push_frame(Frame::EvalReturn(Box::new(continuation)));
         seg.mode = Mode::HandleYield(expr);
         StepEvent::Continue
-    }
-
-    fn invoke_rust_program(&mut self, invocation: RustProgramInvocation) -> StepEvent {
-        let Some(current_seg_id) = self.current_segment else {
-            return StepEvent::Error(VMError::internal(
-                "no current segment for rust program invocation",
-            ));
-        };
-        let program = invocation
-            .factory
-            .create_program_for_run(self.current_run_token());
-        let stream = rust_program_as_stream(program.clone());
-        let effect = *invocation.effect;
-        let continuation = invocation.continuation;
-        let step = {
-            let mut guard = program.lock().expect("Rust program lock poisoned");
-            let Some(seg) = self.segments.get_mut(current_seg_id) else {
-                return StepEvent::Error(VMError::invalid_segment(
-                    "segment missing for rust program invocation",
-                ));
-            };
-            let scope = &mut seg.scope_store;
-            Python::attach(|py| guard.start(py, effect, continuation, &mut self.rust_store, scope))
-        };
-        self.apply_stream_step(step, stream, None)
     }
 
     fn evaluate(&mut self, ir_node: DoCtrl) -> StepEvent {
@@ -769,9 +690,9 @@ impl VM {
         })
     }
 
-    fn handler_trace_info(handler: &Handler) -> (String, HandlerKind, Option<String>, Option<u32>) {
-        let info = handler.handler_debug_info();
-        let kind = if handler.py_identity().is_some() {
+    fn handler_trace_info(handler: &KleisliRef) -> (String, HandlerKind, Option<String>, Option<u32>) {
+        let info = handler.debug_info();
+        let kind = if handler.expects_python_effect() {
             HandlerKind::Python
         } else {
             HandlerKind::RustBuiltin
@@ -784,9 +705,9 @@ impl VM {
         effect: DispatchEffect,
         continuation: Continuation,
     ) -> DoCtrl {
-        let py_effect =
+        let effect_value = if kleisli.expects_python_effect() {
             match Python::attach(|py| dispatch_to_pyobject(py, &effect).map(|obj| obj.unbind())) {
-                Ok(obj) => obj,
+                Ok(obj) => Value::Python(obj),
                 Err(err) => {
                     return DoCtrl::TransferThrow {
                         continuation,
@@ -795,21 +716,9 @@ impl VM {
                         )),
                     };
                 }
-            };
-
-        let py_k = match Python::attach(|py| {
-            Bound::new(py, PyK::from_cont_id(continuation.cont_id))
-                .map(|bound| bound.into_any().unbind())
-        }) {
-            Ok(obj) => obj,
-            Err(err) => {
-                return DoCtrl::TransferThrow {
-                    continuation,
-                    exception: PyException::type_error(format!(
-                        "Kleisli handler failed to create continuation handle: {err}"
-                    )),
-                };
             }
+        } else {
+            Value::DispatchEffect(Box::new(effect))
         };
 
         let debug = kleisli.debug_info();
@@ -827,10 +736,10 @@ impl VM {
             }),
             args: vec![
                 DoCtrl::Pure {
-                    value: Value::Python(py_effect),
+                    value: effect_value,
                 },
                 DoCtrl::Pure {
-                    value: Value::Python(py_k),
+                    value: Value::Continuation(continuation),
                 },
             ],
             kwargs: vec![],
@@ -852,9 +761,7 @@ impl VM {
             }
         }
         self.find_prompt_boundary_by_marker(marker)
-            .map(|(_seg_id, handler, _handler_kleisli, _py_identity)| {
-                Self::handler_trace_info(&handler)
-            })
+            .map(|(_seg_id, handler)| Self::handler_trace_info(&handler))
     }
 
     fn current_handler_identity_for_dispatch(
@@ -2195,7 +2102,7 @@ impl VM {
     fn handle_yield_create_continuation(
         &mut self,
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
     ) -> StepEvent {
         self.handle_create_continuation(expr, handlers, handler_identities)
@@ -2278,10 +2185,6 @@ impl VM {
 
         let func = match f_value {
             Value::Python(func) => PyShared::new(func),
-            Value::PythonHandlerCallable(func) => PyShared::new(func),
-            Value::RustProgramInvocation(invocation) => {
-                return self.invoke_rust_program(invocation);
-            }
             Value::Kleisli(kleisli) => {
                 let args_values = Self::collect_value_args(args);
                 let kwargs_values = Self::collect_value_kwargs(kwargs);
@@ -2376,12 +2279,8 @@ impl VM {
             }
         };
 
-        let (func, handler_return) = match factory_value {
-            Value::Python(factory) => (PyShared::new(factory), false),
-            Value::PythonHandlerCallable(factory) => (PyShared::new(factory), true),
-            Value::RustProgramInvocation(invocation) => {
-                return self.invoke_rust_program(invocation);
-            }
+        let func = match factory_value {
+            Value::Python(factory) => PyShared::new(factory),
             Value::Kleisli(kleisli) => {
                 let args_values = Self::collect_value_args(args);
                 let kwargs_values = Self::collect_value_kwargs(kwargs);
@@ -2418,6 +2317,7 @@ impl VM {
             }
         };
 
+        let handler_return = false;
         self.current_seg_mut().pending_python = Some(PendingPython::ExpandReturn {
             metadata: Some(metadata),
             handler_return,
@@ -2437,6 +2337,30 @@ impl VM {
         if let Some(ref m) = metadata {
             self.maybe_emit_frame_entered(m);
         }
+
+        let eager_start = stream
+            .lock()
+            .expect("IRStream lock poisoned")
+            .eager_start();
+        if eager_start {
+            let step = {
+                let Some(seg_id) = self.current_segment else {
+                    return StepEvent::Error(VMError::internal(
+                        "handle_yield_ir_stream called without current segment",
+                    ));
+                };
+                let Some(seg) = self.segments.get_mut(seg_id) else {
+                    return StepEvent::Error(VMError::invalid_segment(
+                        "handle_yield_ir_stream eager-start segment missing",
+                    ));
+                };
+                let scope = &mut seg.scope_store;
+                let mut guard = stream.lock().expect("IRStream lock poisoned");
+                guard.resume(Value::Unit, &mut self.rust_store, scope)
+            };
+            return self.apply_stream_step(step, stream, metadata);
+        }
+
         let Some(seg) = self.current_segment_mut() else {
             return StepEvent::Error(VMError::internal(
                 "handle_yield_ir_stream called without current segment",
@@ -2450,7 +2374,7 @@ impl VM {
     fn handle_yield_eval(
         &mut self,
         expr: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         metadata: Option<CallMetadata>,
     ) -> StepEvent {
         let cont = Continuation::create_unstarted_with_metadata(expr, handlers, metadata);
@@ -3064,11 +2988,9 @@ impl VM {
         &self,
         handler_chain: &[Marker],
         effect: &DispatchEffect,
-    ) -> Result<(usize, Marker, Handler), VMError> {
+    ) -> Result<(usize, Marker, KleisliRef), VMError> {
         for (idx, marker) in handler_chain.iter().copied().enumerate() {
-            let Some((_prompt_seg_id, handler, _handler_kleisli, _py_identity)) =
-                self.find_prompt_boundary_by_marker(marker)
-            else {
+            let Some((_prompt_seg_id, handler)) = self.find_prompt_boundary_by_marker(marker) else {
                 return Err(VMError::internal(format!(
                     "find_matching_handler: missing handler marker {} at index {}",
                     marker.raw(),
@@ -3118,9 +3040,7 @@ impl VM {
             let active_marker = *ctx.handler_chain.get(ctx.handler_idx)?;
             let active_is_python = self
                 .find_prompt_boundary_by_marker(active_marker)
-                .is_some_and(|(_prompt_seg_id, handler, _handler_kleisli, _py_identity)| {
-                    handler.py_identity().is_some()
-                });
+                .is_some_and(|(_prompt_seg_id, handler)| handler.expects_python_effect());
             if active_is_python && !Self::same_effect_python_type(&effect, &ctx.effect) {
                 return None;
             }
@@ -3226,14 +3146,10 @@ impl VM {
                 .map(|(_, _, _, source_line)| *source_line),
         );
 
-        if selected.py_identity.is_some() || handler.py_identity().is_some() {
+        if handler.py_identity().is_some() {
             self.register_continuation(k_user.clone());
         }
-        let ir_node = selected
-            .kleisli
-            .clone()
-            .map(|kleisli| Self::invoke_kleisli_handler_expr(kleisli, effect.clone(), k_user.clone()))
-            .unwrap_or_else(|| handler.invoke(effect, k_user));
+        let ir_node = Self::invoke_kleisli_handler_expr(handler, effect, k_user);
         Ok(self.evaluate(ir_node))
     }
 
@@ -3302,16 +3218,12 @@ impl VM {
     pub fn install_handler(
         &mut self,
         marker: Marker,
-        handler: Handler,
-        py_identity: Option<PyShared>,
+        handler: KleisliRef,
+        _py_identity: Option<PyShared>,
     ) {
         self.installed_handlers
             .retain(|entry| entry.marker != marker);
-        self.installed_handlers.push(InstalledHandler {
-            marker,
-            handler,
-            py_identity,
-        });
+        self.installed_handlers.push(InstalledHandler { marker, handler });
     }
 
     pub fn remove_handler(&mut self, marker: Marker) -> bool {
@@ -3332,19 +3244,12 @@ impl VM {
         &mut self,
         marker: Marker,
         prompt_seg_id: SegmentId,
-        handler: Handler,
-        py_identity: Option<PyShared>,
+        handler: KleisliRef,
+        _py_identity: Option<PyShared>,
     ) -> bool {
         let Some(seg) = self.segments.get_mut(prompt_seg_id) else {
-            let prompt_seg = Segment::new_prompt(
-                marker,
-                None,
-                marker,
-                handler.clone(),
-                None,
-                None,
-                py_identity.clone(),
-            );
+            let prompt_seg =
+                Segment::new_prompt(marker, None, marker, handler.clone(), None, None, None);
             self.alloc_segment(prompt_seg);
             self.track_run_handler(&handler);
             return true;
@@ -3352,9 +3257,7 @@ impl VM {
         seg.kind = SegmentKind::PromptBoundary {
             handled_marker: marker,
             handler: handler.clone(),
-            handler_kleisli: None,
             return_clause: None,
-            py_identity,
         };
         self.track_run_handler(&handler);
         true
@@ -3698,31 +3601,20 @@ impl VM {
             Ok(plan) => plan,
             Err(err) => return StepEvent::Error(err),
         };
-        let (prompt_handler, prompt_kleisli): (Handler, Option<KleisliRef>) = plan
-            .handler
-            .as_any()
-            .downcast_ref::<HandlerSentinelKleisli>()
-            .map(|sentinel| (sentinel.handler(), None))
-            .unwrap_or_else(|| {
-                (
-                    Arc::new(KleisliHandler::new(plan.handler.clone())) as Handler,
-                    Some(plan.handler.clone()),
-                )
-            });
 
         let mut prompt_seg = Segment::new_prompt(
             plan.handler_marker,
             Some(plan.outside_seg_id),
             plan.handler_marker,
-            prompt_handler.clone(),
-            prompt_kleisli,
+            plan.handler.clone(),
+            None,
             return_clause,
-            plan.py_identity.clone(),
+            None,
         );
         self.copy_interceptor_guard_state(Some(plan.outside_seg_id), &mut prompt_seg);
         self.copy_scope_store_from(Some(plan.outside_seg_id), &mut prompt_seg);
         let prompt_seg_id = self.alloc_segment(prompt_seg);
-        self.track_run_handler(&prompt_handler);
+        self.track_run_handler(&plan.handler);
 
         let mut body_seg = Segment::new(plan.handler_marker, Some(prompt_seg_id));
         self.copy_interceptor_guard_state(Some(plan.outside_seg_id), &mut body_seg);
@@ -3948,8 +3840,6 @@ impl VM {
                 )));
             };
             let handler = entry.handler.clone();
-            let handler_kleisli = entry.kleisli.clone();
-            let py_identity = entry.py_identity.clone();
             let can_handle = match handler.can_handle(&effect) {
                 Ok(value) => value,
                 Err(err) => return StepEvent::Error(err),
@@ -3986,18 +3876,11 @@ impl VM {
 
                 self.current_segment = Some(handler_seg_id);
 
-                if py_identity.is_some() || handler.py_identity().is_some() {
+                if handler.py_identity().is_some() {
                     self.register_continuation(k_user.clone());
                 }
-                let ir_node = handler_kleisli
-                    .map(|kleisli| {
-                        Self::invoke_kleisli_handler_expr(
-                            kleisli,
-                            effect.clone(),
-                            k_user.clone(),
-                        )
-                    })
-                    .unwrap_or_else(|| handler.invoke(effect.clone(), k_user));
+                let ir_node =
+                    Self::invoke_kleisli_handler_expr(handler, effect.clone(), k_user);
                 return self.evaluate(ir_node);
             }
         }
@@ -4133,7 +4016,7 @@ impl VM {
         StepEvent::Continue
     }
 
-    fn current_visible_handlers(&self) -> Vec<Handler> {
+    fn current_visible_handlers(&self) -> Vec<KleisliRef> {
         self.current_handler_chain()
             .into_iter()
             .map(|entry| entry.handler)
@@ -4231,7 +4114,7 @@ impl VM {
     fn handle_create_continuation(
         &mut self,
         program: PyShared,
-        handlers: Vec<Handler>,
+        handlers: Vec<KleisliRef>,
         handler_identities: Vec<Option<PyShared>>,
     ) -> StepEvent {
         let k =
@@ -4266,8 +4149,12 @@ impl VM {
 
         let k_handler_count = k.handlers.len();
         for idx in (0..k_handler_count).rev() {
-            let handler = &k.handlers[idx];
-            let py_identity = k.handler_identities.get(idx).cloned().unwrap_or(None);
+            let base_handler = k.handlers[idx].clone();
+            let handler = if let Some(Some(identity)) = k.handler_identities.get(idx) {
+                Arc::new(IdentityKleisli::new(base_handler, identity.clone())) as KleisliRef
+            } else {
+                base_handler
+            };
             let handler_marker = Marker::fresh();
             let mut prompt_seg = Segment::new_prompt(
                 handler_marker,
@@ -4276,12 +4163,12 @@ impl VM {
                 handler.clone(),
                 None,
                 None,
-                py_identity.clone(),
+                None,
             );
             self.copy_interceptor_guard_state(outside_seg_id, &mut prompt_seg);
             self.copy_scope_store_from(outside_seg_id, &mut prompt_seg);
             let prompt_seg_id = self.alloc_segment(prompt_seg);
-            self.track_run_handler(handler);
+            self.track_run_handler(&handler);
             let mut body_seg = Segment::new(handler_marker, Some(prompt_seg_id));
             self.copy_interceptor_guard_state(outside_seg_id, &mut body_seg);
             self.copy_scope_store_from(outside_seg_id, &mut body_seg);

--- a/packages/doeff-vm/src/vm_tests.rs
+++ b/packages/doeff-vm/src/vm_tests.rs
@@ -1897,9 +1897,12 @@ fn test_g10_resume_continuation_preserves_handler_identity() {
             .expect("missing prompt segment");
         match &prompt_seg.kind {
             SegmentKind::PromptBoundary {
-                py_identity: Some(identity),
+                handler,
                 ..
             } => {
+                let identity = handler
+                    .py_identity()
+                    .expect("G10 FAIL: handler missing preserved identity");
                 assert!(
                     identity.bind(py).is(&id_obj.bind(py)),
                     "G10 FAIL: preserved identity does not match original"


### PR DESCRIPTION
## Summary
Implements VM-KLEISLI-PHASE4 by removing legacy handler/callable dispatch types and making Kleisli the sole dispatch mechanism.

Key changes:
- Removed legacy value/handler abstractions and fallback dispatch path (`HandlerInvoke`, `HandlerRef`, `Handler`, `PythonHandlerCallable`, `RustProgramInvocation`, `KleisliHandler`, old `handler.invoke` path).
- Unified prompt boundaries and handler chains on `KleisliRef` only.
- Implemented working `RustKleisli.apply()` backed by IR streams.
- Added explicit handler capability hooks on `Kleisli` (`can_handle`, `expects_python_effect`, error-context support, run-token lifecycle hooks).
- Removed `HandlerSentinelKleisli` and `as_any` from `Kleisli`.
- Migrated scheduler and built-in Rust handlers to Kleisli/IRStreamFactory flow.
- Preserved backward compatibility for Python-side `KleisliProgram` (`isinstance(x, KleisliProgram)` remains true for `@do` results).

Reference: VM-KLEISLI-PHASE4

## Acceptance Criteria Evidence
- `Value::PythonHandlerCallable` removed:
  - `grep -R "PythonHandlerCallable\|RustProgramInvocation\|HandlerInvoke" packages/doeff-vm/src --include='*.rs' | grep -v "test" | grep -v "//" || echo "Clean!"`
  - Result: `Clean!`
- `Value::RustProgramInvocation` removed:
  - Same grep above (`Clean!`).
- `RustProgramInvocation` struct removed from `handler.rs`:
  - Same grep above (`Clean!`).
- `HandlerInvoke` trait removed from `handler.rs`:
  - Same grep above (`Clean!`).
- `Handler` / `HandlerRef` aliases removed:
  - No matches for `pub type HandlerRef` / `pub type Handler =` in `packages/doeff-vm/src/handler.rs`.
- `PythonHandler` and `KleisliHandler` removed:
  - No matches for `struct PythonHandler` / `struct KleisliHandler` in `packages/doeff-vm/src/handler.rs`.
- `HandlerSentinelKleisli` removed:
  - No matches for `HandlerSentinelKleisli` in `packages/doeff-vm/src` (non-test).
- `as_any()` removed from Kleisli trait:
  - `packages/doeff-vm/src/kleisli.rs` has `trait Kleisli` with no `fn as_any`.
- `PromptBoundary` stores single `handler: KleisliRef`:
  - `packages/doeff-vm/src/segment.rs` `SegmentKind::PromptBoundary` now contains `{ handled_marker, handler, return_clause }`.
- `RustKleisli.apply()` implemented and active:
  - `packages/doeff-vm/src/kleisli.rs` `impl Kleisli for RustKleisli { fn apply(...) ... }` now constructs/returns `DoCtrl::IRStream`.
- Dispatch goes through `kleisli.apply()` only:
  - No `handler.invoke(...)` path remains in `packages/doeff-vm/src/vm.rs`.
- `can_handle` preserved:
  - On `Kleisli` trait (`packages/doeff-vm/src/kleisli.rs`) and used in handler selection.
- Rust built-ins and scheduler work via Kleisli:
  - Full filtered test suite passes (includes state/reader/writer/await/scheduler coverage).
- `isinstance(x, KleisliProgram)` compatibility preserved:
  - `uv run python` check:
    - `type(sample).__name__ == "PyKleisli"`
    - `isinstance(sample, KleisliProgram) == True`
- `make sync` succeeds:
  - Command succeeded with `maturin develop` rebuild.
- `cargo test` succeeds:
  - `220 passed` for `packages/doeff-vm`.
- Full Python suite target succeeds:
  - `uv run pytest -m "not slow and not cli and not semgrep" -q` -> `733 passed, 53 deselected`.

## Validation
Executed:
- `cargo test --manifest-path packages/doeff-vm/Cargo.toml -q` (pass)
- `make sync` (pass)
- `uv run pytest -m "not slow and not cli and not semgrep" -q` (pass)
- `uv run pytest tests/core/test_sa009_async_handler_spec_gaps.py::TestHandlerImmutabilityContract::test_run_handler_stack_matches_passed_handlers tests/core/test_sa009_async_handler_spec_gaps.py::TestHandlerImmutabilityContract::test_async_run_handler_stack_matches_passed_handlers tests/core/test_unified_traceback_system.py::test_handler_sources_and_exception_repr_for_thrown_handler -q` (pass)
- `uv run pyright doeff/ 2>&1 | head -50` (existing repository type issues surfaced; no functional regressions in runtime/test validation)
- Legacy reference greps (clean for deleted symbols)
