### PR TITLE
Migrate OpenAI and OpenRouter handlers to strict @do protocol

### DIFF
--- a/packages/doeff-openai/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-openai/tests/unit/test_effect_handlers.py
@@ -41,6 +41,7 @@ from doeff import (
     default_handlers,
     do,
 )
+from doeff.effects.base import Effect
 
 
 class StructuredAnswer(BaseModel):
@@ -187,9 +188,10 @@ async def test_openai_handler_delegates_unsupported_models() -> None:
     config = MockOpenAIConfig(chat_responses=["openai-response"])
     state = MockOpenAIState()
 
-    def wrapped_openai_handler(effect: Any, k: Any):
+    @do
+    def wrapped_openai_handler(effect: Effect, k: Any):
         return (
-            yield from openai_mock_handler(
+            yield openai_mock_handler(
                 effect,
                 k,
                 config=config,
@@ -197,7 +199,8 @@ async def test_openai_handler_delegates_unsupported_models() -> None:
             )
         )
 
-    def fallback_handler(effect: Any, k: Any):
+    @do
+    def fallback_handler(effect: Effect, k: Any):
         if isinstance(effect, LLMChat):
             return (yield Resume(k, "fallback-response"))
         yield Delegate()

--- a/packages/doeff-openrouter/src/doeff_openrouter/handlers/testing.py
+++ b/packages/doeff-openrouter/src/doeff_openrouter/handlers/testing.py
@@ -14,7 +14,8 @@ from doeff_llm.effects import (
     LLMStructuredQuery,
 )
 
-from doeff import Pass, Resume
+from doeff import Pass, Resume, do
+from doeff.effects.base import Effect
 from doeff_openrouter.effects import (
     RouterChat,
     RouterStreamingChat,
@@ -84,14 +85,16 @@ def mock_handlers(
 
     active_runtime = runtime or MockOpenRouterRuntime()
 
-    def handler(effect: Any, k: Any):
-        return (yield from openrouter_mock_handler(effect, k, runtime=active_runtime))
+    @do
+    def handler(effect: Effect, k: Any):
+        return (yield openrouter_mock_handler(effect, k, runtime=active_runtime))
 
     return handler
 
 
+@do
 def openrouter_mock_handler(
-    effect: Any,
+    effect: Effect,
     k: Any,
     *,
     runtime: MockOpenRouterRuntime | None = None,

--- a/packages/doeff-openrouter/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-openrouter/tests/unit/test_effect_handlers.py
@@ -28,6 +28,7 @@ from doeff_openrouter.handlers import (
 from pydantic import BaseModel
 
 from doeff import Delegate, Resume, WithHandler, default_handlers, do, run
+from doeff.effects.base import Effect
 
 
 class StructuredPayload(BaseModel):
@@ -202,7 +203,8 @@ def test_handler_swapping_between_mock_and_production(monkeypatch) -> None:
 
 
 def test_openrouter_handler_delegates_embedding_effects() -> None:
-    def fallback(effect: Any, k: Any):
+    @do
+    def fallback(effect: Effect, k: Any):
         if isinstance(effect, LLMEmbedding):
             return (yield Resume(k, "embedding-fallback"))
         yield Delegate()

--- a/tests/test_llm_multi_provider_handlers.py
+++ b/tests/test_llm_multi_provider_handlers.py
@@ -31,7 +31,7 @@ def test_multi_model_workflow_routes_to_openai_then_gemini() -> None:
     @do
     def openai_handler(effect: Effect, k: Any):
         return (
-            yield from openai_mock_handler(
+            yield openai_mock_handler(
                 effect,
                 k,
                 config=openai_config,
@@ -97,7 +97,7 @@ def test_openrouter_catch_all_can_handle_unmatched_model() -> None:
 
     @do
     def catch_all_handler(effect: Effect, k: Any):
-        return (yield from openrouter_mock_handler(effect, k))
+        return (yield openrouter_mock_handler(effect, k))
 
     result = run(
         WithHandler(catch_all_handler, workflow()),
@@ -110,7 +110,7 @@ def test_openrouter_catch_all_can_handle_unmatched_model() -> None:
     # Run once more with explicit runtime to verify call capture on catch-all routing.
     @do
     def router_handler(effect: Effect, k: Any):
-        return (yield from openrouter_mock_handler(effect, k, runtime=runtime))
+        return (yield openrouter_mock_handler(effect, k, runtime=runtime))
 
     routed = run(
         WithHandler(router_handler, workflow()),


### PR DESCRIPTION
## Summary
- Migrate OpenAI production/testing handlers to strict `@do` protocol and `Effect`-typed top-level handler signatures
- Migrate OpenRouter production/testing handlers to strict `@do` protocol and `Effect`-typed top-level handler signatures
- Update handler-composition tests to use strict `@do` wrappers where `WithHandler` now rejects plain callables
- Keep business logic intact; only protocol/delegation composition changed (`yield from` -> `yield` for migrated `@do` handlers)

## Acceptance Criteria Evidence
### OpenAI handler migration
- Added `@do` to `_handle_chat_completion`, `_handle_streaming_chat_completion`, `_handle_embedding`, `_handle_structured_output`, `openai_production_handler`
- Updated `openai_production_handler(effect: Effect, k: Any)`
- Converted handler composition calls to `yield _handle_*`

### OpenAI testing handler migration
- Added `@do` to `_handle_chat_completion`, `_handle_streaming_chat_completion`, `_handle_embedding`, `_handle_structured_output`, `openai_mock_handler`, and inner `handler` from `mock_handlers()`
- Updated `openai_mock_handler(effect: Effect, k: Any)`
- Converted handler composition to `yield` for migrated sub-handlers

### OpenRouter handler migration
- Added `@do` to `_handle_chat`, `_handle_streaming_chat`, `_handle_structured_output`, `openrouter_production_handler`
- Updated `openrouter_production_handler(effect: Effect, k: Any)`
- Converted handler composition calls to `yield _handle_*`

### OpenRouter testing handler migration
- Added `@do` to `openrouter_mock_handler` and inner `handler` from `mock_handlers()`
- Updated `openrouter_mock_handler(effect: Effect, k: Any)`
- Converted inner handler composition to `yield openrouter_mock_handler(...)`

### Test handler fixes for strict `WithHandler`
- Updated OpenAI unit test local handlers (`wrapped_openai_handler`, `fallback_handler`) to `@do` + `effect: Effect`
- Updated OpenRouter unit test local `fallback` handler to `@do` + `effect: Effect`
- Updated cross-provider wrapper handlers to `yield` migrated OpenAI/OpenRouter handlers while retaining `yield from` for non-migrated Gemini handler

## Verification
- `uv run pytest packages/doeff-openai/tests/unit/test_effect_handlers.py -x`
  - Result: `5 passed`
- `uv run pytest packages/doeff-openrouter/tests/unit/test_effect_handlers.py -x`
  - Result: `6 passed`
- `uv run pytest tests/test_llm_multi_provider_handlers.py -x`
  - Result: `2 passed`

## Issue Reference
- KLEISLI-PKG-LLM-OPENAI-ROUTER
