### PR TITLE
Migrate docs handler/interceptor examples to @do

### DIFF
--- a/docs/positioning/domain-angles/ai-agents.md
+++ b/docs/positioning/domain-angles/ai-agents.md
@@ -87,8 +87,11 @@ The program never mentions a provider. The handler stack decides.
 Because every LLM call is an effect, you get cost tracking for free:
 
 ```python
+from doeff import Delegate, Effect, Get, do
+
 # Cost-capping handler — applies to ALL LLM effects
-def cost_cap_handler(effect, k):
+@do
+def cost_cap_handler(effect: Effect, k):
     if isinstance(effect, LLMChat):
         current = yield Get("total_cost")
         if current > MAX_BUDGET:

--- a/docs/positioning/domain-angles/gradio-prototyping.md
+++ b/docs/positioning/domain-angles/gradio-prototyping.md
@@ -38,8 +38,11 @@ def style_transfer(content_img, style_img):
 ```
 
 ```python
+from doeff import Delegate, Effect, do
+
 # Handler that streams effects to Gradio — orthogonal to the pipeline
-def gradio_streaming_handler(effect, k):
+@do
+def gradio_streaming_handler(effect: Effect, k):
     if isinstance(effect, Tell):
         if isinstance(effect.value, str):
             gradio_log_queue.put(effect.value)        # -> live log panel
@@ -68,7 +71,10 @@ def image_pipeline(image):
 ```
 
 ```python
-def interactive_step_handler(effect, k):
+from doeff import Delegate, Effect, do
+
+@do
+def interactive_step_handler(effect: Effect, k):
     """Pause at each effect. Show preview. Let user adjust parameters."""
     gradio_step_display.update(f"Next: {type(effect).__name__}")
     gradio_preview.update(getattr(effect, 'input_image', None))


### PR DESCRIPTION
## Summary
- Migrated docs handler examples from plain callables to strict `@do` handlers with `effect: Effect`.
- Ensured yielding interceptor examples use `@do` + `effect: Effect` (already present in `docs/22-with-intercept.md`, verified).
- Updated code-block imports to include `do` and `Effect` where added usage required it.

## Files Updated
- docs/20-why-effects-over-di.md
- docs/positioning/domain-angles/ml-infrastructure.md
- docs/positioning/domain-angles/trading-backtesting.md
- docs/positioning/domain-angles/gradio-prototyping.md
- docs/positioning/domain-angles/ai-agents.md

## Acceptance Criteria Evidence
- [x] All Group A handler examples have `@do` + `effect: Effect`
  - Verification command output:
    - `docs/20-why-effects-over-di.md`: 7
    - `docs/positioning/domain-angles/ml-infrastructure.md`: 9
    - `docs/positioning/domain-angles/trading-backtesting.md`: 5
    - `docs/positioning/domain-angles/gradio-prototyping.md`: 2
    - `docs/positioning/domain-angles/ai-agents.md`: 1
    - `docs/22-with-intercept.md` (`ping_handler`): 1
  - Total verified by file list in issue: 25 examples.
- [x] All Group B interceptor examples have `@do` + `effect: Effect`
  - Verified in `docs/22-with-intercept.md`: 3 (`audit_interceptor`, `counting_interceptor`, `inner_observer`).
- [x] Import lines in code blocks updated to include `do` and `Effect`
  - Added/verified imports in all touched code blocks where `@do` and `Effect` are used.
- [x] No broken markdown formatting
  - Verified fence counts are even in all touched files.
- [x] Group C left untouched
  - Plain transforms still present:
    - `docs/09-advanced-effects.md:332`
    - `docs/13-api-reference.md:523`
    - `docs/18-effect-combinations.md:122`

## Validation
- `uv run pytest -q`
  - Result: `795 passed, 21 warnings in 41.59s`

Refs: KLEISLI-DOCS-001
