### PR TITLE
Remove typed handler utility from doeff-conductor

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -13,6 +13,23 @@ rules:
   # EFFECT SYSTEM PATTERNS
   # ---------------------------------------------------------------------------
 
+  - id: no-make-typed-handler
+    languages: [python]
+    severity: ERROR
+    message: >
+      make_typed_handler/make_typed_handlers encode a type-mapping dispatch model
+      that does not belong in doeff. Use @do handler functions with isinstance checks instead.
+    pattern-either:
+      - pattern: |
+          def make_typed_handler(...):
+              ...
+      - pattern: |
+          def make_typed_handlers(...):
+              ...
+    paths:
+      include:
+        - packages/
+
   - id: doeff-no-effect-creation-context-wrapper
     patterns:
       - pattern-either:

--- a/packages/doeff-conductor/src/doeff_conductor/__init__.py
+++ b/packages/doeff-conductor/src/doeff_conductor/__init__.py
@@ -106,7 +106,6 @@ from .handlers import (
     # Handler utilities
     make_scheduled_handler,
     make_scheduled_handler_with_store,
-    make_typed_handlers,
     mock_handlers,
     production_handlers,
 )
@@ -202,7 +201,6 @@ __all__ = [
     "make_blocking_scheduled_handler_with_store",
     "make_scheduled_handler",
     "make_scheduled_handler_with_store",
-    "make_typed_handlers",
     # Handler utilities
     "mock_handlers",
     "multi_agent",


### PR DESCRIPTION
## Summary
- Removed `make_typed_handlers` from `doeff-conductor` handlers API and exports.
- Updated `run_sync()` to accept protocol handler callable(s) directly without typed-handler normalization.
- Migrated all `doeff-conductor` example/tutorial callsites to explicit `@do` protocol handlers using `isinstance` + `Pass`.
- Added semgrep rule `no-make-typed-handler` to ban new `make_typed_handler` / `make_typed_handlers` definitions under `packages/`.

## Acceptance Criteria Verification
- [x] `make_typed_handler` removed from doeff-agents  
  Evidence: `rg -n "make_typed_handler\\b|make_typed_handlers\\b" packages/doeff-agents packages/doeff-conductor -S` returned no matches.
- [x] `make_typed_handlers` removed from doeff-conductor  
  Evidence: same search result (no matches).
- [x] All callers converted to proper `@do` handlers  
  Evidence: `rg -n "def workflow_handler\\(effect: Effect, k\\)" packages/doeff-conductor/examples packages/doeff-conductor/docs/tutorial.md -S`.
- [x] Examples and docs updated  
  Evidence: updated files under `packages/doeff-conductor/examples/` and `packages/doeff-conductor/docs/tutorial.md`.
- [x] Exports removed from `__init__.py`  
  Evidence: `make_typed_handlers` removed from `packages/doeff-conductor/src/doeff_conductor/__init__.py` and `packages/doeff-conductor/src/doeff_conductor/handlers/__init__.py`.
- [x] `uv run pytest packages/doeff-agents/tests/ -q` passes  
  Output: `9 passed in 0.44s`
- [x] `uv run pytest packages/doeff-conductor/tests/ -q` passes  
  Output: `217 passed, 2 skipped, 78 warnings in 9.82s`
- [x] `uv run pytest -q` passes  
  Output: `801 passed, 21 warnings in 34.45s`

## Semgrep Verification
- Ran `make lint-semgrep` after adding the rule. The command reports pre-existing repository findings unrelated to this change (same as baseline in this branch).
- Verified the new rule itself is clean on the migrated code by running:
  `uv run semgrep --config /tmp/semgrep_no_typed_handler.yaml packages/ --error`
  Result: `0 findings`.

## Issue
Refs: `KLEISLI-REMOVE-TYPED-HANDLERS`
