### PR TITLE
Replace rust_store.rs panic with Python TypeError

### DIFF
--- a/packages/doeff-vm/src/vm_tests.rs
+++ b/packages/doeff-vm/src/vm_tests.rs
@@ -1423,18 +1423,20 @@ fn test_gap11_with_local_scoped_bindings() {
         Value::String("localhost".to_string()),
     );
 
-    let result = store.with_local(
-        HashMap::from([
-            ("db".to_string(), Value::String("test".to_string())),
-            ("temp".to_string(), Value::Int(42)),
-        ]),
-        |s| {
-            assert_eq!(s.ask("db").unwrap().as_str(), Some("test"));
-            assert_eq!(s.ask("temp").unwrap().as_int(), Some(42));
-            assert_eq!(s.ask("host").unwrap().as_str(), Some("localhost"));
-            "done"
-        },
-    );
+    let result = store
+        .with_local(
+            HashMap::from([
+                ("db".to_string(), Value::String("test".to_string())),
+                ("temp".to_string(), Value::Int(42)),
+            ]),
+            |s| {
+                assert_eq!(s.ask("db").unwrap().as_str(), Some("test"));
+                assert_eq!(s.ask("temp").unwrap().as_int(), Some(42));
+                assert_eq!(s.ask("host").unwrap().as_str(), Some("localhost"));
+                "done"
+            },
+        )
+        .expect("with_local should accept string keys");
     assert_eq!(result, "done");
     // After with_local, old bindings restored, temp removed
     assert_eq!(store.ask("db").unwrap().as_str(), Some("prod"));


### PR DESCRIPTION
## Summary
- Replaced the `expect(...)` panic path in `packages/doeff-vm/src/rust_store.rs` with explicit `PyTypeError` mapping via a fallible key-conversion helper.
- Made `RustStore::with_local(...)` return `PyResult<R>` so key-conversion failures propagate as Python errors instead of aborting.
- Updated the existing Rust VM test that calls `with_local(...)` to handle the new return type.
- Added a regression test that constructs an unhashable Python object and verifies conversion errors are surfaced as `TypeError`.

## Acceptance Evidence
Issue reference: **VM-DEBT-004**

- Panic string removed from `rust_store.rs`:
  - Command: `rg -n "Python string keys must be hashable" packages/doeff-vm/src/rust_store.rs`
  - Result: no matches

- Rust regression test for TypeError mapping:
  - Command: `cd packages/doeff-vm && cargo test py_key_to_hashed_maps_unhashable_to_type_error -- --nocapture`
  - Result: `test rust_store::tests::py_key_to_hashed_maps_unhashable_to_type_error ... ok`

- Existing scoped-binding behavior still passes with new `PyResult` signature:
  - Command: `cd packages/doeff-vm && cargo test test_gap11_with_local_scoped_bindings -- --nocapture`
  - Result: `test vm::vm_tests::test_gap11_with_local_scoped_bindings ... ok`

- Python VM API smoke checks:
  - Command: `uv run pytest tests/core/test_rust_vm_api_strict.py::test_rust_vm_exports_traceback_query_types tests/core/test_rust_vm_api_strict.py::test_run_rejects_non_program_object`
  - Result: `2 passed`

## Notes
- The local issue file at `/Users/s22625/repos/doeff-VAULT/issues/VM-DEBT-004.md` currently contains only metadata/title (no explicit Acceptance Criteria section text), so verification above is aligned to the issue title objective.
