### PR TITLE
Guard @do against async def decoration

### DIFF
--- a/doeff/do.py
+++ b/doeff/do.py
@@ -369,6 +369,11 @@ def do(
 
     if not callable(func):
         raise TypeError(f"@do expects a callable, got {type(func).__name__}")
+    if inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func):
+        raise TypeError(
+            "@do does not support async def functions. "
+            "Use a regular def and yield Await(coroutine) inside @do."
+        )
     do_yield_fn = DoYieldFunction(func)
 
     import doeff_vm as vm

--- a/tests/core/test_do_methods.py
+++ b/tests/core/test_do_methods.py
@@ -4,6 +4,7 @@ import inspect
 from typing import Any
 
 import doeff_vm
+import pytest
 
 from doeff import Program, default_handlers, do, run
 
@@ -87,3 +88,23 @@ def test_do_generator_wrapper_wraps_bridge_generator() -> None:
     assert isinstance(wrapper, doeff_vm.DoeffGenerator)
     assert inspect.isgenerator(wrapper.generator)
     assert not hasattr(wrapper.generator, "__doeff_inner__")
+
+
+def test_do_rejects_async_function_decoration() -> None:
+    with pytest.raises(TypeError, match=r"@do does not support async def functions") as exc_info:
+
+        @do
+        async def bad() -> int:
+            return 1
+
+    assert "yield Await(coroutine)" in str(exc_info.value)
+
+
+def test_do_rejects_async_generator_decoration() -> None:
+    with pytest.raises(TypeError, match=r"@do does not support async def functions") as exc_info:
+
+        @do
+        async def bad_async_gen():
+            yield 1
+
+    assert "yield Await(coroutine)" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add a fail-fast runtime guard in `doeff.do.do` that rejects `async def` functions (including async generators) decorated with `@do`
- return a clear `TypeError` message guiding users to use regular `def` plus `yield Await(coroutine)`
- add regression tests covering both async function and async generator decoration cases

## Acceptance Criteria Evidence (VM-DEBT-006)
Issue scope is "Guard @do against async def decoration".

1. `@do` rejects `async def` decoration immediately with a helpful error
- Verified by runtime command:
  - `uv run python - <<'PY' ... PY`
  - Output:
    - `async_fn: @do does not support async def functions. Use a regular def and yield Await(coroutine) inside @do.`
    - `async_gen: @do does not support async def functions. Use a regular def and yield Await(coroutine) inside @do.`

2. Regression tests enforce this behavior
- `uv run pytest tests/core/test_do_methods.py`
- Output: `6 passed`

3. Existing `@do` call-path behavior remains intact in nearby core tests
- `uv run pytest tests/core/test_call_doexpr_evaluation.py tests/core/test_do_methods.py`
- Output: `12 passed`

## Issue Reference
- VM-DEBT-006
