### PR TITLE
Fix stale Tell dispatch leak in format_default traceback

### DIFF
--- a/packages/doeff-vm-core/src/trace_state.rs
+++ b/packages/doeff-vm-core/src/trace_state.rs
@@ -1298,6 +1298,17 @@ impl TraceState {
             let dispatch = dispatch_id.and_then(|id| state.dispatches.get(&id));
             if let Some(dispatch) = dispatch.filter(|dispatch| Self::is_visible_dispatch(dispatch))
             {
+                let dispatch_completed = matches!(
+                    dispatch.result,
+                    EffectResult::Resumed { .. } | EffectResult::Transferred { .. }
+                );
+                if frame.handler_kind.is_some() && dispatch_completed {
+                    active_chain.push(Self::program_yield_entry(
+                        frame,
+                        state.frame_stack.get(index + 1),
+                    ));
+                    continue;
+                }
                 Self::push_effect_yield_entry(&mut active_chain, dispatch, Some(frame));
                 continue;
             }


### PR DESCRIPTION
## Summary
- Updated `entries_from_frame_stack()` in `packages/doeff-vm-core/src/trace_state.rs`.
- Added a handler-only guard: when a mapped dispatch is already completed (`Resumed` or `Transferred`), classify that handler frame as `ProgramYield` instead of `EffectYield`.
- Kept prior behavior for:
  - non-handler frames (completed dispatches still render as `EffectYield`)
  - handler frames with non-completed dispatches (still render as `EffectYield`)

Fixes: TRACE-STALE-TELL

## Acceptance Criteria Evidence
1. `test_format_default_handler_tell_not_in_traceback` passes
   - `uv run pytest tests/core/test_traceback_format_default.py -x -v -k "handler_tell"`
   - Result: `2 passed, 41 deselected`

2. `test_format_default_handler_tell_not_in_traceback_deep` passes
   - Same command as above
   - Result includes:
     - `test_format_default_handler_tell_not_in_traceback PASSED`
     - `test_format_default_handler_tell_not_in_traceback_deep PASSED`

3. All existing tests pass: `uv run pytest tests/ -x`
   - Result: `1028 passed, 1 warning in 40.09s`

4. `make lint` passes
   - Command run: `make lint`
   - Status: **fails in `lint-pyright` with pre-existing typing errors outside this change** (44 errors, 58 warnings), e.g. in `doeff/__init__.py`, `doeff/program.py`, `doeff/graph_snapshot.py`.
   - No new lint issues were introduced in the changed Rust file.

5. Handler frames with active/in-flight dispatches still show as `EffectYield`
   - Verified via focused runtime traceback coverage:
     - `uv run pytest tests/core/test_traceback_format_default.py -x -v -k "shows_effect_yield_on_handler_throw"`
   - Result: pass.

6. Non-handler frames with completed dispatches still show as `EffectYield`
   - Verified via focused runtime traceback coverage:
     - `uv run pytest tests/core/test_traceback_format_default.py -x -v -k "includes_resumed_effects"`
   - Result: pass.

## Commands Run
- `make sync`
- `uv run pytest tests/core/test_traceback_format_default.py -x -v -k "handler_tell"`
- `uv run pytest tests/core/test_traceback_format_default.py -x -v -k "handler_tell_not_in_traceback or shows_effect_yield_on_handler_throw or includes_resumed_effects"`
- `uv run pytest tests/ -x`
- `make lint`
