### PR TITLE
Migrate test/package handlers to strict @do typing

### DIFF
--- a/packages/doeff-flow/src/doeff_flow/handlers/production.py
+++ b/packages/doeff-flow/src/doeff_flow/handlers/production.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from doeff import Delegate, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_flow.effects import TraceAnnotate, TraceCapture, TracePush, TraceSnapshot
 from doeff_flow.trace import (
     LiveTrace,
@@ -148,7 +148,8 @@ def production_handlers(
 
     active_recorder = recorder or ProductionTraceRecorder.create(workflow_id=workflow_id, trace_dir=trace_dir)
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, TracePush):
             active_recorder.push(effect)
             return (yield Resume(k, None))
@@ -161,7 +162,7 @@ def production_handlers(
         if isinstance(effect, TraceCapture):
             captured = active_recorder.capture(effect.format)
             return (yield Resume(k, captured))
-        yield Delegate()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-flow/src/doeff_flow/handlers/testing.py
+++ b/packages/doeff-flow/src/doeff_flow/handlers/testing.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from doeff import Delegate, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_flow.effects import TraceAnnotate, TraceCapture, TracePush, TraceSnapshot
 
 ProtocolHandler = Callable[[Any, Any], Any]
@@ -98,7 +98,8 @@ def mock_handlers(
 
     active_recorder = recorder or MockTraceRecorder()
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, TracePush):
             active_recorder.push(effect)
             return (yield Resume(k, None))
@@ -111,7 +112,7 @@ def mock_handlers(
         if isinstance(effect, TraceCapture):
             captured = active_recorder.capture(effect.format)
             return (yield Resume(k, captured))
-        yield Delegate()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-flow/tests/test_e2e.py
+++ b/packages/doeff-flow/tests/test_e2e.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 from doeff_flow import run_workflow
 from doeff_flow.cli import cli
 
-from doeff import Ask, Delegate, Get, Pure, Put, WithHandler, async_run, default_handlers, do
+from doeff import Ask, Effect, Get, Pass, Pure, Put, WithHandler, async_run, default_handlers, do
 from doeff import run as run_sync
 
 
@@ -126,10 +126,11 @@ class TestWithHandlerTracing:
     def test_sync_run_observes_effects_with_withhandler(self):
         captured_effects: list[object] = []
 
-        def capturing_handler(effect, k):
+        @do
+        def capturing_handler(effect: Effect, k):
             _ = k
             captured_effects.append(effect)
-            yield Delegate()
+            return (yield Pass())
 
         @do
         def workflow():
@@ -153,10 +154,11 @@ class TestWithHandlerTracing:
     async def test_async_run_observes_effects_with_withhandler(self):
         captured_effects: list[object] = []
 
-        def capturing_handler(effect, k):
+        @do
+        def capturing_handler(effect: Effect, k):
             _ = k
             captured_effects.append(effect)
-            yield Delegate()
+            return (yield Pass())
 
         @do
         def workflow():

--- a/packages/doeff-flow/tests/test_trace.py
+++ b/packages/doeff-flow/tests/test_trace.py
@@ -16,7 +16,7 @@ from doeff_flow.trace import (
     write_terminal_trace,
 )
 
-from doeff import Ask, Delegate, Get, Pure, Put, Resume, WithHandler, default_handlers, do
+from doeff import Ask, Effect, Get, Pass, Pure, Put, Resume, WithHandler, default_handlers, do
 from doeff import run as run_sync
 
 
@@ -194,10 +194,11 @@ class TestWithHandlerObservability:
     def test_can_capture_effects_with_delegate(self):
         captured_effects: list[object] = []
 
-        def capturing_handler(effect, k):
+        @do
+        def capturing_handler(effect: Effect, k):
             _ = k
             captured_effects.append(effect)
-            yield Delegate()
+            return (yield Pass())
 
         @do
         def workflow():
@@ -221,12 +222,13 @@ class TestWithHandlerObservability:
     def test_can_modify_effect_result_with_resume(self):
         seen_ask = 0
 
-        def override_ask_handler(effect, k):
+        @do
+        def override_ask_handler(effect: Effect, k):
             nonlocal seen_ask
             if type(effect).__name__ == "PyAsk" and seen_ask < 2:
                 seen_ask += 1
                 return (yield Resume(k, 5))
-            yield Delegate()
+            return (yield Pass())
 
         @do
         def workflow():

--- a/packages/doeff-git/src/doeff_git/handlers/production.py
+++ b/packages/doeff-git/src/doeff_git/handlers/production.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from doeff import Delegate, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_git.effects import CreatePR, GitCommit, GitDiff, GitPull, GitPush, MergePR
 from doeff_git.exceptions import GitCommandError
 from doeff_git.types import MergeStrategy, PRHandle
@@ -185,7 +185,8 @@ def production_handlers(
     local = local_handler or GitLocalHandler()
     hosting = github_handler or GitHubHandler()
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, GitCommit):
             return (yield Resume(k, local.handle_commit(effect)))
         if isinstance(effect, GitDiff):
@@ -201,7 +202,7 @@ def production_handlers(
         if isinstance(effect, MergePR):
             hosting.handle_merge_pr(effect)
             return (yield Resume(k, None))
-        yield Delegate()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-git/src/doeff_git/handlers/testing.py
+++ b/packages/doeff-git/src/doeff_git/handlers/testing.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from doeff import Delegate, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_git.effects import CreatePR, GitCommit, GitDiff, GitPull, GitPush, MergePR
 from doeff_git.types import PRHandle
 
@@ -93,7 +93,8 @@ def mock_handlers(
 
     active_runtime = runtime or MockGitRuntime()
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, GitCommit):
             return (yield Resume(k, active_runtime.handle_commit(effect)))
         if isinstance(effect, GitDiff):
@@ -109,7 +110,7 @@ def mock_handlers(
         if isinstance(effect, MergePR):
             active_runtime.handle_merge_pr(effect)
             return (yield Resume(k, None))
-        yield Delegate()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-pinjected/src/doeff_pinjected/bridge.py
+++ b/packages/doeff-pinjected/src/doeff_pinjected/bridge.py
@@ -12,7 +12,7 @@ from typing import TypeVar, cast
 from loguru import logger
 from pinjected import AsyncResolver, Injected, IProxy
 
-from doeff import Effect, Program, RunResult, WithHandler, async_run, default_async_handlers
+from doeff import Effect, Program, RunResult, WithHandler, async_run, default_async_handlers, do
 from doeff.effects import AskEffect, GraphAnnotateEffect, GraphStepEffect, Intercept, Pure
 from doeff_pinjected.effects import PinjectedResolve
 from doeff_pinjected.handlers import production_handlers
@@ -94,8 +94,9 @@ def program_to_injected(prog: Program[T]) -> Injected[T]:
             original_build_local_handler = reader_effects._build_local_handler
 
             def _bridge_build_local_handler(_overlay: dict):
-                def handle_local_ask(_effect, _k):
-                    yield doeff_vm.Delegate()
+                @do
+                def handle_local_ask(effect: Effect, _k):
+                    return (yield doeff_vm.Delegate())
 
                 return handle_local_ask
 
@@ -172,8 +173,9 @@ def program_to_injected_result(prog: Program[T]) -> Injected[RunResult[T]]:
             original_build_local_handler = reader_effects._build_local_handler
 
             def _bridge_build_local_handler(_overlay: dict):
-                def handle_local_ask(_effect, _k):
-                    yield doeff_vm.Delegate()
+                @do
+                def handle_local_ask(effect: Effect, _k):
+                    return (yield doeff_vm.Delegate())
 
                 return handle_local_ask
 

--- a/packages/doeff-pinjected/src/doeff_pinjected/handlers/production.py
+++ b/packages/doeff-pinjected/src/doeff_pinjected/handlers/production.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from doeff import Ask, Await, Pass, Resume
+from doeff import Ask, Await, Effect, Pass, Resume, do
 from doeff_pinjected.effects import PinjectedProvide, PinjectedResolve
 
 ProtocolHandler = Callable[[Any, Any], Any]
@@ -60,12 +60,14 @@ def production_handlers(
         resolver=resolver,
         bindings=dict(bindings or {}),
     )
-    def handler(effect: Any, k: Any):
+
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, PinjectedResolve):
             return (yield from runtime.handle_resolve(effect, k))
         if isinstance(effect, PinjectedProvide):
             return (yield from runtime.handle_provide(effect, k))
-        yield Pass()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-pinjected/src/doeff_pinjected/handlers/testing.py
+++ b/packages/doeff-pinjected/src/doeff_pinjected/handlers/testing.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
-from doeff import Pass, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_pinjected.effects import PinjectedProvide, PinjectedResolve
 
 ProtocolHandler = Callable[[Any, Any], Any]
@@ -43,7 +43,8 @@ def mock_handlers(
     if runtime is not None and bindings:
         active_runtime.bindings.update(dict(bindings))
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, PinjectedResolve):
             active_runtime.resolve_calls.append(effect.key)
             if effect.key not in active_runtime.bindings:
@@ -53,7 +54,7 @@ def mock_handlers(
             active_runtime.provide_calls.append((effect.key, effect.value))
             active_runtime.bindings[effect.key] = effect.value
             return (yield Resume(k, None))
-        yield Pass()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-pinjected/tests/test_pinjected_bridge.py
+++ b/packages/doeff-pinjected/tests/test_pinjected_bridge.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from dataclasses import dataclass, field
 from typing import Any
 
-from doeff import Ask, AskEffect, Delegate, Resume, WithHandler, default_handlers, do, run
+from doeff import Ask, AskEffect, Effect, Pass, Resume, WithHandler, default_handlers, do, run
 
 _EFFECT_FAILURE_TYPE_NAMES = {"EffectFailure", "EffectFailureError"}
 
@@ -37,7 +37,8 @@ class MockPinjectedGraph:
 def _mock_pinjected_handler(graph: MockPinjectedGraph):
     """Return a WithHandler-compatible function for bridge Ask effects."""
 
-    def handler(effect, k):
+    @do
+    def handler(effect: Effect, k):
         if isinstance(effect, AskEffect):
             if effect.key == "pinjected_graph":
                 return (yield Resume(k, graph))
@@ -46,7 +47,7 @@ def _mock_pinjected_handler(graph: MockPinjectedGraph):
                 binding_name = effect.key.split(":", 1)[1]
                 return (yield Resume(k, graph.resolve(binding_name)))
 
-        yield Delegate()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-test-target/src/doeff_test_target/handlers/production.py
+++ b/packages/doeff-test-target/src/doeff_test_target/handlers/production.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping, MutableSequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from doeff import Pass, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff.effects import ask, tell
 from doeff_test_target.effects import ReadFixtureValue, RecordFixtureEvent
 
@@ -46,12 +46,13 @@ def production_handlers(
         recorded_events=recorded_events if recorded_events is not None else [],
     )
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, ReadFixtureValue):
             return (yield from active_runtime.handle_read_value(effect, k))
         if isinstance(effect, RecordFixtureEvent):
             return (yield from active_runtime.handle_record_event(effect, k))
-        yield Pass()
+        return (yield Pass())
 
     return handler
 

--- a/packages/doeff-test-target/src/doeff_test_target/handlers/testing.py
+++ b/packages/doeff-test-target/src/doeff_test_target/handlers/testing.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
-from doeff import Pass, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_test_target.effects import ReadFixtureValue, RecordFixtureEvent
 
 ProtocolHandler = Callable[[Any, Any], Any]
@@ -44,12 +44,13 @@ def mock_handlers(
         default_prefix=default_prefix,
     )
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, ReadFixtureValue):
             return (yield from active_runtime.handle_read_value(effect, k))
         if isinstance(effect, RecordFixtureEvent):
             return (yield from active_runtime.handle_record_event(effect, k))
-        yield Pass()
+        return (yield Pass())
 
     return handler
 


### PR DESCRIPTION
## Summary
- Migrated package handler closures to strict `@do` form with `effect: Effect` annotation across:
  - `doeff-flow` (`testing.py`, `production.py`)
  - `doeff-git` (`testing.py`, `production.py`)
  - `doeff-pinjected` (`handlers/testing.py`, `handlers/production.py`, bridge local ask handlers)
  - `doeff-test-target` (`testing.py`, `production.py`)
- Updated affected package tests that constructed plain handlers so they satisfy strict WithHandler typing.
- Preserved passthrough behavior under `@do` by using `Pass()` in fallback branches.

## Acceptance Criteria Evidence
- [x] All handler closures decorated with `@do` and `effect: Effect` annotation
  - Verified in:
    - `packages/doeff-flow/src/doeff_flow/handlers/testing.py`
    - `packages/doeff-flow/src/doeff_flow/handlers/production.py`
    - `packages/doeff-git/src/doeff_git/handlers/testing.py`
    - `packages/doeff-git/src/doeff_git/handlers/production.py`
    - `packages/doeff-pinjected/src/doeff_pinjected/handlers/testing.py`
    - `packages/doeff-pinjected/src/doeff_pinjected/handlers/production.py`
    - `packages/doeff-pinjected/src/doeff_pinjected/bridge.py` (both `handle_local_ask` closures)
    - `packages/doeff-test-target/src/doeff_test_target/handlers/testing.py`
    - `packages/doeff-test-target/src/doeff_test_target/handlers/production.py`
- [x] Plain `Intercept` transform functions left as-is if they don't yield
  - `packages/doeff-pinjected/src/doeff_pinjected/bridge.py`:
    - `_transform(effect: Effect)` unchanged (plain transform)
    - `_compat_transform(effect: Effect)` unchanged (plain transform)
- [x] Each package's existing tests still pass
  - `make sync` ✅
  - `uv run pytest packages/doeff-flow/tests/ -q` → `44 passed in 0.26s`
  - `uv run pytest packages/doeff-git/tests/ -q` → `8 passed in 0.98s`
  - `uv run pytest packages/doeff-pinjected/tests/ -q` → `9 passed in 0.12s`
  - `uv run pytest -q` → `795 passed, 21 warnings in 28.56s`
  - Additional validation (for test-target touched files):
    - `uv run pytest packages/doeff-test-target/tests/ -q` → `10 passed in 0.09s`

## Issue
Refs: `KLEISLI-PKG-TEST`
