### PR TITLE
Add SAFETY docs for VM unsafe blocks

### DIFF
--- a/packages/doeff-vm/src/py_shared.rs
+++ b/packages/doeff-vm/src/py_shared.rs
@@ -28,6 +28,8 @@ impl PyShared {
         match Arc::try_unwrap(self.0) {
             Ok(py) => py,
             Err(arc) => {
+                // SAFETY: into_inner is only used while executing VM/Python-initiated paths where
+                // the thread is already attached to the Python runtime.
                 let py = unsafe { Python::assume_attached() };
                 arc.clone_ref(py)
             }

--- a/packages/doeff-vm/src/value.rs
+++ b/packages/doeff-vm/src/value.rs
@@ -527,6 +527,8 @@ impl Clone for Value {
 impl Value {
     pub fn from_effect(effect: &crate::effect::Effect) -> Self {
         if let Some(py_obj) = effect.as_python() {
+            // SAFETY: from_effect only clones an existing Py<PyAny> from VM-managed effect values,
+            // and all callers execute under attached Python contexts.
             let py = unsafe { pyo3::Python::assume_attached() };
             return Value::Python(py_obj.clone_ref(py));
         }


### PR DESCRIPTION
## Summary
- Add `// SAFETY:` documentation above the remaining undocumented `unsafe` blocks in the Rust VM:
  - `packages/doeff-vm/src/py_shared.rs`
  - `packages/doeff-vm/src/value.rs`
- Existing `// SAFETY:` documentation in `packages/doeff-vm/src/pyvm.rs` was already present and left unchanged.

## Acceptance Criteria Evidence
Issue: `VM-DEBT-003`

1. All unsafe blocks in VM are documented with `// SAFETY:` comments.
   - Verification command:
     - `rg -n "unsafe" packages/doeff-vm/src`
   - Verification command:
     - loop check for nearby `SAFETY:` comment on each `unsafe` line
   - Result:
     - `All unsafe blocks in packages/doeff-vm/src have SAFETY docs.`

2. Changes implemented in code
   - Files updated:
     - `packages/doeff-vm/src/py_shared.rs`
     - `packages/doeff-vm/src/value.rs`

## Validation Run
- Rebuild per VM note in repo docs:
  - `make sync` (includes `maturin develop` rebuild of `packages/doeff-vm`)
- Python VM-focused tests:
  - `uv run pytest tests/core/test_rust_vm_api_strict.py tests/core/test_vm_proto_002_doeff_generator_construction.py tests/core/test_vm_proto_003_withhandler_metadata.py tests/core/test_vm_proto_004_traceback_data.py tests/core/test_vm_proto_006_effect_creation_context_removal.py`
  - Result: `25 passed`
- Rust focused regression check for touched area:
  - `cargo test --manifest-path packages/doeff-vm/Cargo.toml value::tests::`
  - Result: `4 passed`

## Additional Notes
- Full `cargo test --manifest-path packages/doeff-vm/Cargo.toml` currently reports 4 failures in `vm::vm_tests` unrelated to these doc-only changes (this PR modifies comments only).

Refs: `VM-DEBT-003`
