### PR TITLE
Push WithIntercept type filtering into Rust VM

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -1222,6 +1222,27 @@ rules:
       category: doexpr-hierarchy
       rationale: "canonical WithHandler signature is (handler, expr: DoExpr)"
 
+  - id: no-withintercept-python-type-wrapper
+    patterns:
+      - pattern-inside: |
+          def WithIntercept(...):
+              ...
+      - pattern: |
+          @do
+          def $WRAPPER(...):
+              ...
+    paths:
+      include:
+        - "**/doeff/rust_vm.py"
+    message: >
+      WithIntercept type filtering must be done in the Rust VM, not via Python @do wrappers.
+      Pass types= directly to vm.WithIntercept instead of creating a filtered wrapper.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: architecture
+      rationale: "WithIntercept filtering belongs to Rust VM dispatch"
+
   - id: doeff-doexpr-root-check-to-generator-strict
     patterns:
       - pattern-inside: |

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -369,23 +369,14 @@ def WithIntercept(
     normalized_types = _normalize_intercept_types(types)
     metadata = _with_intercept_metadata(f)
 
-    if normalized_types is not None:
-        from doeff.do import do
-
-        original_f = f
-
-        @do
-        def filtered(effect: Any) -> Any:
-            matches = isinstance(effect, normalized_types)
-            should_call = (mode == "include" and matches) or (mode == "exclude" and not matches)
-            if should_call:
-                return original_f(effect)
-            return effect
-
-        f = filtered
-
     vm = _vm()
-    return vm.WithIntercept(f, expr, metadata)
+    return vm.WithIntercept(
+        f,
+        expr,
+        types=normalized_types,
+        mode=mode,
+        meta=metadata,
+    )
 
 
 def __getattr__(name: str) -> Any:

--- a/packages/doeff-vm/doeff_vm/__init__.py
+++ b/packages/doeff-vm/doeff_vm/__init__.py
@@ -75,13 +75,19 @@ def _install_validated_runtime_api() -> None:
         coerced_handler = _coerce_handler(handler, api_name="WithHandler", role="handler")
         return raw_with_handler(coerced_handler, expr, return_clause)
 
-    def validated_with_intercept(f, expr, meta=None):
+    def validated_with_intercept(f, expr, types=None, mode="include", meta=None):
         coerced_interceptor = _coerce_handler(
             f,
             api_name="WithIntercept",
             role="interceptor",
         )
-        return raw_with_intercept(coerced_interceptor, expr, meta)
+        return raw_with_intercept(
+            coerced_interceptor,
+            expr,
+            types=types,
+            mode=mode,
+            meta=meta,
+        )
 
     def validated_run(program, handlers=(), env=None, store=None, trace=False):
         _validate_do_handler_annotations(handlers)

--- a/packages/doeff-vm/src/frame.rs
+++ b/packages/doeff-vm/src/frame.rs
@@ -3,9 +3,9 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use crate::ir_stream::IRStreamRef;
 use crate::do_ctrl::DoCtrl;
 use crate::ids::{DispatchId, Marker};
+use crate::ir_stream::IRStreamRef;
 use crate::py_shared::PyShared;
 use crate::step::PyException;
 use crate::value::Value;
@@ -76,6 +76,7 @@ pub struct InterceptorContinuation {
     pub chain: Arc<Vec<Marker>>,
     pub next_idx: usize,
     pub interceptor_metadata: Option<CallMetadata>,
+    pub guard_eval_depth: bool,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Move `WithIntercept` type/mode filtering from Python wrapper logic into Rust VM runtime.
- Extend Rust `DoCtrl::WithIntercept` and VM interceptor state to carry `types` + `mode` and evaluate filter matches in Rust.
- Update PyO3 binding (`PyWithIntercept`) and conversion paths so `types`/`mode` are validated and round-tripped by Rust.
- Remove the Python `@do` filtered-wrapper pattern from `doeff/rust_vm.py`; pass `types` and `mode` directly to `vm.WithIntercept`.
- Add semgrep rule `no-withintercept-python-type-wrapper` to prevent reintroducing the old Python wrapper pattern.
- Add regression test covering direct `doeff_vm.WithIntercept(..., types=..., mode=...)` behavior.

## Acceptance Evidence (VM-DEBT-008)
The linked issue file currently only contains the title (no explicit Acceptance Criteria block), so verification was done against the task intent: Rust-owned filtering + behavior preservation.

- Rust VM now owns filter fields and decision logic:
  - `packages/doeff-vm/src/do_ctrl.rs` (`InterceptMode`, `DoCtrl::WithIntercept { types, mode, ... }`)
  - `packages/doeff-vm/src/vm.rs` (`should_invoke_interceptor`, filtered invocation path)
  - `packages/doeff-vm/src/interceptor_state.rs` (`types`/`mode` persisted in `InterceptorEntry`)
- Python wrapper no longer builds an inline `@do` filter:
  - `doeff/rust_vm.py` now calls `vm.WithIntercept(..., types=..., mode=..., meta=...)` directly.
- Rust binding validates and accepts `types`/`mode`:
  - `packages/doeff-vm/src/pyvm.rs` (`PyWithIntercept` signature + validation helpers)
- Guardrail added:
  - `.semgrep.yaml` rule `no-withintercept-python-type-wrapper`

## Validation Commands
- Rebuild VM extension (required after `.rs` changes):
  - `make sync` (ran after Rust edits)
- Tests:
  - `uv run pytest tests/test_with_intercept.py tests/test_segment_owned_state.py tests/public_api/test_handler_type_validation.py tests/effects/test_local_handler_ask.py`
  - Result: `81 passed`
- Semgrep:
  - `make lint-semgrep` was executed and fails due **61 pre-existing blocking findings** in unrelated files (baseline, not introduced here).
  - Targeted check confirms new rule does not fire on updated code:
    - `semgrep --config .semgrep.yaml doeff/rust_vm.py --json ...`
    - Result: `new rule did not fire`

## Issue Reference
- VM-DEBT-008
