### PR TITLE
Migrate Gemini and Seedream mock handlers to strict @do protocol

### DIFF
--- a/packages/doeff-gemini/src/doeff_gemini/handlers/testing.py
+++ b/packages/doeff-gemini/src/doeff_gemini/handlers/testing.py
@@ -18,7 +18,8 @@ from doeff_llm.effects import (
 )
 from PIL import Image as PILImage
 
-from doeff import Pass, Resume
+from doeff import Pass, Resume, do
+from doeff.effects.base import Effect
 from doeff_gemini.effects import (
     GeminiChat,
     GeminiEmbedding,
@@ -28,7 +29,7 @@ from doeff_gemini.effects import (
 )
 from doeff_gemini.handlers.production import _is_gemini_model
 
-ProtocolHandler = Callable[[Any, Any], Any]
+ProtocolHandler = Callable[[Effect, Any], Any]
 
 
 def _default_value_for_annotation(annotation: Any, field_name: str) -> Any:  # noqa: PLR0911
@@ -188,7 +189,8 @@ def mock_handlers(
         embedding_seed=embedding_seed,
     )
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, LLMStreamingChat | GeminiStreamingChat):
             if not _is_gemini_model(effect.model):
                 yield Pass()
@@ -218,8 +220,9 @@ def mock_handlers(
     return handler
 
 
+@do
 def gemini_mock_handler(
-    effect: Any,
+    effect: Effect,
     k: Any,
     *,
     handler: MockGeminiHandler | None = None,

--- a/packages/doeff-gemini/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-gemini/tests/unit/test_effect_handlers.py
@@ -67,6 +67,7 @@ from doeff import (
     do,
     run,
 )
+from doeff.effects.base import Effect
 from doeff_image.effects import ImageEdit
 from doeff_image.effects import ImageEdit as UnifiedImageEdit
 from doeff_image.effects import ImageGenerate as UnifiedImageGenerate
@@ -232,7 +233,8 @@ def test_handler_swapping_changes_behavior() -> None:
 
 
 def test_gemini_handler_delegates_unsupported_models() -> None:
-    def fallback_handler(effect: Any, k: Any):
+    @do
+    def fallback_handler(effect: Effect, k: Any):
         if isinstance(effect, LLMChat):
             return (yield Resume(k, "fallback-chat"))
         yield Delegate()

--- a/packages/doeff-seedream/src/doeff_seedream/handlers/production.py
+++ b/packages/doeff-seedream/src/doeff_seedream/handlers/production.py
@@ -9,11 +9,12 @@ from doeff_image.effects import ImageEdit, ImageGenerate
 from doeff_image.types import ImageResult
 
 from doeff import Delegate, EffectGenerator, Resume, do
+from doeff.effects.base import Effect
 from doeff_seedream.effects import SeedreamGenerate, SeedreamStructuredOutput
 from doeff_seedream.structured_llm import _edit_image__seedream4_impl
 from doeff_seedream.types import SeedreamImageEditResult
 
-ProtocolHandler = Callable[[Any, Any], Any]
+ProtocolHandler = Callable[[Effect, Any], Any]
 
 SEEDREAM_IMAGE_MODEL_PREFIXES = ("seedream-", "doubao-seedream-")
 
@@ -116,7 +117,8 @@ def _structured_impl(effect: SeedreamStructuredOutput) -> EffectGenerator[Any]:
     )
 
 
-def seedream_image_handler(effect: Any, k: Any):  # noqa: PLR0911
+@do
+def seedream_image_handler(effect: Effect, k: Any):  # noqa: PLR0911
     """Protocol handler with model routing for unified image effects."""
     if isinstance(effect, SeedreamGenerate):
         if not _is_seedream_model(effect.model):
@@ -161,7 +163,8 @@ def production_handlers(
     active_image_edit_impl = image_edit_impl or _image_edit_impl
     active_structured_impl = structured_impl or _structured_impl
 
-    def handler(effect: Any, k: Any):  # noqa: PLR0911
+    @do
+    def handler(effect: Effect, k: Any):  # noqa: PLR0911
         if isinstance(effect, SeedreamGenerate):
             if not _is_seedream_model(effect.model):
                 yield Delegate()

--- a/packages/doeff-seedream/src/doeff_seedream/handlers/testing.py
+++ b/packages/doeff-seedream/src/doeff_seedream/handlers/testing.py
@@ -13,11 +13,12 @@ from doeff_image.effects import ImageEdit, ImageGenerate
 from doeff_image.types import ImageResult
 from PIL import Image as PILImage
 
-from doeff import Delegate, Resume
+from doeff import Delegate, Resume, do
+from doeff.effects.base import Effect
 from doeff_seedream.effects import SeedreamGenerate, SeedreamStructuredOutput
 from doeff_seedream.types import SeedreamImage, SeedreamImageEditResult
 
-ProtocolHandler = Callable[[Any, Any], Any]
+ProtocolHandler = Callable[[Effect, Any], Any]
 
 
 def _default_value_for_annotation(annotation: Any, field_name: str) -> Any:  # noqa: PLR0911
@@ -193,7 +194,8 @@ def mock_handlers(
         structured_responses=structured_responses or {},
     )
 
-    def handler(effect: Any, k: Any):
+    @do
+    def handler(effect: Effect, k: Any):
         if isinstance(effect, SeedreamGenerate):
             return (yield Resume(k, active_handler.handle_generate(effect)))
         if isinstance(effect, ImageGenerate):

--- a/packages/doeff-seedream/tests/test_edit_image.py
+++ b/packages/doeff-seedream/tests/test_edit_image.py
@@ -21,8 +21,8 @@ from doeff_seedream import SeedreamClient, edit_image__seedream4, get_seedream_c
 
 from doeff import (
     AskEffect,
-    Delegate,
     Get,
+    Pass,
     Resume,
     Try,
     WithHandler,
@@ -30,6 +30,7 @@ from doeff import (
     default_handlers,
     do,
 )
+from doeff.effects.base import Effect
 
 
 class RecordingSeedreamClient(SeedreamClient):
@@ -56,10 +57,11 @@ class FailingSeedreamClient(SeedreamClient):
 
 
 def _build_mock_seedream_handler(overrides: dict[str, Any]):
-    def _handler(effect, k):
+    @do
+    def _handler(effect: Effect, k: Any):
         if isinstance(effect, AskEffect) and effect.key in overrides:
             return (yield Resume(k, overrides[effect.key]))
-        yield Delegate()
+        yield Pass()
 
     return _handler
 

--- a/tests/test_llm_multi_provider_handlers.py
+++ b/tests/test_llm_multi_provider_handlers.py
@@ -42,7 +42,7 @@ def test_multi_model_workflow_routes_to_openai_then_gemini() -> None:
     @do
     def gemini_handler(effect: Effect, k: Any):
         return (
-            yield from gemini_mock_handler(
+            yield gemini_mock_handler(
                 effect,
                 k,
                 chat_responses={"gemini-1.5-pro": "Gemini summary"},


### PR DESCRIPTION
## Summary
- Migrated Gemini testing handlers to strict `@do` handler protocol (`Effect`-typed signatures)
- Migrated Seedream testing handlers to strict `@do` handler protocol (`Effect`-typed signatures)
- Updated Seedream test helper handler to strict `@do` + transparent pass-through via `Pass`
- Updated cross-provider composition test to call `gemini_mock_handler` with `yield` after strict migration
- Strictified Seedream production handler entry points (`seedream_image_handler` and `production_handlers()` inner handler) to satisfy current `WithHandler` requirements exercised by package tests
- Updated one Gemini unit-test fallback handler to strict `@do` to keep the verification suite green

## Acceptance Criteria Evidence
Issue: `KLEISLI-MOCK-HANDLERS`

Executed required verification commands:

1. `uv run pytest packages/doeff-gemini/tests/unit/test_effect_handlers.py -x`
- Result: **PASS** (`8 passed`)

2. `uv run pytest packages/doeff-seedream/tests/ -x`
- Result: **PASS** (`12 passed`)

3. `uv run pytest tests/test_llm_multi_provider_handlers.py -x`
- Result: **PASS** (`2 passed`)

## Notes
- During verification, additional strict-handler regressions surfaced in Seedream production and one Gemini test-local fallback handler; both were migrated in this PR so the required acceptance commands complete successfully under strict handler validation.
