### PR TITLE
Fix WithHandler type-filter skip scope loss after filtered dispatch

### DIFF
--- a/packages/doeff-vm/src/vm.rs
+++ b/packages/doeff-vm/src/vm.rs
@@ -3138,20 +3138,41 @@ impl VM {
                 })?;
 
         let mut selected: Option<(usize, HandlerChainEntry)> = None;
+        let mut first_type_filtered_skip: Option<(usize, HandlerChainEntry)> = None;
         for (idx, entry) in handler_chain.iter().enumerate() {
-            if entry.handler.can_handle(&effect)?
-                && self.should_invoke_handler(entry, &effect_obj).map_err(|err| {
-                    VMError::python_error(format!(
-                        "failed to evaluate WithHandler type filter: {err:?}"
-                    ))
-                })?
-            {
+            let can_handle = entry.handler.can_handle(&effect)?;
+            if !can_handle {
+                continue;
+            }
+
+            let should_invoke = self.should_invoke_handler(entry, &effect_obj).map_err(|err| {
+                VMError::python_error(format!(
+                    "failed to evaluate WithHandler type filter: {err:?}"
+                ))
+            })?;
+            if should_invoke {
                 selected = Some((idx, entry.clone()));
                 break;
             }
+
+            if first_type_filtered_skip.is_none() {
+                first_type_filtered_skip = Some((idx, entry.clone()));
+            }
         }
+        let mut bootstrap_with_pass = false;
         let (handler_idx, selected) = match selected {
-            Some(found) => found,
+            Some(found) => {
+                if let Some(skipped) = &first_type_filtered_skip {
+                    if skipped.0 < found.0 {
+                        bootstrap_with_pass = true;
+                        skipped.clone()
+                    } else {
+                        found
+                    }
+                } else {
+                    found
+                }
+            }
             None => {
                 if let Some(original) = original_exception.clone() {
                     self.current_seg_mut().mode = Mode::Throw(original);
@@ -3229,6 +3250,12 @@ impl VM {
                 .as_ref()
                 .map(|(_, _, _, source_line)| *source_line),
         );
+
+        // Preserve handler scope when a type-filtered handler is skipped: this mirrors the
+        // `Pass()` forwarding topology without invoking the skipped handler body.
+        if bootstrap_with_pass {
+            return Ok(self.handle_forward(ForwardKind::Pass, effect));
+        }
 
         if handler.py_identity().is_some() {
             self.register_continuation(k_user.clone());


### PR DESCRIPTION
## Summary
- Fixes handler scope loss when `WithHandler` type filtering skips an inner handler and an outer handler handles the same dispatch.
- In `VM::start_dispatch`, track when a `can_handle=true` handler is skipped by type filter.
- When a later handler is selected after such a skip, bootstrap dispatch through `handle_forward(ForwardKind::Pass, ...)` so topology matches `Pass()` forwarding semantics and keeps inner prompt scope visible for subsequent effects.

## Acceptance Criteria Evidence
Issue: `TYPE-FILTER-SCOPE-LOSS`

1. `TestTypedHandler` matches `TestIsinstancePass`:
- Command: `uv run pytest tests/test_with_handler_type_filter_regression.py::TestIsinstancePass tests/test_with_handler_type_filter_regression.py::TestTypedHandler -q`
- Output: `12 passed in 0.02s`

2. Existing type-filter tests still pass:
- Command: `uv run pytest tests/test_with_handler_type_filter.py -q`
- Output: `19 passed in 0.05s`

3. Type-filter skip preserves handler scope equivalence with `Pass()`:
- Command: `uv run pytest tests/test_with_handler_type_filter_regression.py -q`
- Output: `12 passed in 0.03s`
- Includes the `Beta -> Alpha` and `Alpha -> Beta -> Alpha` regressions that previously routed `Alpha` to fallback after a typed skip.

## Validation
- Rebuilt Rust VM extension after `.rs` changes:
  - Command: `make sync`
  - Result: `doeff-vm` rebuilt via `maturin develop` successfully.
- Additional guard check:
  - Command: `uv run pytest tests/core/test_pass_primitive.py -q`
  - Output: `3 passed in 0.01s`
