### PR TITLE
Fix pop_frame unwrap panic path in VM step loop

### DIFF
--- a/packages/doeff-vm/src/vm_tests.rs
+++ b/packages/doeff-vm/src/vm_tests.rs
@@ -883,6 +883,17 @@ fn test_vm_proto_frame_push_sites_extract_doeff_generator() {
 }
 
 #[test]
+fn test_vm_debt_002_step_loop_does_not_unwrap_pop_frame() {
+    let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/vm.rs"));
+    let runtime_boundary = src.find("\n#[cfg(test)]\nmod tests").unwrap_or(src.len());
+    let runtime_src = &src[..runtime_boundary];
+    assert!(
+        !runtime_src.contains("pop_frame().unwrap()"),
+        "VM-DEBT-002: step loop must not panic via pop_frame().unwrap()"
+    );
+}
+
+#[test]
 fn test_resume_is_not_terminal() {
     let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/vm.rs"));
     let runtime_boundary = src.find("\n#[cfg(test)]\nmod tests").unwrap_or(src.len());


### PR DESCRIPTION
## Summary
- replace `segment.pop_frame().unwrap()` in `step_deliver_or_throw` with a guarded `let Some(frame) = ... else { ... }` path that returns `StepEvent::Error(VMError::internal(...))` instead of panicking.
- move mode extraction to the same mutable segment borrow used for the frame pop, avoiding the panic-prone unwrap path while preserving behavior.
- add regression test `test_vm_debt_002_step_loop_does_not_unwrap_pop_frame` to lock the invariant.

## Acceptance Criteria Evidence
1. VM step loop no longer contains `pop_frame().unwrap()` panic path.
- Verified in code: `packages/doeff-vm/src/vm.rs` now uses guarded pop with explicit internal error.
- Verified by test command:
  - `cd packages/doeff-vm && cargo test test_vm_debt_002_step_loop_does_not_unwrap_pop_frame -- --nocapture`
  - Result: `1 passed; 0 failed`

2. Rust VM extension rebuilt after `.rs` changes.
- Rebuild command:
  - `make sync`
- Evidence from output:
  - `Built doeff-vm @ file:///.../packages/doeff-vm`
  - `cd packages/doeff-vm && maturin develop`
  - `Installed doeff-vm-0.1.0`

3. Targeted runtime verification passes against rebuilt environment.
- `uv run pytest tests/core/test_rust_vm_api_strict.py -q` -> `11 passed`
- `uv run pytest tests/core/test_vm_proto_002_doeff_generator_construction.py -q` -> `5 passed`

## Issue
Refs VM-DEBT-002
