### PR TITLE
Migrate core handlers to strict @do protocol

### DIFF
--- a/packages/doeff-events/src/doeff_events/handlers/memory.py
+++ b/packages/doeff-events/src/doeff_events/handlers/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from doeff import Pass, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff.effects import CreateExternalPromise, ExternalPromise, Wait
 from doeff_events.effects import PublishEffect, WaitForEventEffect
 
@@ -49,7 +49,8 @@ def event_handler():
 
     listeners: ListenerMap = {}
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, WaitForEventEffect):
             promise = yield CreateExternalPromise()
 

--- a/packages/doeff-notify/src/doeff_notify/handlers/log.py
+++ b/packages/doeff-notify/src/doeff_notify/handlers/log.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from itertools import count
 from typing import Any
 
-from doeff import Delegate, Resume, Tell
+from doeff import Effect, Pass, Resume, Tell, do
 from doeff_notify.effects import Acknowledge, Notify, NotifyThread
 from doeff_notify.types import Channel, NotificationResult
 
@@ -26,7 +26,8 @@ def _notify_payload(effect: Notify, notification_id: str) -> dict[str, Any]:
     }
 
 
-def log_handler(effect, k):
+@do
+def log_handler(effect: Effect, k: Any):
     """Emit notification events as Tell effects for logging handlers."""
 
     if isinstance(effect, Notify):
@@ -64,7 +65,7 @@ def log_handler(effect, k):
         )
         return (yield Resume(k, False))
 
-    yield Delegate()
+    yield Pass()
 
 
 __all__ = ["log_handler"]

--- a/packages/doeff-notify/src/doeff_notify/handlers/stdout.py
+++ b/packages/doeff-notify/src/doeff_notify/handlers/stdout.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from itertools import count
+from typing import Any
 
-from doeff import Delegate, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_notify.effects import Acknowledge, Notify, NotifyThread
 from doeff_notify.types import Channel, NotificationResult, Urgency
 
@@ -21,7 +22,8 @@ def _next_id() -> str:
     return f"console-{next(_CONSOLE_IDS)}"
 
 
-def console_handler(effect, k):
+@do
+def console_handler(effect: Effect, k: Any):
     """Print notifications to stdout and return NotificationResult payloads."""
 
     if isinstance(effect, Notify):
@@ -47,7 +49,7 @@ def console_handler(effect, k):
     if isinstance(effect, Acknowledge):
         return (yield Resume(k, False))
 
-    yield Delegate()
+    yield Pass()
 
 
 __all__ = ["console_handler"]

--- a/packages/doeff-notify/src/doeff_notify/handlers/testing.py
+++ b/packages/doeff-notify/src/doeff_notify/handlers/testing.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from itertools import count
 from typing import Any, overload
 
-from doeff import Delegate, Resume
+from doeff import Effect, Pass, Resume, do
 from doeff_notify.effects import Acknowledge, Notify, NotifyThread
 from doeff_notify.types import Channel, NotificationResult
 
@@ -55,7 +55,8 @@ def build_testing_handler(
     seen_ids: set[str] = set()
     next_id = count(1)
 
-    def _handler(effect, k):
+    @do
+    def _handler(effect: Effect, k: Any):
         if isinstance(effect, Notify):
             capture.notifications.append(effect)
             notification_id = f"{default_channel}-{next(next_id)}"
@@ -80,7 +81,7 @@ def build_testing_handler(
             acknowledged = auto_acknowledge and effect.notification_id in seen_ids
             return (yield Resume(k, acknowledged))
 
-        yield Delegate()
+        yield Pass()
 
     return _handler, capture
 

--- a/packages/doeff-notify/tests/test_handlers.py
+++ b/packages/doeff-notify/tests/test_handlers.py
@@ -23,7 +23,7 @@ from doeff_notify.handlers import (
 )
 from doeff_notify.types import Channel, NotificationResult, Urgency
 
-from doeff import Delegate, Resume, WithHandler, default_handlers, do, run
+from doeff import Effect, Pass, Resume, WithHandler, default_handlers, do, run
 from doeff.effects import WriterTellEffect
 
 
@@ -132,11 +132,12 @@ def _logging_program():
 def test_log_handler_emits_tell_events() -> None:
     logs: list[Any] = []
 
-    def capture_tell_handler(effect, k):
+    @do
+    def capture_tell_handler(effect: Effect, k: Any):
         if isinstance(effect, WriterTellEffect):
             logs.append(effect.message)
             return (yield Resume(k, None))
-        yield Delegate()
+        yield Pass()
 
     result = run(
         WithHandler(capture_tell_handler, WithHandler(log_handler, _logging_program())),

--- a/packages/doeff-preset/src/doeff_preset/handlers/config.py
+++ b/packages/doeff-preset/src/doeff_preset/handlers/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from doeff import AskEffect, MissingEnvKeyError, Pass, Resume
+from doeff import AskEffect, Effect, MissingEnvKeyError, Pass, Resume, do
 from doeff_preset.effects.config import is_preset_config_key
 
 ProtocolHandler = Callable[[Any, Any], Any]
@@ -44,7 +44,8 @@ def make_config_handler(
     if defaults:
         config.update(defaults)
 
-    def handle_ask_with_config(effect: Any, k):
+    @do
+    def handle_ask_with_config(effect: Effect, k: Any):
         """Handle Ask effect with preset.* config support.
 
         - `preset.*` keys are resolved from this handler's config.
@@ -52,7 +53,7 @@ def make_config_handler(
         """
         if not isinstance(effect, AskEffect):
             yield Pass()
-            return
+            return None
 
         key = effect.key
 

--- a/packages/doeff-preset/src/doeff_preset/handlers/log_display.py
+++ b/packages/doeff-preset/src/doeff_preset/handlers/log_display.py
@@ -13,7 +13,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
-from doeff import Pass, WriterTellEffect
+from doeff import Effect, Pass, WriterTellEffect, do
 
 # Global console for log output
 _console = Console(stderr=True)
@@ -70,9 +70,10 @@ def format_slog(message: dict[str, Any]) -> Panel | Text:
     return Text.from_markup(f"{level_badge} {display_text}")
 
 
+@do
 def handle_tell_with_display(
-    effect: Any,
-    _k,
+    effect: Effect,
+    _k: Any,
 ):
     """Handle WriterTellEffect with console display for slog messages.
 
@@ -88,7 +89,7 @@ def handle_tell_with_display(
     """
     if not isinstance(effect, WriterTellEffect):
         yield Pass()
-        return
+        return None
 
     message = effect.message
 
@@ -99,13 +100,15 @@ def handle_tell_with_display(
 
     # Delegate to outer Writer handler for normal log accumulation.
     yield Pass()
+    return None
 
 
 def log_display_handlers() -> ProtocolHandler:
     """Return a protocol handler for slog display."""
 
-    def handler(effect: Any, k: Any):
-        return (yield from handle_tell_with_display(effect, k))
+    @do
+    def handler(effect: Effect, k: Any):
+        return (yield handle_tell_with_display(effect, k))
 
     return handler
 

--- a/packages/doeff-preset/src/doeff_preset/handlers/production.py
+++ b/packages/doeff-preset/src/doeff_preset/handlers/production.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from doeff import AskEffect, Pass, WriterTellEffect
+from doeff import AskEffect, Effect, Pass, WriterTellEffect, do
 from doeff_preset.handlers.config import config_handlers
 from doeff_preset.handlers.log_display import log_display_handlers
 
@@ -17,11 +17,12 @@ def production_handlers(config_defaults: dict[str, Any] | None = None) -> Protoc
     slog_handler = log_display_handlers()
     ask_handler = config_handlers(config_defaults)
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, WriterTellEffect):
-            return (yield from slog_handler(effect, k))
+            return (yield slog_handler(effect, k))
         if isinstance(effect, AskEffect):
-            return (yield from ask_handler(effect, k))
+            return (yield ask_handler(effect, k))
         yield Pass()
 
     return handler

--- a/packages/doeff-preset/src/doeff_preset/handlers/testing.py
+++ b/packages/doeff-preset/src/doeff_preset/handlers/testing.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from doeff import AskEffect, Pass, WriterTellEffect
+from doeff import AskEffect, Effect, Pass, WriterTellEffect, do
 from doeff_preset.handlers.config import config_handlers
 
 ProtocolHandler = Callable[[Any, Any], Any]
 
 
-def _handle_tell_noop(effect: Any, _k):
+@do
+def _handle_tell_noop(effect: Effect, _k: Any):
     """Do not display structured logs during tests; delegate writer behavior."""
     if not isinstance(effect, WriterTellEffect):
         yield Pass()
-        return
+        return None
     yield Pass()
+    return None
 
 
 def mock_log_display_handlers() -> ProtocolHandler:
@@ -29,11 +31,12 @@ def mock_handlers(config_defaults: dict[str, Any] | None = None) -> ProtocolHand
     slog_handler = mock_log_display_handlers()
     ask_handler = config_handlers(config_defaults)
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, WriterTellEffect):
-            return (yield from slog_handler(effect, k))
+            return (yield slog_handler(effect, k))
         if isinstance(effect, AskEffect):
-            return (yield from ask_handler(effect, k))
+            return (yield ask_handler(effect, k))
         yield Pass()
 
     return handler

--- a/packages/doeff-preset/tests/test_preset_handlers.py
+++ b/packages/doeff-preset/tests/test_preset_handlers.py
@@ -33,6 +33,7 @@ from doeff_preset.handlers import (
 from doeff import (
     Ask,
     AskEffect,
+    Effect,
     EffectBase,
     MissingEnvKeyError,
     Pass,
@@ -201,7 +202,8 @@ class TestConfigHandlers:
             show_logs = yield Ask("preset.show_logs")
             return show_logs
 
-        def mock_preset_config(effect, k):
+        @do
+        def mock_preset_config(effect: Effect, k: Any):
             if isinstance(effect, AskEffect) and effect.key == "preset.show_logs":
                 return (yield Resume(k, False))
             yield Pass()
@@ -265,7 +267,8 @@ class TestPresetHandlers:
         class CustomEffect(EffectBase):
             value: str
 
-        def handle_custom(effect: CustomEffect, k):
+        @do
+        def handle_custom(effect: Effect, k: Any):
             if isinstance(effect, CustomEffect):
                 return (yield Resume(k, f"handled: {effect.value}"))
             yield Pass()

--- a/packages/doeff-secret/src/doeff_secret/testing.py
+++ b/packages/doeff-secret/src/doeff_secret/testing.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
-from doeff import Delegate, Resume
+from doeff import Delegate, Effect, Resume, do
 
 from .effects import DeleteSecret, GetSecret, ListSecrets, SetSecret
 
@@ -95,7 +95,8 @@ def in_memory_handlers(
         project=project,
     )
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, GetSecret):
             value = active_store.get_secret(effect.secret_id, version=effect.version)
             return (yield Resume(k, value))

--- a/packages/doeff-time/tests/test_sim_time.py
+++ b/packages/doeff-time/tests/test_sim_time.py
@@ -8,6 +8,7 @@ from doeff_events import Publish, WaitForEvent, event_handler
 from doeff_time import Delay, GetTime, ScheduleAt, SetTime, WaitUntil, sim_time_handler
 
 from doeff import (
+    Effect,
     Gather,
     Listen,
     Pass,
@@ -60,7 +61,8 @@ def _run_with_probe(
 ):
     seen = 0
 
-    def probe(effect: Any, k: Any):
+    @do
+    def probe(effect: Effect, k: Any):
         nonlocal seen
         if isinstance(effect, effect_type):
             seen += 1


### PR DESCRIPTION
## Summary
- Migrated the core handler set in `doeff-notify`, `doeff-secret`, `doeff-events`, `doeff-time`, and `doeff-preset` to strict handler protocol (`@do` + `effect: Effect`).
- Added the `doeff-time` wrapper pattern for class runtimes so `WithHandler(...)` receives closure handlers with `(effect, k)` signatures while preserving runtime state.
- Updated strict-handler test helpers in affected package tests to match the enforced protocol.
- Fixed `sim_time` formatted tell forwarding by guarding recursive tell formatting and using `Transfer` for continuation handoff.

## Acceptance Criteria Evidence
### 1) All target handlers are `@do` + `effect: Effect`
Confirmed in source at these key points:
- `packages/doeff-notify/src/doeff_notify/handlers/stdout.py` (`console_handler`)
- `packages/doeff-notify/src/doeff_notify/handlers/log.py` (`log_handler`)
- `packages/doeff-notify/src/doeff_notify/handlers/testing.py` (`_handler`)
- `packages/doeff-secret/src/doeff_secret/handlers.py` (`handle_get_secret`, env-var `handler`s)
- `packages/doeff-secret/src/doeff_secret/testing.py` (`in_memory_handlers` `handler`)
- `packages/doeff-events/src/doeff_events/handlers/memory.py` (`handler`)
- `packages/doeff-time/src/doeff_time/handlers/sync_time.py` (`SyncTimeRuntime.handle`, `sync_time_handler` local `handler`)
- `packages/doeff-time/src/doeff_time/handlers/async_time.py` (`AsyncTimeRuntime.handle`, `async_time_handler` local `handler`)
- `packages/doeff-time/src/doeff_time/handlers/sim_time.py` (`SimTimeRuntime.handle`)
- `packages/doeff-preset/src/doeff_preset/handlers/config.py` (`handle_ask_with_config`)

### 2) `doeff-time` class method handlers handled correctly
- Added runtime-local protocol wrapper closures (`_protocol_handler`) in sync/async/sim runtimes to satisfy strict `(effect, k)` validation when passed to `WithHandler`.
- Updated scheduled-execution paths to use these wrappers instead of bound `self.handle` directly.

### 3) Existing tests pass
Commands run:
- `make sync`
- `uv run pytest packages/doeff-notify/tests/ -q`
- `uv run pytest packages/doeff-secret/tests/ -q`
- `uv run pytest packages/doeff-events/tests/ -q`
- `uv run pytest packages/doeff-time/tests/ -q`
- `uv run pytest packages/doeff-preset/tests/ -q`
- `uv run pytest -q`

Results:
- Package tests: all passing (`5 + 8 + 6 + 61 + 21`)
- Full suite: `795 passed, 21 warnings`

## Issue
- References: `KLEISLI-PKG-CORE`
