### PR TITLE
Fix top-level WithHandler type extraction path

### DIFF
--- a/doeff/__init__.py
+++ b/doeff/__init__.py
@@ -128,6 +128,7 @@ from doeff.graph_snapshot import (
 from doeff.kleisli import KleisliProgram
 from doeff.program import Program, ProgramBase
 from doeff.rust_vm import (
+    WithHandler,
     WithIntercept,
     async_run,
     default_async_handlers,
@@ -161,7 +162,6 @@ capture = capture_graph
 
 # G8: lazy re-exports of VM dispatch primitives from doeff_vm
 _VM_LAZY_EXPORTS = {
-    "WithHandler",
     "Pure",
     "Apply",
     "Expand",

--- a/tests/core/test_spec_gaps.py
+++ b/tests/core/test_spec_gaps.py
@@ -66,12 +66,12 @@ class TestG8ImportPaths:
 
         assert K is not None
 
-    def test_identity_matches_doeff_vm(self) -> None:
-        """doeff.WithHandler is doeff_vm.WithHandler (same object)."""
+    def test_identity_matches_public_exports(self) -> None:
+        """doeff.WithHandler is doeff.rust_vm.WithHandler (same object)."""
         import doeff
         import doeff_vm
 
-        assert doeff.WithHandler is doeff_vm.WithHandler
+        assert doeff.WithHandler is doeff.rust_vm.WithHandler
         assert doeff.Resume is doeff_vm.Resume
         assert doeff.Delegate is doeff_vm.Delegate
         assert doeff.Transfer is doeff_vm.Transfer

--- a/tests/public_api/test_handler_type_validation.py
+++ b/tests/public_api/test_handler_type_validation.py
@@ -136,6 +136,22 @@ def test_withhandler_accepts_rust_handler() -> None:
     assert type(ctrl).__name__ == "WithHandler"
 
 
+def test_withhandler_public_import_matches_rust_vm_type_extraction() -> None:
+    from doeff import WithHandler as doeff_withhandler
+    from doeff.rust_vm import WithHandler as rust_vm_withhandler
+
+    @do
+    def typed_handler(_effect: Ping, _k):
+        yield Pass()
+
+    doeff_ctrl = doeff_withhandler(typed_handler, body())
+    rust_ctrl = rust_vm_withhandler(typed_handler, body())
+
+    assert doeff_ctrl.types == (Ping,)
+    assert rust_ctrl.types == (Ping,)
+    assert doeff_withhandler is rust_vm_withhandler
+
+
 def test_run_accepts_do_decorated_handler() -> None:
     result = run(body(), handlers=[do_handler])
     assert result.is_ok()


### PR DESCRIPTION
## Summary
- Route top-level `doeff.WithHandler` to `doeff.rust_vm.WithHandler`.
- Remove `WithHandler` from the lazy `doeff_vm` export path so annotation-based type extraction is preserved.
- Add regression coverage proving import-path parity and object identity.
- Update the G8 spec-gap expectation to match the corrected public export contract.

## Issue
- WITHHANDLER-IMPORT-BUG

## Acceptance Criteria Evidence
1. `from doeff import WithHandler; node = WithHandler(typed_handler, expr); assert node.types == (MyEffect,)`
- Command:
  - `uv run python - <<'PY' ... PY`
- Output:
  - `node1.types (<class '__main__.MyEffect'>,)`

2. `from doeff.rust_vm import WithHandler` produces same result
- Same command output:
  - `node2.types (<class '__main__.MyEffect'>,)`

3. Both paths are the same object (`is`) or produce identical behavior
- Same command output:
  - `same_object True`

4. `uv run pytest` pass
- Command:
  - `uv run pytest`
- Output summary:
  - `830 passed, 1 warning in 26.21s`

5. Regression test added
- Added:
  - `tests/public_api/test_handler_type_validation.py::test_withhandler_public_import_matches_rust_vm_type_extraction`
- Command:
  - `uv run pytest tests/public_api/test_handler_type_validation.py::test_withhandler_public_import_matches_rust_vm_type_extraction -q`
- Output:
  - `1 passed in 0.01s`

## Changed Files
- `doeff/__init__.py`
- `tests/public_api/test_handler_type_validation.py`
- `tests/core/test_spec_gaps.py`
