### PR TITLE
TRACE-HANDLER-STACK: improve default traceback handler rendering

### DIFF
--- a/doeff/traceback.py
+++ b/doeff/traceback.py
@@ -348,8 +348,37 @@ else:
                 "returned": "✓",
                 "threw": "✗",
             }
-            parts = [f"{entry.handler_name}{marker.get(entry.status, '?')}" for entry in stack]
-            return f"[{' > '.join(parts)}]" if parts else "[]"
+            lines = ["handlers:"]
+            if not stack:
+                lines.append("  (empty)")
+                return "\n".join(lines)
+
+            all_pending = all(entry.status == "pending" for entry in stack)
+            pending_count = 0
+            for entry in stack:
+                if entry.status == "pending":
+                    pending_count += 1
+                    continue
+
+                if pending_count:
+                    lines.append(f"  · {pending_count} pending")
+                    pending_count = 0
+
+                if entry.source_file is None or entry.source_line is None:
+                    if entry.handler_kind == "rust_builtin":
+                        location = "(rust_builtin)"
+                    else:
+                        location = "(unknown)"
+                else:
+                    location = f"{entry.source_file}:{entry.source_line}"
+
+                lines.append(f"  {entry.handler_name} {marker.get(entry.status, '?')}  {location}")
+
+            if pending_count:
+                suffix = " (no handler matched)" if all_pending else ""
+                lines.append(f"  · {pending_count} pending{suffix}")
+
+            return "\n".join(lines)
 
         def _render_effect_result(
             self,
@@ -383,18 +412,13 @@ else:
             previous_spawn_boundary: SpawnBoundary | None = None
             for entry in self.active_chain:
                 if isinstance(entry, ProgramYield):
+                    if entry.is_handler:
+                        continue
                     previous_handler_stack = None
                     previous_spawn_boundary = None
-                    if entry.is_handler:
-                        kind = entry.handler_kind or "unknown"
-                        lines.append(
-                            f"  ⚙ {entry.function_name}()  "
-                            f"{entry.source_file}:{entry.source_line} ({kind})"
-                        )
-                    else:
-                        lines.append(
-                            f"  {entry.function_name}()  {entry.source_file}:{entry.source_line}"
-                        )
+                    lines.append(
+                        f"  {entry.function_name}()  {entry.source_file}:{entry.source_line}"
+                    )
                     lines.append(f"    yield {entry.sub_program_repr}")
                     lines.append("")
                     continue
@@ -404,16 +428,17 @@ else:
                         previous_handler_stack is not None
                         and entry.handler_stack == previous_handler_stack
                     ):
-                        stack_line = "[same]"
+                        stack_lines = ("(same handlers)",)
                     else:
-                        stack_line = self._render_handler_stack(entry.handler_stack)
+                        stack_lines = tuple(self._render_handler_stack(entry.handler_stack).splitlines())
                     previous_handler_stack = entry.handler_stack
                     previous_spawn_boundary = None
                     lines.append(
                         f"  {entry.function_name}()  {entry.source_file}:{entry.source_line}"
                     )
                     lines.append(f"    yield {entry.effect_repr}")
-                    lines.append(f"    {stack_line}")
+                    for stack_line in stack_lines:
+                        lines.append(f"    {stack_line}")
                     lines.append(f"    {self._render_effect_result(entry.result)}")
                     lines.append("")
                     continue

--- a/tests/core/test_doeff_trace_stderr.py
+++ b/tests/core/test_doeff_trace_stderr.py
@@ -97,6 +97,6 @@ def test_doeff_trace_renders_active_chain(capsys: pytest.CaptureFixture[str]) ->
     captured = capsys.readouterr()
     assert "exploding_handler" in captured.err
     assert "handler exploded" in captured.err
-    assert "exploding_handler✗" in captured.err
+    assert "exploding_handler ✗" in captured.err
     assert "·" in captured.err
     assert "Boom" in captured.err

--- a/tests/core/test_spec_trace_001_examples.py
+++ b/tests/core/test_spec_trace_001_examples.py
@@ -18,7 +18,6 @@ _DEFAULT_HANDLER_NAMES = (
     "ReaderHandler",
     "StateHandler",
 )
-_HANDLER_STATUS_MARKERS = {"⚡", "·", "↗", "⇆", "✓", "⇢", "✗"}
 
 
 def _line_of(function: object, needle: str) -> int:
@@ -29,34 +28,12 @@ def _line_of(function: object, needle: str) -> int:
     raise AssertionError(f"failed to find {needle!r} in source")
 
 
-def _handler_tokens(stack_line: str) -> list[str]:
-    stripped = stack_line.strip()
-    if stripped == "[same]":
-        return []
-    assert stripped.startswith("[")
-    assert stripped.endswith("]")
-    body = stripped[1:-1]
-    if body == "":
-        return []
-    return [token.strip() for token in body.split(" > ")]
-
-
-def _token_handler_name(token: str) -> str:
-    if token and token[-1] in _HANDLER_STATUS_MARKERS:
-        return token[:-1]
-    return token
-
-
-def _token_has_handler_name(token: str, handler_name: str) -> bool:
-    return _token_handler_name(token).endswith(handler_name)
-
-
-def _stack_line_after_effect(
+def _handler_lines_after_effect(
     lines: list[str],
     *,
     effect_fragment: str,
     detail_fragment: str | None = None,
-) -> str:
+) -> list[str]:
     for idx, raw in enumerate(lines):
         text = raw.strip()
         if not text.startswith("yield "):
@@ -66,13 +43,25 @@ def _stack_line_after_effect(
         if detail_fragment is not None and detail_fragment not in text:
             continue
 
-        for follow in lines[idx + 1 :]:
-            candidate = follow.strip()
-            if candidate.startswith("["):
-                return candidate
-            if candidate.startswith(("yield ", "raise ")):
+        for follow_idx in range(idx + 1, len(lines)):
+            candidate = lines[follow_idx].strip()
+            if candidate == "handlers:":
+                block: list[str] = []
+                for entry in lines[follow_idx + 1 :]:
+                    entry_text = entry.strip()
+                    if entry_text == "":
+                        break
+                    if entry_text.startswith(("→ ", "✗ ", "⇢ ", "yield ", "raise ", "handlers:")):
+                        break
+                    if entry_text == "(same handlers)":
+                        break
+                    block.append(entry_text)
+                return block
+            if candidate == "(same handlers)":
+                return [candidate]
+            if candidate.startswith(("yield ", "raise ", "→ ", "✗ ", "⇢ ")):
                 break
-    raise AssertionError(f"stack line not found after effect {effect_fragment!r}")
+    raise AssertionError(f"handler lines not found after effect {effect_fragment!r}")
 
 
 def _first_line_index(lines: list[str], fragment: str) -> int:
@@ -82,19 +71,12 @@ def _first_line_index(lines: list[str], fragment: str) -> int:
     raise AssertionError(f"line containing {fragment!r} not found")
 
 
-def _assert_default_handlers_visible(stack_line: str) -> None:
-    tokens = _handler_tokens(stack_line)
-    assert tokens, stack_line
-    assert "..." not in stack_line
-
-    names_to_marker: dict[str, str] = {}
-    for token in tokens:
-        if token and token[-1] in _HANDLER_STATUS_MARKERS:
-            names_to_marker[token[:-1]] = token[-1]
-
-    for handler_name in _DEFAULT_HANDLER_NAMES:
-        assert handler_name in names_to_marker, stack_line
-        assert names_to_marker[handler_name] in _HANDLER_STATUS_MARKERS
+def _assert_default_handlers_visible(handler_lines: list[str]) -> None:
+    assert handler_lines
+    assert all("..." not in line for line in handler_lines)
+    assert any(name in line for line in handler_lines for name in _DEFAULT_HANDLER_NAMES) or any(
+        "pending" in line for line in handler_lines
+    )
 
 
 def _assert_basic_structure(rendered: str, *, exception_type: str) -> list[str]:
@@ -103,9 +85,10 @@ def _assert_basic_structure(rendered: str, *, exception_type: str) -> list[str]:
     assert any("()" in line for line in lines)
     assert any("yield " in line for line in lines)
 
-    stack_lines = [line.strip() for line in lines if line.strip().startswith("[")]
-    assert stack_lines
-    assert any(">" in line or line == "[same]" for line in stack_lines)
+    handler_markers = [
+        line.strip() for line in lines if line.strip() in {"handlers:", "(same handlers)"}
+    ]
+    assert handler_markers
     assert any("→ resumed" in line or "✗ " in line or "⇢ " in line for line in lines)
     assert lines[-1].startswith(exception_type)
     return lines
@@ -163,12 +146,12 @@ def test_example_1_nested_program_failure() -> None:
     assert "<builtins.PyAsk" not in rendered
     assert " object at 0x" not in rendered
 
-    timeout_stack = _stack_line_after_effect(
+    timeout_handlers = _handler_lines_after_effect(
         lines,
         effect_fragment="Ask(",
         detail_fragment="timeout",
     )
-    _assert_default_handlers_visible(timeout_stack)
+    _assert_default_handlers_visible(timeout_handlers)
 
     source_file = inspect.getsourcefile(fetch_config.original_generator)
     assert source_file is not None
@@ -198,19 +181,15 @@ def test_example_2_custom_handler_with_withhandler() -> None:
     rendered = _render_failure(WithHandler(auth_handler, WithHandler(rate_limiter, call_api())))
     lines = _assert_basic_structure(rendered, exception_type="ConnectionError")
 
-    rate_limit_stack = _stack_line_after_effect(
+    rate_limit_handlers = _handler_lines_after_effect(
         lines,
         effect_fragment="Ask(",
         detail_fragment="rate_limit",
     )
-    tokens = _handler_tokens(rate_limit_stack)
-    assert tokens
-    assert _token_has_handler_name(tokens[0], "rate_limiter"), rate_limit_stack
-    assert any(
-        _token_has_handler_name(token, "auth_handler") and token.endswith("·")
-        for token in tokens
-    )
-    _assert_default_handlers_visible(rate_limit_stack)
+    assert rate_limit_handlers
+    assert any("rate_limiter ✓" in line for line in rate_limit_handlers)
+    assert any("pending" in line for line in rate_limit_handlers)
+    _assert_default_handlers_visible(rate_limit_handlers)
     assert "Ask('token')" not in rendered
     assert 'Ask("token")' not in rendered
     assert "→ resumed with" in rendered
@@ -240,12 +219,12 @@ def test_example_3_handler_throws() -> None:
     )
     lines = _assert_basic_structure(rendered, exception_type="TypeError")
 
-    stack_line = _stack_line_after_effect(
+    handler_lines = _handler_lines_after_effect(
         lines,
         effect_fragment="Put(",
         detail_fragment="result",
     )
-    assert "strict_handler✗" in stack_line
+    assert any("strict_handler ✗" in line for line in handler_lines)
 
     result_line = next(line.strip() for line in lines if "raised TypeError" in line)
     assert result_line.startswith("✗ ")
@@ -262,13 +241,13 @@ def test_example_4_missing_env_key() -> None:
     rendered = _render_failure(needs_db())
     lines = _assert_basic_structure(rendered, exception_type="MissingEnvKeyError")
 
-    stack_line = _stack_line_after_effect(
+    handler_lines = _handler_lines_after_effect(
         lines,
         effect_fragment="Ask(",
         detail_fragment="database_url",
     )
-    assert "LazyAskHandler⇆" in stack_line
-    assert "ReaderHandler✗" in stack_line
+    assert any("LazyAskHandler ⇆" in line for line in handler_lines)
+    assert any("ReaderHandler ✗" in line for line in handler_lines)
     assert "MissingEnvKeyError" in rendered
     assert "database_url" in rendered
 
@@ -292,16 +271,13 @@ def test_example_5_handler_stack_changes() -> None:
     rendered = _render_failure(outer(), store={"x": 0, "y": 0})
     lines = _assert_basic_structure(rendered, exception_type="ValueError")
 
-    outer_stack = _stack_line_after_effect(lines, effect_fragment="Put(", detail_fragment='"x"')
-    inner_stack = _stack_line_after_effect(lines, effect_fragment="Put(", detail_fragment='"y"')
-    assert outer_stack != inner_stack
-    assert "my_handler" not in outer_stack
-
-    inner_tokens = _handler_tokens(inner_stack)
-    assert inner_tokens
-    assert _token_has_handler_name(inner_tokens[0], "my_handler"), inner_stack
-    _assert_default_handlers_visible(outer_stack)
-    _assert_default_handlers_visible(inner_stack)
+    outer_handlers = _handler_lines_after_effect(lines, effect_fragment="Put(", detail_fragment='"x"')
+    inner_handlers = _handler_lines_after_effect(lines, effect_fragment="Put(", detail_fragment='"y"')
+    assert outer_handlers != inner_handlers
+    assert not any("my_handler" in line for line in outer_handlers)
+    assert any("my_handler" in line for line in inner_handlers)
+    _assert_default_handlers_visible(outer_handlers)
+    _assert_default_handlers_visible(inner_handlers)
 
 
 def test_example_8_spawn_chain() -> None:

--- a/tests/core/test_traceback_format_default.py
+++ b/tests/core/test_traceback_format_default.py
@@ -98,17 +98,17 @@ def _render_single_delegated_handler(handler_name: str) -> str:
 
 def test_format_default_shows_sync_await_handler_when_delegated() -> None:
     rendered = _render_single_delegated_handler("sync_await_handler")
-    assert "sync_await_handler⇆" in rendered
+    assert "sync_await_handler ⇆" in rendered
 
 
 def test_format_default_shows_async_await_handler_when_delegated() -> None:
     rendered = _render_single_delegated_handler("async_await_handler")
-    assert "async_await_handler⇆" in rendered
+    assert "async_await_handler ⇆" in rendered
 
 
 def test_format_default_shows_rust_await_handler_when_delegated() -> None:
     rendered = _render_single_delegated_handler("AwaitHandler")
-    assert "AwaitHandler⇆" in rendered
+    assert "AwaitHandler ⇆" in rendered
 
 
 def test_format_default_shows_every_handler_and_status_marker() -> None:
@@ -156,10 +156,15 @@ def test_format_default_shows_every_handler_and_status_marker() -> None:
     )
 
     rendered = tb.format_default()
-    assert (
-        "[h_active⚡ > h_pending· > h_passed↗ > h_delegated⇆ > h_resumed✓ > "
-        "h_transferred⇢ > h_returned✓ > h_threw✗]"
-    ) in rendered
+    assert "handlers:" in rendered
+    assert "h_active ⚡" in rendered
+    assert "· 1 pending" in rendered
+    assert "h_passed ↗" in rendered
+    assert "h_delegated ⇆" in rendered
+    assert "h_resumed ✓" in rendered
+    assert "h_transferred ⇢" in rendered
+    assert "h_returned ✓" in rendered
+    assert "h_threw ✗" in rendered
 
 
 def test_format_default_distinguishes_passed_and_delegated_markers() -> None:
@@ -194,7 +199,9 @@ def test_format_default_distinguishes_passed_and_delegated_markers() -> None:
     )
 
     rendered = tb.format_default()
-    assert "[h_passed↗ > h_delegated⇆ > h_resumed✓]" in rendered
+    assert "h_passed ↗" in rendered
+    assert "h_delegated ⇆" in rendered
+    assert "h_resumed ✓" in rendered
 
 
 def test_format_default_program_yield() -> None:
@@ -246,8 +253,9 @@ def test_format_default_handler_program_yield_python() -> None:
     )
 
     rendered = tb.format_default()
-    assert "⚙ analyze_video_handler()  video.py:164 (python)" in rendered
-    assert "yield _lower_analyze_video()" in rendered
+    assert "⚙ " not in rendered
+    assert "analyze_video_handler()  video.py:164" not in rendered
+    assert "yield _lower_analyze_video()" not in rendered
 
 
 def test_format_default_handler_program_yield_rust_builtin() -> None:
@@ -273,8 +281,9 @@ def test_format_default_handler_program_yield_rust_builtin() -> None:
     )
 
     rendered = tb.format_default()
-    assert "⚙ StateHandler()  <rust>:0 (rust_builtin)" in rendered
-    assert "yield [MISSING] <sub_program>" in rendered
+    assert "⚙ " not in rendered
+    assert "(rust_builtin)" not in rendered
+    assert "yield [MISSING] <sub_program>" not in rendered
 
 
 def test_format_default_effect_yield_with_markers() -> None:
@@ -304,7 +313,8 @@ def test_format_default_effect_yield_with_markers() -> None:
     )
 
     rendered = tb.format_default()
-    assert "[h1⇆ > h2✓]" in rendered
+    assert "h1 ⇆" in rendered
+    assert "h2 ✓" in rendered
     assert "→ resumed with None" in rendered
 
 
@@ -345,9 +355,188 @@ def test_format_default_handler_stack_same() -> None:
     )
 
     rendered = tb.format_default()
-    stack_line = "[h1⇆ > h2✓]"
-    assert rendered.count(stack_line) == 1
-    assert rendered.count("[same]") == 1
+    assert rendered.count("h1 ⇆") == 1
+    assert rendered.count("h2 ✓") == 1
+    assert rendered.count("(same handlers)") == 1
+
+
+def test_format_default_handler_stack_shows_source_locations() -> None:
+    tb = _tb(
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 7,
+                "effect_repr": "Ask('x')",
+                "handler_stack": [
+                    {
+                        "handler_name": "py_handler",
+                        "handler_kind": "python",
+                        "source_file": "handlers/my_handler.py",
+                        "source_line": 42,
+                        "status": "resumed",
+                    },
+                    {
+                        "handler_name": "StateHandler",
+                        "handler_kind": "rust_builtin",
+                        "source_file": None,
+                        "source_line": None,
+                        "status": "threw",
+                    },
+                ],
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "StateHandler",
+                    "exception_repr": "RuntimeError('boom')",
+                },
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 8,
+                "exception_type": "RuntimeError",
+                "message": "boom",
+            },
+        ]
+    )
+
+    rendered = tb.format_default()
+    assert "handlers:" in rendered
+    assert "py_handler ✓  handlers/my_handler.py:42" in rendered
+    assert "StateHandler ✗  (rust_builtin)" in rendered
+
+
+def test_format_default_handler_stack_collapses_pending_groups() -> None:
+    tb = _tb(
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 9,
+                "effect_repr": "Ping()",
+                "handler_stack": [
+                    {"handler_name": "pending_1", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "pending_2", "handler_kind": "python", "status": "pending"},
+                    {
+                        "handler_name": "active_handler",
+                        "handler_kind": "python",
+                        "source_file": "handlers/active.py",
+                        "source_line": 10,
+                        "status": "resumed",
+                    },
+                    {"handler_name": "pending_3", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "pending_4", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "pending_5", "handler_kind": "python", "status": "pending"},
+                ],
+                "result": {"kind": "resumed", "value_repr": "1"},
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 10,
+                "exception_type": "RuntimeError",
+                "message": "boom",
+            },
+        ]
+    )
+
+    rendered = tb.format_default()
+    assert "· 2 pending" in rendered
+    assert "active_handler ✓  handlers/active.py:10" in rendered
+    assert "· 3 pending" in rendered
+    assert "pending_1" not in rendered
+    assert "pending_5" not in rendered
+
+
+def test_format_default_handler_stack_all_pending_shows_no_match() -> None:
+    tb = _tb(
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 11,
+                "effect_repr": "Ping()",
+                "handler_stack": [
+                    {"handler_name": "p1", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "p2", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "p3", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "p4", "handler_kind": "python", "status": "pending"},
+                ],
+                "result": {"kind": "active"},
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 12,
+                "exception_type": "RuntimeError",
+                "message": "boom",
+            },
+        ]
+    )
+
+    rendered = tb.format_default()
+    assert "· 4 pending (no handler matched)" in rendered
+
+
+def test_format_default_handler_stack_mixed_pending_groups_keep_order() -> None:
+    tb = _tb(
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 13,
+                "effect_repr": "Ping()",
+                "handler_stack": [
+                    {"handler_name": "p1", "handler_kind": "python", "status": "pending"},
+                    {
+                        "handler_name": "delegate_handler",
+                        "handler_kind": "python",
+                        "source_file": "handlers/delegate.py",
+                        "source_line": 7,
+                        "status": "delegated",
+                    },
+                    {"handler_name": "p2", "handler_kind": "python", "status": "pending"},
+                    {"handler_name": "p3", "handler_kind": "python", "status": "pending"},
+                    {
+                        "handler_name": "throw_handler",
+                        "handler_kind": "python",
+                        "source_file": "handlers/throw.py",
+                        "source_line": 9,
+                        "status": "threw",
+                    },
+                    {"handler_name": "p4", "handler_kind": "python", "status": "pending"},
+                ],
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "throw_handler",
+                    "exception_repr": "RuntimeError('boom')",
+                },
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 14,
+                "exception_type": "RuntimeError",
+                "message": "boom",
+            },
+        ]
+    )
+
+    rendered = tb.format_default()
+    first_pending = rendered.index("· 1 pending")
+    delegated = rendered.index("delegate_handler ⇆  handlers/delegate.py:7")
+    middle_pending = rendered.index("· 2 pending")
+    threw = rendered.index("throw_handler ✗  handlers/throw.py:9")
+    trailing_pending = rendered.rindex("· 1 pending")
+    assert first_pending < delegated < middle_pending < threw < trailing_pending
 
 
 def test_format_default_keeps_duplicate_handler_names_from_vm_chain() -> None:
@@ -368,12 +557,7 @@ def test_format_default_keeps_duplicate_handler_names_from_vm_chain() -> None:
     assert result.is_err()
 
     rendered = _tb_from_run_result(result).format_default()
-    handler_stack_line = next(
-        line.strip()
-        for line in rendered.splitlines()
-        if line.strip().startswith("[") and "same_name_handler" in line
-    )
-    assert handler_stack_line.count("same_name_handler↗") == 2
+    assert rendered.count("same_name_handler ↗") >= 2
 
 
 def test_format_default_duplicate_name_throw_marks_correct_handler() -> None:
@@ -403,14 +587,8 @@ def test_format_default_duplicate_name_throw_marks_correct_handler() -> None:
     assert result.is_err()
 
     rendered = _tb_from_run_result(result).format_default()
-    stack_line = next(
-        line.strip()
-        for line in rendered.splitlines()
-        if line.strip().startswith("[") and "handler" in line
-    )
-    assert "handler✗ >" in stack_line
-    assert "> " in stack_line
-    assert "handler·" in stack_line
+    assert "handler ✗" in rendered
+    assert "pending" in rendered
     assert "inner:boom" in rendered
 
 
@@ -453,7 +631,7 @@ def test_format_default_renders_all_handlers() -> None:
     )
 
     rendered = tb.format_default()
-    assert "sync_await_handler⇆" in rendered
+    assert "sync_await_handler ⇆" in rendered
     assert "user_handler" in rendered
 
 
@@ -823,7 +1001,7 @@ def test_format_default_shows_effect_yield_on_handler_throw() -> None:
 
     rendered = _tb_from_run_result(result).format_default()
     assert "yield Boom" in rendered
-    assert "crash_handler✗" in rendered
+    assert "crash_handler ✗" in rendered
     assert "·" in rendered
     assert "raised RuntimeError('handler exploded')" in rendered
     # With typed handler metadata, crash_handler now appears as a proper frame
@@ -858,7 +1036,7 @@ def test_format_default_shows_program_yield_chain() -> None:
     assert "outer()" in rendered
     assert "inner()" in rendered
     assert "yield Boom" in rendered
-    assert "crash_handler✗" in rendered
+    assert "crash_handler ✗" in rendered
     assert "handler exploded" in rendered
     assert source_file in rendered
     assert "crash_handler" in rendered
@@ -889,9 +1067,9 @@ def test_runtime_marks_python_handler_program_frame() -> None:
     assert handler_frames
     assert any(frame.is_handler and frame.handler_kind == "python" for frame in handler_frames)
     rendered = tb.format_default()
-    assert "⚙ " in rendered
-    assert "crash_handler()" in rendered
-    assert "(python)" in rendered
+    assert "⚙ " not in rendered
+    assert "(python)" not in rendered
+    assert "crash_handler ✗" in rendered
 
 
 def test_runtime_marks_rust_builtin_handler_program_frame() -> None:
@@ -918,8 +1096,8 @@ def test_runtime_marks_rust_builtin_handler_program_frame() -> None:
     ]
     assert rust_handler_frames
     rendered = tb.format_default()
-    assert "⚙ " in rendered
-    assert "(rust_builtin)" in rendered
+    assert "⚙ " not in rendered
+    assert "pending" in rendered
 
 
 def test_runtime_handler_cleanup_after_resume_stays_tagged() -> None:
@@ -951,7 +1129,8 @@ def test_runtime_handler_cleanup_after_resume_stays_tagged() -> None:
     assert handler_frames
     assert all(frame.handler_kind == "python" for frame in handler_frames)
     rendered = tb.format_default()
-    assert "⚙ " in rendered
+    assert "⚙ " not in rendered
+    assert "resume_then_cleanup" in rendered
     assert "cleanup boom" in rendered
 
 
@@ -1135,9 +1314,9 @@ def test_format_default_shows_delegation_chain() -> None:
 
     rendered = _tb_from_run_result(result).format_default()
     assert "yield Boom" in rendered
-    assert "inner_delegate_handler↗" in rendered
-    assert "outer_crash_handler✗" in rendered
-    assert "StateHandler·" in rendered
+    assert "inner_delegate_handler ↗" in rendered
+    assert "outer_crash_handler ✗" in rendered
+    assert "pending" in rendered
     assert "delegated boom" in rendered
     assert "outer_crash_handler" in rendered
     assert "\n\nRuntimeError: delegated boom" in rendered
@@ -1180,9 +1359,9 @@ def test_format_default_runtime_distinguishes_passed_and_delegated() -> None:
     assert result.is_err()
 
     rendered = _tb_from_run_result(result).format_default()
-    assert "inner_pass_handler↗" in rendered
-    assert "middle_delegate_handler⇆" in rendered
-    assert "outer_throw_handler✗" in rendered
+    assert "inner_pass_handler ↗" in rendered
+    assert "middle_delegate_handler ⇆" in rendered
+    assert "outer_throw_handler ✗" in rendered
     assert "pass-vs-delegate boom" in rendered
 
 
@@ -1209,7 +1388,7 @@ def test_format_default_spawn_shows_effect_in_child() -> None:
     rendered = _tb_from_run_result(result).format_default()
     source_file = str(Path(__file__).resolve())
     assert "yield Boom" in rendered
-    assert "crash_handler✗" in rendered
+    assert "crash_handler ✗" in rendered
     assert "·" in rendered
     assert "child exploded" in rendered
     assert "── in task " in rendered
@@ -1220,20 +1399,13 @@ def test_format_default_spawn_shows_effect_in_child() -> None:
     assert "parent()" in rendered
     assert source_file in rendered
     assert "child()" in rendered
-    assert "crash_handler()" in rendered
+    assert "⚙ crash_handler()" not in rendered
     boundary_pos = rendered.index("── in task ")
     gather_pos = rendered.index("yield Gather(")
     child_pos = rendered.index("  child()")
     assert gather_pos < boundary_pos < child_pos
-    child_stack_line = next(
-        line.strip()
-        for line in rendered.splitlines()
-        if line.strip().startswith("[") and "crash_handler" in line
-    )
-    assert child_stack_line.count("ResultSafeHandler·") >= 2
-    assert child_stack_line.count("WriterHandler·") >= 2
-    assert child_stack_line.count("ReaderHandler·") >= 2
-    assert child_stack_line.count("StateHandler·") >= 2
+    assert "handlers:" in rendered
+    assert "pending" in rendered
 
 
 def test_spawn_site_attribution_under_single_delegate_handler() -> None:

--- a/tests/core/test_traceback_spec_compliance.py
+++ b/tests/core/test_traceback_spec_compliance.py
@@ -18,7 +18,6 @@ _DEFAULT_HANDLER_NAMES = (
     "ReaderHandler",
     "StateHandler",
 )
-_HANDLER_STATUS_MARKERS = {"⚡", "·", "↗", "⇆", "✓", "⇢", "✗"}
 
 
 def _line_of(function: object, needle: str) -> int:
@@ -36,41 +35,8 @@ def _assert_common_trace_properties(rendered: str) -> None:
 
 
 def _assert_default_handlers_visible(rendered: str) -> None:
-    stack_lines = [
-        line.strip()
-        for line in rendered.splitlines()
-        if line.strip().startswith("[") and line.strip().endswith("]")
-    ]
-    assert stack_lines
-    assert all("..." not in line for line in stack_lines)
-
-    default_rows = 0
-    for line in stack_lines:
-        body = line[1:-1]
-        tokens = [token.strip() for token in body.split(" > ")] if body else []
-        names: list[str] = []
-        for token in tokens:
-            if token and token[-1] in _HANDLER_STATUS_MARKERS:
-                names.append(token[:-1])
-            else:
-                names.append(token)
-
-        if not any(name in _DEFAULT_HANDLER_NAMES for name in names):
-            continue
-
-        try:
-            first_default_index = next(
-                idx for idx, name in enumerate(names) if name == _DEFAULT_HANDLER_NAMES[0]
-            )
-        except StopIteration:
-            continue
-
-        expected = list(_DEFAULT_HANDLER_NAMES)
-        observed = names[first_default_index : first_default_index + len(expected)]
-        assert observed == expected
-        default_rows += 1
-
-    assert default_rows > 0
+    assert "handlers:" in rendered
+    assert any(name in rendered for name in _DEFAULT_HANDLER_NAMES) or "pending" in rendered
 
 
 def _render_failure(
@@ -150,8 +116,8 @@ def test_spec_example_2_with_handler_stack_markers() -> None:
     wrapped = WithHandler(auth_handler, WithHandler(rate_limiter, call_api()))
     rendered = _render_failure(wrapped)
     assert "yield Ask('rate_limit')" in rendered or 'yield Ask("rate_limit")' in rendered
-    assert "rate_limiter✓" in rendered
-    assert "auth_handler·" in rendered
+    assert "rate_limiter ✓" in rendered
+    assert "pending" in rendered
     assert "→ resumed with Int(100)" in rendered or "→ resumed with 100" in rendered
     assert "raise ConnectionError('timeout')" in rendered
     assert "ConnectionError: timeout" in rendered
@@ -179,7 +145,7 @@ def test_spec_example_3_handler_throws() -> None:
         store={"result": 0},
     )
     assert "yield Put(" in rendered
-    assert "strict_handler✗" in rendered
+    assert "strict_handler ✗" in rendered
     assert "expected int, got str" in rendered
     assert "TypeError: expected int, got str" in rendered
     _assert_default_handlers_visible(rendered)
@@ -218,7 +184,7 @@ def test_spec_example_6_handler_return_abandons_inner_chain() -> None:
 
     rendered = _render_failure(outer(), store={"result": ""})
     assert "yield Ask(" in rendered
-    assert "short_circuit_handler✓" in rendered
+    assert "short_circuit_handler ✓" in rendered
     assert "inner()" in rendered
     assert "raise ValueError(" in rendered
     assert "Unexpected: fallback" in rendered


### PR DESCRIPTION
## Summary
- rewrote `DoeffTraceback._render_handler_stack()` to render a multi-line `handlers:` block with per-handler status and source location
- added pending-collapse behavior (`· N pending`) including all-pending special case (`· N pending (no handler matched)`)
- updated `format_default()` to:
  - suppress handler `ProgramYield` frames (`is_handler=True`)
  - render multi-line handler blocks
  - use `(same handlers)` when stack is unchanged
- kept `format_chained()`, `format_sectioned()`, and `format_short()` logic unchanged
- updated and expanded traceback tests to match the new rendering and suppression rules

## Acceptance Criteria Evidence
1. Multi-line handler stack with source locations: covered by `tests/core/test_traceback_format_default.py::test_format_default_handler_stack_shows_source_locations` (passed)
2. Consecutive pending collapse: covered by `tests/core/test_traceback_format_default.py::test_format_default_handler_stack_collapses_pending_groups` (passed)
3. Handler ProgramYield suppression in `format_default()`: covered by
   - `tests/core/test_traceback_format_default.py::test_format_default_handler_program_yield_python` (passed)
   - `tests/core/test_traceback_format_default.py::test_format_default_handler_program_yield_rust_builtin` (passed)
4. `format_chained()` unchanged: verified by existing format-invariance tests (`test_existing_formats_unchanged`) plus no code changes in `format_chained()`
5. `(same handlers)` replaces `[same]`: covered by `tests/core/test_traceback_format_default.py::test_format_default_handler_stack_same` (passed)
6. Existing tests updated and passing: updated traceback/spec/stderr tests now pass
7. New tests added for pending collapse, source locations, all-pending, mixed grouping: all added in `tests/core/test_traceback_format_default.py` and passing
8. `format_chained()`, `format_sectioned()`, `format_short()` unchanged: no code changes to those methods
9. `make sync && uv run pytest tests/ -x`
   - `make sync`: passed (Rust VM rebuilt via `maturin develop`)
   - `uv run pytest tests/ -x`: passed (`1026 passed, 1 warning`)
10. `make lint`
   - currently fails in this branch due pre-existing pyright errors across unrelated modules under `doeff/` (not introduced by this PR).

## Issue
Refs: TRACE-HANDLER-STACK
