### PR TITLE
Refactor Gemini cost calculation into effect handlers

### DIFF
--- a/packages/doeff-gemini/src/doeff_gemini/__init__.py
+++ b/packages/doeff-gemini/src/doeff_gemini/__init__.py
@@ -9,12 +9,14 @@ from .client import GeminiClient, get_gemini_client, track_api_call
 from .costs import calculate_cost, gemini_cost_calculator__default
 from .effects import (
     GeminiChat,
+    GeminiCalculateCost,
     GeminiEmbedding,
     GeminiImageEdit,
     GeminiStreamingChat,
     GeminiStructuredOutput,
 )
 from .handlers import (
+    default_gemini_cost_handler,
     gemini_image_handler,
     gemini_mock_handler,
     gemini_production_handler,
@@ -45,6 +47,7 @@ __all__ = [
     "CostInfo",
     "GeminiCallResult",
     "GeminiChat",
+    "GeminiCalculateCost",
     "GeminiClient",
     "GeminiCostEstimate",
     "GeminiEmbedding",
@@ -60,6 +63,7 @@ __all__ = [
     "build_contents",
     "build_generation_config",
     "calculate_cost",
+    "default_gemini_cost_handler",
     "edit_image__gemini",
     "gemini_mock_handler",
     "gemini_production_handler",

--- a/packages/doeff-gemini/src/doeff_gemini/costs.py
+++ b/packages/doeff-gemini/src/doeff_gemini/costs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from doeff import Tell, do
+from doeff import do
 
 from .types import CostInfo, GeminiCallResult, GeminiCostEstimate
 
@@ -17,28 +17,81 @@ class ModelPricing:
     text_output: float
     image_input: float = 0.0
     image_output: float = 0.0
+    long_context_threshold: int | None = None
+    long_context_text_input: float | None = None
+    long_context_text_output: float | None = None
+
+
+class UnknownModelPricingError(ValueError):
+    """Raised when no default pricing exists for a model."""
 
 
 _MODEL_PRICING: dict[str, ModelPricing] = {
-    "gemini-2.5-flash": ModelPricing(
-        text_input=0.30, text_output=2.50, image_input=0.0, image_output=0.0
-    ),
-    "gemini-2.5-flash-image-preview": ModelPricing(
-        text_input=0.30, text_output=2.50, image_input=0.30, image_output=30.0
-    ),
+    # https://ai.google.dev/pricing (checked 2026-02-28)
+    # <= 200k input tokens: $1.25 / 1M input, $10.00 / 1M output
+    # > 200k input tokens:  $2.50 / 1M input, $15.00 / 1M output
     "gemini-2.5-pro": ModelPricing(
-        text_input=12.50, text_output=150.0, image_input=0.0, image_output=0.0
+        text_input=1.25,
+        text_output=10.0,
+        long_context_threshold=200_000,
+        long_context_text_input=2.50,
+        long_context_text_output=15.0,
     ),
+    # <= 200k input tokens: $0.30 / 1M input, $2.50 / 1M output
+    # > 200k input tokens:  $0.60 / 1M input, $2.50 / 1M output
+    "gemini-2.5-flash": ModelPricing(
+        text_input=0.30,
+        text_output=2.50,
+        long_context_threshold=200_000,
+        long_context_text_input=0.60,
+        long_context_text_output=2.50,
+    ),
+    # Current image-generation pricing is $0.039/image, equivalent to $30/1M image-output tokens.
+    "gemini-2.5-flash-image-preview": ModelPricing(
+        text_input=0.30,
+        text_output=2.50,
+        image_input=0.0,
+        image_output=30.0,
+        long_context_threshold=200_000,
+        long_context_text_input=0.60,
+        long_context_text_output=2.50,
+    ),
+    # Token pricing + image-generation pricing on https://ai.google.dev/pricing.
+    # Image generation: $0.039/image => equivalent to $30/1M image-output tokens.
     "gemini-2.0-flash": ModelPricing(
-        text_input=1.25, text_output=10.0, image_input=0.0, image_output=0.0
+        text_input=0.10,
+        text_output=0.40,
+        image_input=0.0,
+        image_output=30.0,
     ),
+    "gemini-2.0-flash-preview-image-generation": ModelPricing(
+        text_input=0.10,
+        text_output=0.40,
+        image_input=0.0,
+        image_output=30.0,
+    ),
+    "gemini-2.0-flash-lite": ModelPricing(
+        text_input=0.075,
+        text_output=0.30,
+    ),
+    # 1.5 models are legacy/deprecated on current pricing page but retained for backward compatibility.
+    # Rates from the last official ai.google.dev/pricing listing:
+    # <= 128k input tokens, then higher long-context tier above 128k.
     "gemini-1.5-flash": ModelPricing(
-        text_input=1.25, text_output=10.0, image_input=0.0, image_output=0.0
+        text_input=0.075,
+        text_output=0.30,
+        long_context_threshold=128_000,
+        long_context_text_input=0.15,
+        long_context_text_output=0.60,
     ),
     "gemini-1.5-pro": ModelPricing(
-        text_input=12.50, text_output=150.0, image_input=0.0, image_output=0.0
+        text_input=1.25,
+        text_output=5.0,
+        long_context_threshold=128_000,
+        long_context_text_input=2.50,
+        long_context_text_output=10.0,
     ),
-    # Gemini 3 Pro Image (Nano Banana Pro) pricing
+    # Gemini 3 Pro Image (Nano Banana Pro) legacy/preview pricing.
     "gemini-3-pro-image-preview": ModelPricing(
         text_input=2.00,
         text_output=12.00,
@@ -58,16 +111,43 @@ def _normalize_model_name(model: str) -> str:
         base = base[:-7]
     if base.endswith("-exp"):
         base = base[:-4]
+    for suffix in ("-001", "-002", "-003"):
+        if base.endswith(suffix):
+            candidate = base[: -len(suffix)]
+            if candidate in _MODEL_PRICING:
+                return candidate
     return base
+
+
+def _resolve_effective_text_rates(pricing: ModelPricing, text_input_tokens: int) -> tuple[float, float]:
+    if (
+        pricing.long_context_threshold is not None
+        and text_input_tokens > pricing.long_context_threshold
+    ):
+        return (
+            pricing.long_context_text_input
+            if pricing.long_context_text_input is not None
+            else pricing.text_input,
+            pricing.long_context_text_output
+            if pricing.long_context_text_output is not None
+            else pricing.text_output,
+        )
+    return pricing.text_input, pricing.text_output
+
+
+def get_model_pricing(model: str) -> ModelPricing | None:
+    """Return default pricing for a model, if known."""
+
+    normalized = _normalize_model_name(model)
+    return _MODEL_PRICING.get(normalized)
 
 
 def calculate_cost(model: str, usage: dict[str, int]) -> CostInfo:
     """Calculate Gemini cost information for the given usage."""
 
-    normalized = _normalize_model_name(model)
-    pricing = _MODEL_PRICING.get(normalized)
+    pricing = get_model_pricing(model)
     if pricing is None:
-        raise ValueError(f"No pricing information available for model '{model}'")
+        raise UnknownModelPricingError(f"No pricing information available for model '{model}'")
 
     text_in_tokens = usage.get("text_input_tokens", 0) or 0
     text_out_tokens = usage.get("text_output_tokens", 0) or 0
@@ -85,8 +165,12 @@ def calculate_cost(model: str, usage: dict[str, int]) -> CostInfo:
         # tokens as image output when the model has image-output pricing.
         image_out_tokens = total_tokens - (text_in_tokens + text_out_tokens + image_in_tokens)
 
-    text_in_cost = (text_in_tokens / 1_000_000) * pricing.text_input
-    text_out_cost = (text_out_tokens / 1_000_000) * pricing.text_output
+    effective_text_input_rate, effective_text_output_rate = _resolve_effective_text_rates(
+        pricing, text_in_tokens
+    )
+
+    text_in_cost = (text_in_tokens / 1_000_000) * effective_text_input_rate
+    text_out_cost = (text_out_tokens / 1_000_000) * effective_text_output_rate
     image_in_cost = (image_in_tokens / 1_000_000) * pricing.image_input
     image_out_cost = (image_out_tokens / 1_000_000) * pricing.image_output
 
@@ -101,23 +185,40 @@ def calculate_cost(model: str, usage: dict[str, int]) -> CostInfo:
     )
 
 
+def calculate_known_model_cost(call_result: GeminiCallResult) -> GeminiCostEstimate | None:
+    """Calculate cost for a known model, or return ``None`` when model pricing is unknown."""
+
+    usage = call_result.payload.get("usage") if isinstance(call_result.payload, dict) else None
+    if not usage:
+        raise ValueError("Gemini usage metadata missing for cost calculation")
+
+    try:
+        cost_info = calculate_cost(call_result.model_name, usage)
+    except UnknownModelPricingError:
+        return None
+
+    return GeminiCostEstimate(cost_info=cost_info, raw_usage=usage)
+
+
 @do
 def gemini_cost_calculator__default(
     call_result: GeminiCallResult,
 ) -> GeminiCostEstimate:
-    """Default Kleisli cost calculator backed by the built-in pricing table."""
+    """Legacy Kleisli wrapper around default known-model pricing."""
 
-    usage = call_result.payload.get("usage") if isinstance(call_result.payload, dict) else None
-    if not usage:
-        yield Tell("Gemini cost calculation failed: usage metadata missing")
-        raise ValueError("Gemini usage metadata missing for cost calculation")
-
-    cost_info = calculate_cost(call_result.model_name, usage)
-    return GeminiCostEstimate(cost_info=cost_info, raw_usage=usage)
+    estimate = calculate_known_model_cost(call_result)
+    if estimate is None:
+        raise UnknownModelPricingError(
+            f"No pricing information available for model '{call_result.model_name}'"
+        )
+    return estimate
 
 
 __all__ = [
     "ModelPricing",
+    "UnknownModelPricingError",
     "calculate_cost",
+    "calculate_known_model_cost",
+    "get_model_pricing",
     "gemini_cost_calculator__default",
 ]

--- a/packages/doeff-gemini/src/doeff_gemini/effects/__init__.py
+++ b/packages/doeff-gemini/src/doeff_gemini/effects/__init__.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from doeff_image.effects import ImageEdit, ImageGenerate
 
 from .chat import GeminiChat, GeminiStreamingChat
+from .cost import GeminiCalculateCost
 from .embedding import GeminiEmbedding
 from .image import GeminiImageEdit
 from .structured import GeminiStructuredOutput
 
 __all__ = [
     "GeminiChat",
+    "GeminiCalculateCost",
     "GeminiEmbedding",
     "GeminiImageEdit",
     "GeminiStreamingChat",

--- a/packages/doeff-gemini/src/doeff_gemini/effects/cost.py
+++ b/packages/doeff-gemini/src/doeff_gemini/effects/cost.py
@@ -1,0 +1,19 @@
+"""Cost-calculation effect for doeff-gemini."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from doeff.effects.base import EffectBase
+
+from doeff_gemini.types import GeminiCallResult
+
+
+@dataclass(frozen=True)
+class GeminiCalculateCost(EffectBase):
+    """Request a cost estimate for a Gemini API call result."""
+
+    call_result: GeminiCallResult
+
+
+__all__ = ["GeminiCalculateCost"]

--- a/packages/doeff-gemini/src/doeff_gemini/handlers/__init__.py
+++ b/packages/doeff-gemini/src/doeff_gemini/handlers/__init__.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
-from .production import gemini_image_handler, gemini_production_handler, production_handlers
+from .production import (
+    default_gemini_cost_handler,
+    gemini_image_handler,
+    gemini_production_handler,
+    production_handlers,
+)
 from .testing import MockGeminiHandler, gemini_mock_handler, mock_handlers
 
 __all__ = [
     "MockGeminiHandler",
+    "default_gemini_cost_handler",
     "gemini_image_handler",
     "gemini_mock_handler",
     "gemini_production_handler",

--- a/packages/doeff-gemini/src/doeff_gemini/structured_llm.py
+++ b/packages/doeff-gemini/src/doeff_gemini/structured_llm.py
@@ -824,7 +824,7 @@ def structured_llm__gemini(
 
     safe_retry_result = yield Try(
         _retry_with_backoff(
-            make_api_call,
+            lambda: make_api_call(),
             max_attempts=max_retries,
             delay_strategy=_gemini_random_backoff,
         )
@@ -848,7 +848,7 @@ def structured_llm__gemini(
         if safe_structured.is_err():
             exc = safe_structured.error
             if isinstance(exc, GeminiStructuredOutputError):
-                default_sllm = _make_gemini_json_fix_sllm(
+                default_sllm_impl = _make_gemini_json_fix_sllm(
                     model=model,
                     max_output_tokens=max_output_tokens,
                     system_instruction=system_instruction,
@@ -857,6 +857,10 @@ def structured_llm__gemini(
                     tool_config=tool_config,
                     generation_config_overrides=generation_config_overrides,
                 )
+
+                def default_sllm(json_text: str, response_format: type[BaseModel]):
+                    return default_sllm_impl(json_text, response_format=response_format)
+
                 result = yield repair_structured_response(
                     model=model,
                     response_format=response_format,
@@ -1025,7 +1029,7 @@ def edit_image__gemini(
 
     safe_retry_result = yield Try(
         _retry_with_backoff(
-            make_api_call,
+            lambda: make_api_call(),
             max_attempts=max_retries,
             delay_strategy=_gemini_random_backoff,
         )


### PR DESCRIPTION
## Summary
- replaces Ask-based `gemini_cost_calculator` injection with a first-class effect: `GeminiCalculateCost`
- adds `default_gemini_cost_handler` and wires it into Gemini production handlers so known models are priced by default
- updates Gemini pricing table from `https://ai.google.dev/pricing` for:
  - `gemini-2.5-pro`
  - `gemini-2.5-flash`
  - `gemini-2.0-flash`
  - `gemini-2.0-flash-lite`
  - `gemini-1.5-pro` (legacy compatibility tier retained)
  - `gemini-1.5-flash` (legacy compatibility tier retained)
- keeps unknown model behavior fail-fast by delegating unknown pricing in the default cost handler
- fixes retry/callable auto-unwrap regressions in Gemini structured/image flows
- updates Gemini docs/tests to use handler-stack based cost composition

## Details
- New effect: `packages/doeff-gemini/src/doeff_gemini/effects/cost.py`
- `track_api_call` now does `yield GeminiCalculateCost(call_result)`
- `production_handlers(..., cost_handler=...)` now includes cost-effect handling and defaults to `default_gemini_cost_handler`
- custom pricing now composes via handler stack order (no Ask dependency)

## Validation
- `uv run pytest packages/doeff-gemini/tests/ -q --tb=short`
  - `40 passed, 1 skipped`
- `uv run pytest -q`
  - `795 passed`

## Issue
- KLEISLI-PKG-LLM