### PR TITLE
VM-CATCHALL-AUDIT-001: Replace catch-all match arms with explicit variants

### DIFF
--- a/packages/doeff-core-effects/src/handlers/mod.rs
+++ b/packages/doeff-core-effects/src/handlers/mod.rs
@@ -1111,7 +1111,22 @@ impl IRStreamProgram for LazyAskHandlerProgram {
                 let Some(semaphore) = semaphore else {
                     let semaphore = match value {
                         Value::Python(_) => value,
-                        _ => {
+                        Value::Unit
+                        | Value::Int(_)
+                        | Value::String(_)
+                        | Value::Bool(_)
+                        | Value::None
+                        | Value::Continuation(_)
+                        | Value::Handlers(_)
+                        | Value::Kleisli(_)
+                        | Value::Task(_)
+                        | Value::Promise(_)
+                        | Value::ExternalPromise(_)
+                        | Value::CallStack(_)
+                        | Value::Trace(_)
+                        | Value::Traceback(_)
+                        | Value::ActiveChain(_)
+                        | Value::List(_) => {
                             return IRStreamStep::Throw(PyException::type_error(
                                 "CreateSemaphore must return a semaphore handle".to_string(),
                             ));
@@ -1847,16 +1862,15 @@ mod tests {
         assert_eq!(location.phase.as_deref(), Some("AwaitBridgeResult"));
 
         let step = IRStream::resume(&mut program, Value::Int(12), &mut store, &mut scope);
-        match step {
-            IRStreamStep::Yield(DoCtrl::Resume {
-                continuation,
-                value,
-            }) => {
-                assert_eq!(continuation.cont_id, continuation_id);
-                assert_eq!(value.as_int(), Some(12));
-            }
-            _ => panic!("expected IRStream Yield(Resume)"),
-        }
+        let IRStreamStep::Yield(DoCtrl::Resume {
+            continuation,
+            value,
+        }) = step
+        else {
+            panic!("expected IRStream Yield(Resume)");
+        };
+        assert_eq!(continuation.cont_id, continuation_id);
+        assert_eq!(value.as_int(), Some(12));
 
         let location = IRStream::debug_location(&program).expect("await debug location");
         assert_eq!(location.phase.as_deref(), Some("Idle"));
@@ -1880,16 +1894,15 @@ mod tests {
         assert_eq!(location.phase.as_deref(), Some("ModifyApply"));
 
         let step = IRStream::resume(&mut program, Value::Int(8), &mut store, &mut scope);
-        match step {
-            IRStreamStep::Yield(DoCtrl::Resume {
-                continuation,
-                value,
-            }) => {
-                assert_eq!(continuation.cont_id, continuation_id);
-                assert_eq!(value.as_int(), Some(5));
-            }
-            _ => panic!("expected IRStream Yield(Resume)"),
-        }
+        let IRStreamStep::Yield(DoCtrl::Resume {
+            continuation,
+            value,
+        }) = step
+        else {
+            panic!("expected IRStream Yield(Resume)");
+        };
+        assert_eq!(continuation.cont_id, continuation_id);
+        assert_eq!(value.as_int(), Some(5));
 
         assert_eq!(store.get("count").and_then(Value::as_int), Some(8));
         let location = IRStream::debug_location(&program).expect("state debug location");
@@ -1951,16 +1964,15 @@ mod tests {
         assert_eq!(location.phase.as_deref(), Some("AwaitRelease"));
 
         let step = IRStream::resume(&mut program, Value::Unit, &mut store, &mut scope);
-        match step {
-            IRStreamStep::Yield(DoCtrl::Resume {
-                continuation,
-                value,
-            }) => {
-                assert_eq!(continuation.cont_id, continuation_id);
-                assert_eq!(value.as_int(), Some(44));
-            }
-            _ => panic!("expected IRStream Yield(Resume)"),
-        }
+        let IRStreamStep::Yield(DoCtrl::Resume {
+            continuation,
+            value,
+        }) = step
+        else {
+            panic!("expected IRStream Yield(Resume)");
+        };
+        assert_eq!(continuation.cont_id, continuation_id);
+        assert_eq!(value.as_int(), Some(44));
     }
 
     #[test]
@@ -2060,15 +2072,13 @@ mod tests {
                     &mut scope,
                 )
             };
-            match step {
-                IRStreamStep::Yield(DoCtrl::Resume { value, .. }) => {
-                    assert_eq!(value.as_int(), Some(42));
-                }
-                _ => panic!(
+            let IRStreamStep::Yield(DoCtrl::Resume { value, .. }) = step else {
+                panic!(
                     "Expected Yield(Resume), got {:?}",
                     std::mem::discriminant(&step)
-                ),
-            }
+                );
+            };
+            assert_eq!(value.as_int(), Some(42));
         });
     }
 
@@ -2126,13 +2136,11 @@ mod tests {
                     &mut scope,
                 )
             };
-            match step {
-                IRStreamStep::NeedsPython(PythonCall::CallFunc { args, .. }) => {
-                    assert_eq!(args.len(), 1);
-                    assert_eq!(args[0].as_int(), Some(10));
-                }
-                _ => panic!("Expected NeedsPython(CallFunc)"),
-            }
+            let IRStreamStep::NeedsPython(PythonCall::CallFunc { args, .. }) = step else {
+                panic!("Expected NeedsPython(CallFunc)");
+            };
+            assert_eq!(args.len(), 1);
+            assert_eq!(args[0].as_int(), Some(10));
         });
     }
 
@@ -2165,12 +2173,10 @@ mod tests {
                 let mut guard = program_ref.lock().unwrap();
                 guard.resume(Value::Int(20), &mut store, &mut scope)
             };
-            match step {
-                IRStreamStep::Yield(DoCtrl::Resume { value, .. }) => {
-                    assert_eq!(value.as_int(), Some(10)); // old_value returned (SPEC-008 L1271)
-                }
-                _ => panic!("Expected Yield(Resume) with old_value"),
-            }
+            let IRStreamStep::Yield(DoCtrl::Resume { value, .. }) = step else {
+                panic!("Expected Yield(Resume) with old_value");
+            };
+            assert_eq!(value.as_int(), Some(10)); // old_value returned (SPEC-008 L1271)
             assert_eq!(store.get("key").unwrap().as_int(), Some(20)); // new value stored
         });
     }
@@ -2221,12 +2227,10 @@ mod tests {
                     &mut scope,
                 )
             };
-            match step {
-                IRStreamStep::Yield(DoCtrl::Resume { value, .. }) => {
-                    assert_eq!(value.as_str(), Some("value"));
-                }
-                _ => panic!("Expected Yield(Resume)"),
-            }
+            let IRStreamStep::Yield(DoCtrl::Resume { value, .. }) = step else {
+                panic!("Expected Yield(Resume)");
+            };
+            assert_eq!(value.as_str(), Some("value"));
         });
     }
 
@@ -2349,19 +2353,18 @@ mod tests {
                 let mut guard = ok_program.lock().unwrap();
                 guard.resume(Value::Int(42), &mut store, &mut scope)
             };
-            match ok_step {
-                IRStreamStep::Yield(DoCtrl::Resume {
-                    value: Value::Python(obj),
-                    ..
-                }) => {
-                    let bound = obj.bind(py);
-                    let is_ok: bool = bound.call_method0("is_ok").unwrap().extract().unwrap();
-                    let inner = bound.getattr("value").unwrap();
-                    assert!(is_ok);
-                    assert_eq!(inner.extract::<i64>().unwrap(), 42);
-                }
-                _ => panic!("expected Resume with Ok(value)"),
-            }
+            let IRStreamStep::Yield(DoCtrl::Resume {
+                value: Value::Python(obj),
+                ..
+            }) = ok_step
+            else {
+                panic!("expected Resume with Ok(value)");
+            };
+            let bound = obj.bind(py);
+            let is_ok: bool = bound.call_method0("is_ok").unwrap().extract().unwrap();
+            let inner = bound.getattr("value").unwrap();
+            assert!(is_ok);
+            assert_eq!(inner.extract::<i64>().unwrap(), 42);
 
             let err_program = ResultSafeHandlerFactory.create_program();
             let _ = {
@@ -2374,20 +2377,19 @@ mod tests {
                 guard.throw(PyException::runtime_error("boom"), &mut store, &mut scope)
             };
 
-            match err_step {
-                IRStreamStep::Yield(DoCtrl::Resume {
-                    value: Value::Python(obj),
-                    ..
-                }) => {
-                    let bound = obj.bind(py);
-                    let is_err: bool = bound.call_method0("is_err").unwrap().extract().unwrap();
-                    let error = bound.getattr("error").unwrap();
-                    let msg = error.str().unwrap().to_str().unwrap().to_string();
-                    assert!(is_err);
-                    assert!(msg.contains("boom"));
-                }
-                _ => panic!("expected Resume with Err(exception)"),
-            }
+            let IRStreamStep::Yield(DoCtrl::Resume {
+                value: Value::Python(obj),
+                ..
+            }) = err_step
+            else {
+                panic!("expected Resume with Err(exception)");
+            };
+            let bound = obj.bind(py);
+            let is_err: bool = bound.call_method0("is_err").unwrap().extract().unwrap();
+            let error = bound.getattr("error").unwrap();
+            let msg = error.str().unwrap().to_str().unwrap().to_string();
+            assert!(is_err);
+            assert!(msg.contains("boom"));
         });
     }
 
@@ -2443,13 +2445,11 @@ mod tests {
                 let mut guard = program_ref.lock().unwrap();
                 guard.resume(Value::Int(200), &mut store, &mut scope)
             };
-            match step3 {
-                IRStreamStep::Yield(DoCtrl::Resume { value, .. }) => {
-                    // 100 + 200 = 300
-                    assert_eq!(value.as_int(), Some(300));
-                }
-                _ => panic!("Expected Yield(Resume) with combined value 300"),
-            }
+            let IRStreamStep::Yield(DoCtrl::Resume { value, .. }) = step3 else {
+                panic!("Expected Yield(Resume) with combined value 300");
+            };
+            // 100 + 200 = 300
+            assert_eq!(value.as_int(), Some(300));
         });
     }
 }

--- a/packages/doeff-core-effects/src/scheduler/mod.rs
+++ b/packages/doeff-core-effects/src/scheduler/mod.rs
@@ -344,14 +344,34 @@ fn throw_to_continuation(k: Continuation, error: PyException) -> IRStreamStep {
 
 fn step_targets_cont_id(step: &IRStreamStep, cont_id: ContId) -> bool {
     match step {
-        IRStreamStep::Yield(DoCtrl::Resume { continuation, .. })
-        | IRStreamStep::Yield(DoCtrl::ResumeThrow { continuation, .. })
-        | IRStreamStep::Yield(DoCtrl::Transfer { continuation, .. })
-        | IRStreamStep::Yield(DoCtrl::TransferThrow { continuation, .. })
-        | IRStreamStep::Yield(DoCtrl::ResumeContinuation { continuation, .. }) => {
-            continuation.cont_id == cont_id
-        }
-        _ => false,
+        IRStreamStep::Yield(ctrl) => match ctrl {
+            DoCtrl::Resume { continuation, .. }
+            | DoCtrl::ResumeThrow { continuation, .. }
+            | DoCtrl::Transfer { continuation, .. }
+            | DoCtrl::TransferThrow { continuation, .. }
+            | DoCtrl::ResumeContinuation { continuation, .. } => continuation.cont_id == cont_id,
+            DoCtrl::Pure { .. }
+            | DoCtrl::Map { .. }
+            | DoCtrl::FlatMap { .. }
+            | DoCtrl::Perform { .. }
+            | DoCtrl::WithHandler { .. }
+            | DoCtrl::WithIntercept { .. }
+            | DoCtrl::Finally { .. }
+            | DoCtrl::Delegate { .. }
+            | DoCtrl::Pass { .. }
+            | DoCtrl::GetContinuation
+            | DoCtrl::GetHandlers
+            | DoCtrl::GetTraceback { .. }
+            | DoCtrl::CreateContinuation { .. }
+            | DoCtrl::PythonAsyncSyntaxEscape { .. }
+            | DoCtrl::Apply { .. }
+            | DoCtrl::Expand { .. }
+            | DoCtrl::IRStream { .. }
+            | DoCtrl::Eval { .. }
+            | DoCtrl::EvalInScope { .. }
+            | DoCtrl::GetCallStack => false,
+        },
+        IRStreamStep::Return(_) | IRStreamStep::Throw(_) | IRStreamStep::NeedsPython(_) => false,
     }
 }
 
@@ -1156,7 +1176,7 @@ impl SchedulerState {
         let task_exists = self.tasks.contains_key(&task_id);
         let cont_id = match self.tasks.get(&task_id) {
             Some(TaskState::Pending { cont, .. }) => Some(cont.cont_id),
-            _ => None,
+            Some(TaskState::Done { .. }) | None => None,
         };
         if let Some(cont_id) = cont_id {
             self.clear_waiters_for_owner(Some(task_id), cont_id);
@@ -1214,7 +1234,7 @@ impl SchedulerState {
         let task_id = self.current_task?;
         match self.tasks.get(&task_id) {
             Some(TaskState::Pending { priority, .. }) => Some(*priority),
-            _ => None,
+            Some(TaskState::Done { .. }) | None => None,
         }
     }
 
@@ -1467,7 +1487,7 @@ impl SchedulerState {
                     *pending_log_merge_items = merge_items;
                     *priority
                 }
-                _ => return None,
+                Some(TaskState::Done { .. }) | None => return None,
             };
 
             self.enqueue_ready_task(waiting_task, priority);
@@ -1516,7 +1536,7 @@ impl SchedulerState {
                         Some(current_max) if current_max.priority >= woken.priority => {
                             Some(current_max)
                         }
-                        _ => Some(woken),
+                        Some(_) | None => Some(woken),
                     };
                 }
             }
@@ -1629,7 +1649,7 @@ impl SchedulerState {
     pub fn task_cont(&self, task_id: TaskId) -> Option<Continuation> {
         match self.tasks.get(&task_id) {
             Some(TaskState::Pending { cont, .. }) => Some(cont.clone()),
-            _ => None,
+            Some(TaskState::Done { .. }) | None => None,
         }
     }
 
@@ -1640,13 +1660,13 @@ impl SchedulerState {
                 Waitable::Task(task_id) => match self.tasks.get(task_id) {
                     Some(TaskState::Done { result: Ok(v), .. }) => results.push(v.clone()),
                     Some(TaskState::Done { result: Err(_), .. }) => return None,
-                    _ => return None,
+                    Some(TaskState::Pending { .. }) | None => return None,
                 },
                 Waitable::Promise(pid) | Waitable::ExternalPromise(pid) => {
                     match self.promises.get(pid) {
                         Some(PromiseState::Done(Ok(v))) => results.push(v.clone()),
                         Some(PromiseState::Done(Err(_))) => return None,
-                        _ => return None,
+                        Some(PromiseState::Pending) | None => return None,
                     }
                 }
             }
@@ -1729,7 +1749,7 @@ impl SchedulerState {
                 Waitable::Task(task_id) => {
                     let task_result = match self.tasks.get(task_id) {
                         Some(TaskState::Done { result, .. }) => result.clone(),
-                        _ => return None,
+                        Some(TaskState::Pending { .. }) | None => return None,
                     };
                     match task_result {
                         Ok(value) => results.push(value),
@@ -1743,7 +1763,7 @@ impl SchedulerState {
                     match self.promises.get(pid) {
                         Some(PromiseState::Done(Ok(v))) => results.push(v.clone()),
                         Some(PromiseState::Done(Err(e))) => return Some(Err(e.clone())),
-                        _ => return None,
+                        Some(PromiseState::Pending) | None => return None,
                     }
                 }
             }
@@ -1758,7 +1778,7 @@ impl SchedulerState {
                 Waitable::Task(task_id) => {
                     let task_result = match self.tasks.get(task_id) {
                         Some(TaskState::Done { result, .. }) => result.clone(),
-                        _ => continue,
+                        Some(TaskState::Pending { .. }) | None => continue,
                     };
                     if task_result.is_err() {
                         self.execution_context_task_override = Some(*task_id);
@@ -2560,7 +2580,22 @@ impl IRStreamProgram for SchedulerProgram {
             SchedulerPhase::SpawnAwaitTraceback { k_user, effect } => {
                 let traceback = match value {
                     Value::Traceback(hops) => hops,
-                    _ => {
+                    Value::Python(_)
+                    | Value::Unit
+                    | Value::Int(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::None
+                    | Value::Continuation(_)
+                    | Value::Handlers(_)
+                    | Value::Kleisli(_)
+                    | Value::Task(_)
+                    | Value::Promise(_)
+                    | Value::ExternalPromise(_)
+                    | Value::CallStack(_)
+                    | Value::Trace(_)
+                    | Value::ActiveChain(_)
+                    | Value::List(_) => {
                         return IRStreamStep::Throw(PyException::type_error(
                             "scheduler Spawn expected GetTraceback result".to_string(),
                         ));
@@ -2651,7 +2686,22 @@ impl IRStreamProgram for SchedulerProgram {
             } => {
                 let handlers = match value {
                     Value::Handlers(hs) => hs,
-                    _ => {
+                    Value::Python(_)
+                    | Value::Unit
+                    | Value::Int(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::None
+                    | Value::Continuation(_)
+                    | Value::Kleisli(_)
+                    | Value::Task(_)
+                    | Value::Promise(_)
+                    | Value::ExternalPromise(_)
+                    | Value::CallStack(_)
+                    | Value::Trace(_)
+                    | Value::Traceback(_)
+                    | Value::ActiveChain(_)
+                    | Value::List(_) => {
                         return IRStreamStep::Throw(PyException::type_error(
                             "scheduler Spawn expected GetHandlers result".to_string(),
                         ));
@@ -2683,7 +2733,22 @@ impl IRStreamProgram for SchedulerProgram {
                 // Value should be the continuation created by CreateContinuation
                 let cont = match value {
                     Value::Continuation(c) => c,
-                    _ => {
+                    Value::Python(_)
+                    | Value::Unit
+                    | Value::Int(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::None
+                    | Value::Handlers(_)
+                    | Value::Kleisli(_)
+                    | Value::Task(_)
+                    | Value::Promise(_)
+                    | Value::ExternalPromise(_)
+                    | Value::CallStack(_)
+                    | Value::Trace(_)
+                    | Value::Traceback(_)
+                    | Value::ActiveChain(_)
+                    | Value::List(_) => {
                         return IRStreamStep::Throw(PyException::type_error(
                             "expected continuation from CreateContinuation, got unexpected type"
                                 .to_string(),
@@ -2780,7 +2845,10 @@ impl IRStreamProgram for SchedulerProgram {
             SchedulerPhase::PreemptiveTransfer { k_user } => {
                 self.continue_preemptive_transfer(Err(exc), k_user, store)
             }
-            _ => IRStreamStep::Throw(exc),
+            SchedulerPhase::Idle
+            | SchedulerPhase::SpawnAwaitTraceback { .. }
+            | SchedulerPhase::SpawnAwaitHandlers { .. }
+            | SchedulerPhase::SpawnAwaitContinuation { .. } => IRStreamStep::Throw(exc),
         }
     }
 }
@@ -2984,16 +3052,15 @@ mod tests {
         let cont_id = cont.cont_id;
         let step = transfer_to_continuation(cont, Value::Int(123));
 
-        match step {
-            IRStreamStep::Yield(DoCtrl::Transfer {
-                continuation,
-                value,
-            }) => {
-                assert_eq!(continuation.cont_id, cont_id);
-                assert_eq!(value.as_int(), Some(123));
-            }
-            _ => panic!("started continuation must emit DoCtrl::Transfer"),
-        }
+        let IRStreamStep::Yield(DoCtrl::Transfer {
+            continuation,
+            value,
+        }) = step
+        else {
+            panic!("started continuation must emit DoCtrl::Transfer");
+        };
+        assert_eq!(continuation.cont_id, cont_id);
+        assert_eq!(value.as_int(), Some(123));
     }
 
     #[test]
@@ -3002,16 +3069,15 @@ mod tests {
         let cont_id = cont.cont_id;
         let step = transfer_to_continuation(cont, Value::Int(456));
 
-        match step {
-            IRStreamStep::Yield(DoCtrl::ResumeContinuation {
-                continuation,
-                value,
-            }) => {
-                assert_eq!(continuation.cont_id, cont_id);
-                assert_eq!(value.as_int(), Some(456));
-            }
-            _ => panic!("unstarted continuation must emit DoCtrl::ResumeContinuation"),
-        }
+        let IRStreamStep::Yield(DoCtrl::ResumeContinuation {
+            continuation,
+            value,
+        }) = step
+        else {
+            panic!("unstarted continuation must emit DoCtrl::ResumeContinuation");
+        };
+        assert_eq!(continuation.cont_id, cont_id);
+        assert_eq!(value.as_int(), Some(456));
     }
 
     #[test]
@@ -3277,23 +3343,23 @@ mod tests {
                 &mut _scope,
             );
 
-            match step {
-                IRStreamStep::Yield(DoCtrl::Resume {
-                    continuation,
-                    value,
-                })
-                | IRStreamStep::Yield(DoCtrl::Transfer {
-                    continuation,
-                    value,
-                })
-                | IRStreamStep::Yield(DoCtrl::ResumeContinuation {
-                    continuation,
-                    value,
-                }) => {
-                    assert_eq!(continuation.cont_id, k_user_id);
-                    assert!(matches!(value, Value::Task(_)));
-                }
-                _ => panic!("expected IRStream Yield(Resume|Transfer|ResumeContinuation)"),
+            if let IRStreamStep::Yield(DoCtrl::Resume {
+                continuation,
+                value,
+            })
+            | IRStreamStep::Yield(DoCtrl::Transfer {
+                continuation,
+                value,
+            })
+            | IRStreamStep::Yield(DoCtrl::ResumeContinuation {
+                continuation,
+                value,
+            }) = step
+            {
+                assert_eq!(continuation.cont_id, k_user_id);
+                assert!(matches!(value, Value::Task(_)));
+            } else {
+                panic!("expected IRStream Yield(Resume|Transfer|ResumeContinuation)");
             }
 
             let location = IRStream::debug_location(&program).expect("scheduler debug location");
@@ -4261,14 +4327,12 @@ mod tests {
             state.enqueue_ready_task(task, PRIORITY_NORMAL);
 
             let step = state.transfer_next_or(scheduler_k.clone(), &mut store);
-            match step {
-                IRStreamStep::Yield(DoCtrl::Transfer { continuation, .. }) => {
-                    assert_eq!(continuation.cont_id, expected_cont);
-                }
-                IRStreamStep::Yield(DoCtrl::Resume { .. }) => {
-                    panic!("task switches must not emit DoCtrl::Resume")
-                }
-                _ => panic!("task switches must emit DoCtrl::Transfer"),
+            if let IRStreamStep::Yield(DoCtrl::Transfer { continuation, .. }) = step {
+                assert_eq!(continuation.cont_id, expected_cont);
+            } else if matches!(step, IRStreamStep::Yield(DoCtrl::Resume { .. })) {
+                panic!("task switches must not emit DoCtrl::Resume");
+            } else {
+                panic!("task switches must emit DoCtrl::Transfer");
             }
 
             // Simulate that the resumed task yielded back to scheduler.
@@ -4303,22 +4367,19 @@ mod tests {
 
         // transfer_next_or should resume whichever waiter is globally ready.
         let step = state.transfer_next_or(waiter.clone(), &mut store);
-        match step {
-            IRStreamStep::Yield(DoCtrl::Transfer {
-                continuation,
-                value,
-            }) => {
-                assert_eq!(continuation.cont_id, waiter.cont_id);
-                match value {
-                    Value::List(values) => {
-                        assert_eq!(values.len(), 1);
-                        assert_eq!(values[0].as_int(), Some(7));
-                    }
-                    _ => panic!("wait completion should resume waiter with gathered value"),
-                }
-            }
-            _ => panic!("completed waiter must resume via DoCtrl::Transfer"),
-        }
+        let IRStreamStep::Yield(DoCtrl::Transfer {
+            continuation,
+            value,
+        }) = step
+        else {
+            panic!("completed waiter must resume via DoCtrl::Transfer");
+        };
+        assert_eq!(continuation.cont_id, waiter.cont_id);
+        let Value::List(values) = value else {
+            panic!("wait completion should resume waiter with gathered value");
+        };
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].as_int(), Some(7));
     }
 
     #[test]
@@ -4360,15 +4421,13 @@ mod tests {
             let parsed = parse_scheduler_python_effect(&PyShared::new(obj), creation_site)
                 .expect("failed to parse effect")
                 .expect("effect should be parsed as scheduler spawn");
-            match parsed {
-                SchedulerEffect::Spawn { creation_site, .. } => {
-                    let site = creation_site.expect("spawn creation site should be captured");
-                    assert_eq!(site.function_name, "parent");
-                    assert_eq!(site.source_file, "/tmp/user_program.py");
-                    assert_eq!(site.source_line, 321);
-                }
-                _ => panic!("expected SchedulerEffect::Spawn"),
-            }
+            let SchedulerEffect::Spawn { creation_site, .. } = parsed else {
+                panic!("expected SchedulerEffect::Spawn");
+            };
+            let site = creation_site.expect("spawn creation site should be captured");
+            assert_eq!(site.function_name, "parent");
+            assert_eq!(site.source_file, "/tmp/user_program.py");
+            assert_eq!(site.source_line, 321);
         });
     }
 

--- a/packages/doeff-vm-core/src/kleisli.rs
+++ b/packages/doeff-vm-core/src/kleisli.rs
@@ -346,7 +346,22 @@ impl PyKleisli {
             Value::Continuation(k) => Bound::new(py, PyK::from_cont_id(k.cont_id))
                 .map(|obj| obj.into_any())
                 .map_err(Self::map_pyerr),
-            _ => value.to_pyobject(py).map_err(Self::map_pyerr),
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::String(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => value.to_pyobject(py).map_err(Self::map_pyerr),
         }
     }
 }

--- a/packages/doeff-vm-core/src/trace_state.rs
+++ b/packages/doeff-vm-core/src/trace_state.rs
@@ -73,7 +73,9 @@ impl ActiveChainAssemblyState {
         self.dispatches.get(&dispatch_id).is_some_and(|dispatch| {
             matches!(
                 dispatch.result,
-                EffectResult::Resumed { .. } | EffectResult::Transferred { .. } | EffectResult::Threw { .. }
+                EffectResult::Resumed { .. }
+                    | EffectResult::Transferred { .. }
+                    | EffectResult::Threw { .. }
             )
         })
     }
@@ -377,7 +379,18 @@ impl TraceState {
                     ..
                 },
             ) => Python::attach(|py| lhs_value.bind(py).as_ptr() == rhs_value.bind(py).as_ptr()),
-            _ => false,
+            (
+                PyException::Materialized { .. },
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+            )
+            | (
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+                PyException::Materialized { .. },
+            )
+            | (PyException::RuntimeError { .. }, PyException::TypeError { .. })
+            | (PyException::TypeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::RuntimeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::TypeError { .. }, PyException::TypeError { .. }) => false,
         }
     }
 
@@ -994,12 +1007,7 @@ impl TraceState {
                 else {
                     continue;
                 };
-                Self::upsert_frame_state_from_metadata(
-                    frame_stack,
-                    stream,
-                    metadata,
-                    handler_kind,
-                );
+                Self::upsert_frame_state_from_metadata(frame_stack, stream, metadata, handler_kind);
             }
         }
     }
@@ -1028,12 +1036,7 @@ impl TraceState {
             else {
                 continue;
             };
-            Self::upsert_frame_state_from_metadata(
-                frame_stack,
-                stream,
-                metadata,
-                handler_kind,
-            );
+            Self::upsert_frame_state_from_metadata(frame_stack, stream, metadata, handler_kind);
         }
     }
 
@@ -1179,14 +1182,19 @@ impl TraceState {
                 }
             })
             .or_else(|| {
-                state.dispatch_order.iter().rev().copied().find_map(|dispatch_id| {
-                    let dispatch = state.dispatches.get(&dispatch_id)?;
-                    if Self::is_visible_dispatch(dispatch) {
-                        Some(dispatch_id)
-                    } else {
-                        None
-                    }
-                })
+                state
+                    .dispatch_order
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find_map(|dispatch_id| {
+                        let dispatch = state.dispatches.get(&dispatch_id)?;
+                        if Self::is_visible_dispatch(dispatch) {
+                            Some(dispatch_id)
+                        } else {
+                            None
+                        }
+                    })
             })
     }
 
@@ -1308,7 +1316,12 @@ impl TraceState {
             })
             .or_else(|| dispatch.handler_stack.last());
         let Some(handler) = handler else {
-            return (MISSING_UNKNOWN.to_string(), HandlerKind::RustBuiltin, None, None);
+            return (
+                MISSING_UNKNOWN.to_string(),
+                HandlerKind::RustBuiltin,
+                None,
+                None,
+            );
         };
         (
             handler.handler_name.clone(),
@@ -1420,7 +1433,33 @@ impl TraceState {
                     && lhs_exception_type == rhs_exception_type
                     && lhs_message == rhs_message
             }
-            _ => false,
+            (
+                ActiveChainEntry::ProgramYield { .. },
+                ActiveChainEntry::EffectYield { .. }
+                | ActiveChainEntry::ContextEntry { .. }
+                | ActiveChainEntry::ExceptionSite { .. },
+            )
+            | (
+                ActiveChainEntry::EffectYield { .. },
+                ActiveChainEntry::ProgramYield { .. }
+                | ActiveChainEntry::ContextEntry { .. }
+                | ActiveChainEntry::ExceptionSite { .. },
+            )
+            | (
+                ActiveChainEntry::ContextEntry { .. },
+                ActiveChainEntry::ProgramYield { .. }
+                | ActiveChainEntry::EffectYield { .. }
+                | ActiveChainEntry::ExceptionSite { .. },
+            )
+            | (
+                ActiveChainEntry::ExceptionSite { .. },
+                ActiveChainEntry::ProgramYield { .. }
+                | ActiveChainEntry::EffectYield { .. }
+                | ActiveChainEntry::ContextEntry { .. },
+            )
+            | (ActiveChainEntry::ContextEntry { .. }, ActiveChainEntry::ContextEntry { .. }) => {
+                false
+            }
         }
     }
 
@@ -1441,7 +1480,9 @@ impl TraceState {
         let exception_site = Self::exception_site(exception);
         let exception_function_name = match &exception_site {
             ActiveChainEntry::ExceptionSite { function_name, .. } => function_name.as_str(),
-            _ => "",
+            ActiveChainEntry::ProgramYield { .. }
+            | ActiveChainEntry::EffectYield { .. }
+            | ActiveChainEntry::ContextEntry { .. } => "",
         };
         let exception_function_is_visible = active_chain.iter().any(|entry| match entry {
             ActiveChainEntry::ProgramYield { function_name, .. }

--- a/packages/doeff-vm-core/src/value.rs
+++ b/packages/doeff-vm-core/src/value.rs
@@ -14,8 +14,8 @@ use crate::capture::{
 use crate::frame::CallMetadata;
 use crate::ids::{PromiseId, TaskId};
 use crate::kleisli::KleisliRef;
-use crate::pyvm::{PyTraceFrame, PyTraceHop};
 use crate::py_shared::PyShared;
+use crate::pyvm::{PyTraceFrame, PyTraceHop};
 
 /// Opaque handle to a spawned task.
 #[derive(Clone, Copy, Debug)]
@@ -489,7 +489,22 @@ impl Value {
     pub fn as_int(&self) -> Option<i64> {
         match self {
             Value::Int(i) => Some(*i),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::String(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 
@@ -497,7 +512,22 @@ impl Value {
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Value::String(s) => Some(s),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 
@@ -505,7 +535,22 @@ impl Value {
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Value::Bool(b) => Some(*b),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::String(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 
@@ -513,7 +558,22 @@ impl Value {
     pub fn as_handlers(&self) -> Option<&[KleisliRef]> {
         match self {
             Value::Handlers(h) => Some(h),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::String(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 }

--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -411,7 +411,11 @@ impl VM {
                     types,
                     ..
                 } if *handled_marker == marker => Some((seg_id, handler.clone(), types.clone())),
-                _ => None,
+                SegmentKind::PromptBoundary { .. }
+                | SegmentKind::Normal
+                | SegmentKind::InterceptorBoundary { .. }
+                | SegmentKind::MaskBoundary { .. }
+                | SegmentKind::FinallyBoundary { .. } => None,
             })
     }
 
@@ -472,7 +476,9 @@ impl VM {
                     mode: *mode,
                     metadata: metadata.clone(),
                 })),
-                _ => {
+                SegmentKind::Normal
+                | SegmentKind::MaskBoundary { .. }
+                | SegmentKind::FinallyBoundary { .. } => {
                     assert!(
                         self.interceptor_state.get_entry(seg.marker).is_none(),
                         "normal segment marker {} unexpectedly has interceptor state entry",
@@ -634,10 +640,7 @@ impl VM {
         child_seg.scope_store = source_seg.scope_store.clone();
     }
 
-    fn remap_interceptor_skip_markers(
-        seg: &mut Segment,
-        marker_remap: &HashMap<Marker, Marker>,
-    ) {
+    fn remap_interceptor_skip_markers(seg: &mut Segment, marker_remap: &HashMap<Marker, Marker>) {
         if marker_remap.is_empty() {
             return;
         }
@@ -654,7 +657,10 @@ impl VM {
         }
     }
 
-    fn remap_interceptor_markers_in_doctrl(ctrl: &mut DoCtrl, marker_remap: &HashMap<Marker, Marker>) {
+    fn remap_interceptor_markers_in_doctrl(
+        ctrl: &mut DoCtrl,
+        marker_remap: &HashMap<Marker, Marker>,
+    ) {
         match ctrl {
             DoCtrl::Pure { .. } => {}
             DoCtrl::Map { .. } => {}
@@ -747,12 +753,8 @@ impl VM {
             EvalReturnContinuation::EvalInScopeReturn { continuation } => {
                 Self::remap_interceptor_markers_in_continuation(continuation, marker_remap);
             }
-            EvalReturnContinuation::ApplyResolveFunction {
-                args, kwargs, ..
-            }
-            | EvalReturnContinuation::ExpandResolveFactory {
-                args, kwargs, ..
-            } => {
+            EvalReturnContinuation::ApplyResolveFunction { args, kwargs, .. }
+            | EvalReturnContinuation::ExpandResolveFactory { args, kwargs, .. } => {
                 for arg in args {
                     Self::remap_interceptor_markers_in_doctrl(arg, marker_remap);
                 }
@@ -760,7 +762,9 @@ impl VM {
                     Self::remap_interceptor_markers_in_doctrl(kwarg, marker_remap);
                 }
             }
-            EvalReturnContinuation::ApplyResolveArg { f, args, kwargs, .. } => {
+            EvalReturnContinuation::ApplyResolveArg {
+                f, args, kwargs, ..
+            } => {
                 Self::remap_interceptor_markers_in_doctrl(f, marker_remap);
                 for arg in args {
                     Self::remap_interceptor_markers_in_doctrl(arg, marker_remap);
@@ -769,7 +773,9 @@ impl VM {
                     Self::remap_interceptor_markers_in_doctrl(kwarg, marker_remap);
                 }
             }
-            EvalReturnContinuation::ApplyResolveKwarg { f, args, kwargs, .. } => {
+            EvalReturnContinuation::ApplyResolveKwarg {
+                f, args, kwargs, ..
+            } => {
                 Self::remap_interceptor_markers_in_doctrl(f, marker_remap);
                 for arg in args {
                     Self::remap_interceptor_markers_in_doctrl(arg, marker_remap);
@@ -802,7 +808,10 @@ impl VM {
         }
     }
 
-    fn remap_interceptor_markers_in_frame(frame: &mut Frame, marker_remap: &HashMap<Marker, Marker>) {
+    fn remap_interceptor_markers_in_frame(
+        frame: &mut Frame,
+        marker_remap: &HashMap<Marker, Marker>,
+    ) {
         match frame {
             Frame::Program { .. } => {}
             Frame::InterceptorApply(interceptor_continuation) => {
@@ -882,7 +891,10 @@ impl VM {
         }
     }
 
-    fn remap_interceptor_markers_in_segment(seg: &mut Segment, marker_remap: &HashMap<Marker, Marker>) {
+    fn remap_interceptor_markers_in_segment(
+        seg: &mut Segment,
+        marker_remap: &HashMap<Marker, Marker>,
+    ) {
         if marker_remap.is_empty() {
             return;
         }
@@ -1201,10 +1213,20 @@ impl VM {
         // Invariant: when a handler Program frame yields DoCtrl::IRStream via `yield helper()`,
         // that handler Program frame is on top of the stack. Reading the top Program frame's
         // provenance correctly propagates handler context to nested sub-program frames.
-        self.current_seg().frames.last().and_then(|frame| match frame {
-            Frame::Program { handler_kind, .. } => *handler_kind,
-            _ => None,
-        })
+        self.current_seg()
+            .frames
+            .last()
+            .and_then(|frame| match frame {
+                Frame::Program { handler_kind, .. } => *handler_kind,
+                Frame::InterceptorApply(_)
+                | Frame::InterceptorEval(_)
+                | Frame::HandlerDispatch { .. }
+                | Frame::EvalReturn(_)
+                | Frame::MapReturn { .. }
+                | Frame::FlatMapBindResult
+                | Frame::FlatMapBindSource { .. }
+                | Frame::InterceptBodyReturn { .. } => None,
+            })
     }
 
     fn dispatch_uses_user_continuation_stream(
@@ -1215,13 +1237,23 @@ impl VM {
         self.dispatch_state
             .find_by_dispatch_id(dispatch_id)
             .is_some_and(|ctx| {
-                ctx.k_current.frames_snapshot.iter().any(|frame| match frame {
-                    Frame::Program {
-                        stream: snapshot_stream,
-                        ..
-                    } => Arc::ptr_eq(snapshot_stream, stream),
-                    _ => false,
-                })
+                ctx.k_current
+                    .frames_snapshot
+                    .iter()
+                    .any(|frame| match frame {
+                        Frame::Program {
+                            stream: snapshot_stream,
+                            ..
+                        } => Arc::ptr_eq(snapshot_stream, stream),
+                        Frame::InterceptorApply(_)
+                        | Frame::InterceptorEval(_)
+                        | Frame::HandlerDispatch { .. }
+                        | Frame::EvalReturn(_)
+                        | Frame::MapReturn { .. }
+                        | Frame::FlatMapBindResult
+                        | Frame::FlatMapBindSource { .. }
+                        | Frame::InterceptBodyReturn { .. } => false,
+                    })
             })
     }
 
@@ -1303,11 +1335,7 @@ impl VM {
         }
     }
 
-    fn emit_frame_entered(
-        &mut self,
-        metadata: &CallMetadata,
-        handler_kind: Option<HandlerKind>,
-    ) {
+    fn emit_frame_entered(&mut self, metadata: &CallMetadata, handler_kind: Option<HandlerKind>) {
         self.trace_state.emit_frame_entered(
             metadata,
             Self::program_call_repr(metadata),
@@ -1319,11 +1347,7 @@ impl VM {
         self.trace_state.emit_frame_exited(metadata);
     }
 
-    fn emit_handler_threw_for_dispatch(
-        &mut self,
-        dispatch_id: DispatchId,
-        exc: &PyException,
-    ) {
+    fn emit_handler_threw_for_dispatch(&mut self, dispatch_id: DispatchId, exc: &PyException) {
         let handler_identity = self
             .current_handler_identity_for_dispatch(dispatch_id)
             .or_else(|| {
@@ -1452,11 +1476,14 @@ impl VM {
                 });
             }
 
-            let active_chain_obj = Value::ActiveChain(active_chain).to_pyobject(py).map_err(|err| {
-                VMError::python_error(format!(
-                    "failed to convert active_chain snapshot to Python object: {err}"
-                ))
-            })?;
+            let active_chain_obj =
+                Value::ActiveChain(active_chain)
+                    .to_pyobject(py)
+                    .map_err(|err| {
+                        VMError::python_error(format!(
+                            "failed to convert active_chain snapshot to Python object: {err}"
+                        ))
+                    })?;
             let active_chain_list = active_chain_obj.cast::<PyList>().map_err(|err| {
                 VMError::python_error(format!(
                     "active_chain snapshot serialization did not produce list: {err}"
@@ -1585,9 +1612,9 @@ impl VM {
                         Mode::Throw(exc) => {
                             self.begin_finally_cleanup(cleanup, FinallyOutcome::Throw(exc))
                         }
-                        _ => StepEvent::Error(VMError::internal(
-                            "invalid mode while resolving FinallyBoundary",
-                        )),
+                        Mode::HandleYield(_) | Mode::Return(_) => StepEvent::Error(
+                            VMError::internal("invalid mode while resolving FinallyBoundary"),
+                        ),
                     };
                 }
                 match mode {
@@ -1721,7 +1748,18 @@ impl VM {
                     ..
                 },
             ) => Python::attach(|py| lhs_value.bind(py).as_ptr() == rhs_value.bind(py).as_ptr()),
-            _ => false,
+            (
+                PyException::Materialized { .. },
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+            )
+            | (
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+                PyException::Materialized { .. },
+            )
+            | (PyException::RuntimeError { .. }, PyException::TypeError { .. })
+            | (PyException::TypeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::RuntimeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::TypeError { .. }, PyException::TypeError { .. }) => false,
         }
     }
 
@@ -2083,11 +2121,12 @@ impl VM {
                     &call,
                     PythonCall::GenNext | PythonCall::GenSend { .. } | PythonCall::GenThrow { .. }
                 ) {
-                    self.current_seg_mut().pending_python = Some(PendingPython::StepUserGenerator {
-                        stream,
-                        metadata,
-                        handler_kind,
-                    });
+                    self.current_seg_mut().pending_python =
+                        Some(PendingPython::StepUserGenerator {
+                            stream,
+                            metadata,
+                            handler_kind,
+                        });
                     return StepEvent::NeedsPython(call);
                 }
 
@@ -2133,14 +2172,8 @@ impl VM {
         handler_kind: Option<HandlerKind>,
     ) -> StepEvent {
         let chain = Arc::new(self.current_interceptor_chain());
-        self.current_seg_mut().mode = self.continue_interceptor_chain_mode(
-            yielded,
-            stream,
-            metadata,
-            handler_kind,
-            chain,
-            0,
-        );
+        self.current_seg_mut().mode =
+            self.continue_interceptor_chain_mode(yielded, stream, metadata, handler_kind, chain, 0);
         StepEvent::Continue
     }
 
@@ -3017,16 +3050,14 @@ impl VM {
         let Some(current_seg) = self.segments.get(current_seg_id) else {
             return StepEvent::Error(VMError::internal("EvalInScope current segment not found"));
         };
-        let mut return_to = Continuation::capture(current_seg, current_seg_id, current_seg.dispatch_id);
+        let mut return_to =
+            Continuation::capture(current_seg, current_seg_id, current_seg.dispatch_id);
         // Correctness constraint: active interceptor markers are still referenced by
         // live frames in the current dispatch. We must preserve them as-is for the
         // replay chain; remapping them would require remapping those live frames,
         // which are outside the EvalInScope replay scope.
-        let mut active_interceptor_markers: HashSet<Marker> = current_seg
-            .interceptor_skip_stack
-            .iter()
-            .copied()
-            .collect();
+        let mut active_interceptor_markers: HashSet<Marker> =
+            current_seg.interceptor_skip_stack.iter().copied().collect();
         active_interceptor_markers.insert(current_seg.marker);
 
         let Some(replay_chain_start_seg_id) = self.eval_in_scope_chain_start_segment(&scope) else {
@@ -3200,7 +3231,10 @@ impl VM {
         let prompt_seg = self.segments.get_mut(prompt_seg_id)?;
         match &mut prompt_seg.kind {
             SegmentKind::PromptBoundary { return_clause, .. } => return_clause.take(),
-            _ => None,
+            SegmentKind::Normal
+            | SegmentKind::InterceptorBoundary { .. }
+            | SegmentKind::MaskBoundary { .. }
+            | SegmentKind::FinallyBoundary { .. } => None,
         }
     }
 
@@ -3413,7 +3447,7 @@ impl VM {
                 self.current_seg_mut().mode =
                     self.mode_after_generror(GenErrorSite::CallFuncReturn, exception, false);
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -3456,7 +3490,7 @@ impl VM {
             PyCallOutcome::GenError(exception) => {
                 self.receive_expand_gen_error(handler_return, exception);
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -3484,18 +3518,21 @@ impl VM {
                             return;
                         };
                         seg.push_frame(Frame::HandlerDispatch { dispatch_id });
-                        match self.handle_yield_ir_stream(stream, metadata, Some(HandlerKind::Python)) {
+                        match self.handle_yield_ir_stream(
+                            stream,
+                            metadata,
+                            Some(HandlerKind::Python),
+                        ) {
                             StepEvent::Continue => {}
                             StepEvent::Error(err) => {
                                 self.current_seg_mut().mode =
                                     Mode::Throw(PyException::runtime_error(err.to_string()));
                             }
-                            _ => {
-                                self.current_seg_mut().mode = Mode::Throw(
-                                    PyException::runtime_error(
+                            StepEvent::NeedsPython(_) | StepEvent::Done(_) => {
+                                self.current_seg_mut().mode =
+                                    Mode::Throw(PyException::runtime_error(
                                         "unexpected StepEvent from handle_yield_ir_stream",
-                                    ),
-                                );
+                                    ));
                             }
                         }
                     }
@@ -3521,12 +3558,11 @@ impl VM {
                                 self.current_seg_mut().mode =
                                     Mode::Throw(PyException::runtime_error(err.to_string()));
                             }
-                            _ => {
-                                self.current_seg_mut().mode = Mode::Throw(
-                                    PyException::runtime_error(
+                            StepEvent::NeedsPython(_) | StepEvent::Done(_) => {
+                                self.current_seg_mut().mode =
+                                    Mode::Throw(PyException::runtime_error(
                                         "unexpected StepEvent from handle_yield_ir_stream",
-                                    ),
-                                );
+                                    ));
                             }
                         }
                     }
@@ -3657,7 +3693,7 @@ impl VM {
                     false,
                 );
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -3672,7 +3708,7 @@ impl VM {
                 self.current_seg_mut().mode =
                     self.mode_after_generror(GenErrorSite::AsyncEscape, exception, false);
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -4196,7 +4232,10 @@ impl VM {
                     cleanups.push(cleanup.clone());
                     cursor = seg.caller;
                 }
-                _ => break,
+                SegmentKind::Normal
+                | SegmentKind::PromptBoundary { .. }
+                | SegmentKind::InterceptorBoundary { .. }
+                | SegmentKind::MaskBoundary { .. } => break,
             }
         }
         cleanups
@@ -4295,7 +4334,8 @@ impl VM {
         self.lazy_pop_completed();
         let error_dispatch = self.error_dispatch_for_continuation(&k);
         self.record_continuation_activation(kind, &k, &value);
-        if let Err(err) = self.maybe_attach_active_chain_to_execution_context(k.dispatch_id, &mut value)
+        if let Err(err) =
+            self.maybe_attach_active_chain_to_execution_context(k.dispatch_id, &mut value)
         {
             return StepEvent::Error(err);
         }


### PR DESCRIPTION
## Summary
- replaced non-allowed Rust `_ =>` match arms in `packages/doeff-vm-core/src` and `packages/doeff-core-effects/src` with explicit variant handling
- preserved allowed patterns only: `_ => unreachable!()`, primitive-type catch-alls, and the known skip in `vm.rs` call-stack metadata path
- updated affected tests to avoid `_ =>` catch-all arms while preserving assertions

## Acceptance Criteria Evidence
1. **Zero `_ => {}` silent catch-alls in scope**
   - Command: `rg -n '_ =>' packages/doeff-vm-core/src/ packages/doeff-core-effects/src/`
   - Result: remaining matches are only allowed exceptions (`_ => unreachable!()`, primitive matches in `do_ctrl.rs`/string parsing, and known skip in `vm.rs` call-stack metadata path).

2. **Allowed catch-alls preserved**
   - `_ => unreachable!()` remains in VM fail-fast locations.
   - Primitive catch-alls remain in `do_ctrl.rs` (`char`/`&str`) and waitable type-string parsing.

3. **Exhaustive replacements applied for banned/default cases**
   - Replaced `_ => None` / `_ => false` / `_ => return None` / `_ => continue` / `_ => <error path>` across:
     - `packages/doeff-vm-core/src/value.rs`
     - `packages/doeff-vm-core/src/kleisli.rs`
     - `packages/doeff-vm-core/src/trace_state.rs`
     - `packages/doeff-vm-core/src/vm.rs`
     - `packages/doeff-core-effects/src/handlers/mod.rs`
     - `packages/doeff-core-effects/src/scheduler/mod.rs`

4. **`make sync && uv run pytest` passes**
   - `make sync`: succeeded (including `maturin develop` rebuild for `doeff-vm`).
   - `uv run pytest`: `1033 passed, 1 warning in 45.54s`.

5. **`cargo clippy` on both crates**
   - Ran successfully:
     - `cargo clippy --manifest-path packages/doeff-vm-core/Cargo.toml`
     - `cargo clippy --manifest-path packages/doeff-core-effects/Cargo.toml`
   - Both commands exit 0 (with existing warnings unrelated to this migration).

## Issue
- VM-CATCHALL-AUDIT-001
