### PR TITLE
Fix _coerce_handler silent pass-through of non-callables

### DIFF
--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -87,9 +87,7 @@ def _coerce_handler(
     doeff_generator_fn_type = getattr(vm, "DoeffGeneratorFn", None)
     if doeff_generator_fn_type is not None and isinstance(handler, doeff_generator_fn_type):
         return handler
-    if callable(handler):
-        raise TypeError(_format_handler_type_error(api_name=api_name, role=role, value=handler))
-    return handler
+    raise TypeError(_format_handler_type_error(api_name=api_name, role=role, value=handler))
 
 
 def _coerce_program(program: Any) -> Any:

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -52,9 +52,7 @@ def _coerce_handler(handler, *, api_name: str, role: str):
         return handler
     if isinstance(handler, _ext.DoeffGeneratorFn):
         return handler
-    if callable(handler):
-        raise TypeError(_format_handler_type_error(api_name=api_name, role=role, value=handler))
-    return handler
+    raise TypeError(_format_handler_type_error(api_name=api_name, role=role, value=handler))
 
 
 def _coerce_handlers(handlers, *, api_name: str):

--- a/tests/public_api/test_handler_type_validation.py
+++ b/tests/public_api/test_handler_type_validation.py
@@ -14,6 +14,7 @@ from doeff import (
     WithIntercept,
     async_run,
     do,
+    rust_vm,
     run,
 )
 
@@ -82,6 +83,46 @@ def test_withintercept_rejects_plain_callable_with_helpful_message() -> None:
     assert "WithIntercept interceptor must be" in message
     assert "@do" in message
     assert "plain_interceptor" in message
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_type"),
+    [
+        ("not_callable", "str"),
+        (123, "int"),
+        (object(), "object"),
+    ],
+)
+def test_private_rust_vm_coerce_rejects_non_callable_values(
+    value: object,
+    expected_type: str,
+) -> None:
+    with pytest.raises(TypeError) as exc_info:
+        rust_vm._coerce_handler(value, api_name="WithHandler", role="handler")
+
+    message = str(exc_info.value)
+    assert "WithHandler handler must be" in message
+    assert f"type: {expected_type}" in message
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_type"),
+    [
+        ("not_callable", "str"),
+        (123, "int"),
+        (object(), "object"),
+    ],
+)
+def test_private_doeff_vm_coerce_rejects_non_callable_values(
+    value: object,
+    expected_type: str,
+) -> None:
+    with pytest.raises(TypeError) as exc_info:
+        doeff_vm._coerce_handler(value, api_name="WithIntercept", role="interceptor")
+
+    message = str(exc_info.value)
+    assert "WithIntercept interceptor must be" in message
+    assert f"type: {expected_type}" in message
 
 
 def test_withhandler_accepts_do_decorated_handler() -> None:


### PR DESCRIPTION
## Summary
- make `_coerce_handler()` strict in both wrapper layers:
  - `doeff/rust_vm.py`
  - `packages/doeff-vm/doeff_vm/__init__.py`
- remove silent pass-through of unsupported non-callable values
- keep pass-through only for supported handler kinds (`RustHandler`, `PyKleisli`, `DoeffGeneratorFn`)
- add regression tests that directly verify non-callable values are rejected with helpful `TypeError` messages

## Issue
- VM-DEBT-005

## Acceptance Criteria Evidence

1. `_coerce_handler` no longer silently passes through non-callables

Command:
```bash
uv run python - <<'PY'
import doeff_vm
from doeff.rust_vm import _coerce_handler as rust_coerce

cases = [
    ("doeff.rust_vm", rust_coerce, "WithHandler", "handler"),
    ("doeff_vm", doeff_vm._coerce_handler, "WithIntercept", "interceptor"),
]

for label, fn, api_name, role in cases:
    try:
        fn("not_callable", api_name=api_name, role=role)
    except TypeError as exc:
        print(f"{label}: PASS ({str(exc).splitlines()[0]})")
    else:
        print(f"{label}: FAIL (value passed through)")
PY
```

Output:
```text
doeff.rust_vm: PASS (WithHandler handler must be a @do decorated function, PyKleisli, or RustHandler.)
doeff_vm: PASS (WithIntercept interceptor must be a @do decorated function, PyKleisli, or RustHandler.)
```

2. Regression tests pass

Commands:
```bash
uv run pytest tests/public_api/test_handler_type_validation.py
uv run pytest tests/core/test_sa007_spec_gaps.py::test_SA_007_G03_withhandler_constructor_validates_handler_type
```

Output summary:
```text
tests/public_api/test_handler_type_validation.py ............... [100%]
15 passed in 0.03s

tests/core/test_sa007_spec_gaps.py . [100%]
1 passed in 0.01s
```
