### PR TITLE
Fix GRAPH-SNAPSHOT-HASATTR-001: remove graph_snapshot hasattr checks

### DIFF
--- a/doeff/graph_snapshot.py
+++ b/doeff/graph_snapshot.py
@@ -7,6 +7,7 @@ using vis.js Network, which is simpler and more reliable than Cytoscape.
 
 import asyncio
 import json
+import heapq
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,20 @@ from typing import Any
 from loguru import logger
 
 from doeff import Await, do
-from doeff.types import WGraph
+from doeff.types import WGraph, WStep
+
+
+def _step_value(step: WStep) -> Any | None:
+    output = step.output
+    return output.value if output is not None else None
+
+
+def _step_label(step: WStep, value: Any | None, fallback: str) -> str:
+    if step.meta:
+        maybe_label = step.meta.get("label")
+        if maybe_label is not None:
+            return str(maybe_label)
+    return str(value) if value is not None else fallback
 
 
 def escape_html(text: str) -> str:
@@ -48,47 +62,44 @@ def build_graph_snapshot(
     node_counter = 1
     node_ids: dict[int, int] = {}  # Map WNode id() to node ID
     node_lookup: dict[int, dict[str, Any]] = {}
+    steps = tuple(graph.steps)
+    last_step = graph.last
 
     # First pass: create nodes for all steps
-    if hasattr(graph, "steps"):
-        for step in graph.steps:
-            node_id = node_counter
-            node_counter += 1
+    for step in steps:
+        node_id = node_counter
+        node_counter += 1
 
-            # Map output node to ID
-            if hasattr(step, "output"):
-                node_ids[id(step.output)] = node_id
+        output = step.output
+        if output is not None:
+            node_ids[id(output)] = node_id
 
-            # WStep has output (WNode) which has value
-            value = step.output.value if hasattr(step, "output") and hasattr(step.output, "value") else None
+        value = _step_value(step)
+        label = _step_label(step, value, f"Step {node_id}")
 
-            # Try to get a label from value or meta
-            label = str(value) if value is not None else f"Step {node_id}"
-            if hasattr(step, "meta") and step.meta and "label" in step.meta:
-                label = step.meta["label"]
+        # Truncate label if too long
+        if len(label) > 30:
+            label = label[:27] + "..."
 
-            # Truncate label if too long
-            if len(label) > 30:
-                label = label[:27] + "..."
-
-            node_data = {
-                "id": node_id,
-                "label": label,
-                "title": repr(value) if value is not None else "",  # Tooltip
-                "color": {
-                    "background": "#dbeafe",
-                    "border": "#60a5fa"
-                }
+        node_data = {
+            "id": node_id,
+            "label": label,
+            "title": repr(value) if value is not None else "",  # Tooltip
+            "color": {
+                "background": "#dbeafe",
+                "border": "#60a5fa"
             }
+        }
 
-            nodes.append(node_data)
-            node_lookup[node_id] = node_data
+        nodes.append(node_data)
+        node_lookup[node_id] = node_data
 
     # Process last node (which is also a WStep)
-    if hasattr(graph, "last") and graph.last:
+    if last_step is not None:
+        last_output = last_step.output
         # Check if last node already exists
-        if hasattr(graph.last, "output") and id(graph.last.output) in node_ids:
-            last_node_id = node_ids[id(graph.last.output)]
+        if last_output is not None and id(last_output) in node_ids:
+            last_node_id = node_ids[id(last_output)]
             # Mark existing node as last
             for node in nodes:
                 if node["id"] == last_node_id:
@@ -105,14 +116,12 @@ def build_graph_snapshot(
             last_node_id = node_id
 
             # Map output node to ID
-            if hasattr(graph.last, "output"):
-                node_ids[id(graph.last.output)] = node_id
+            if last_output is not None:
+                node_ids[id(last_output)] = node_id
 
-            value = graph.last.output.value if hasattr(graph.last, "output") and hasattr(graph.last.output, "value") else None
+            value = _step_value(last_step)
 
-            label = str(value) if value is not None else "Complete"
-            if hasattr(graph.last, "meta") and graph.last.meta and "label" in graph.last.meta:
-                label = graph.last.meta["label"]
+            label = _step_label(last_step, value, "Complete")
 
             if len(label) > 30:
                 label = label[:27] + "..."
@@ -135,54 +144,47 @@ def build_graph_snapshot(
 
     # Second pass: create edges and determine levels
     # Build edges list first
-    edges_list: list[dict[str, int]] = []
+    edges_list: list[tuple[int, int]] = []
     seen_edges: set[tuple[int, int]] = set()
 
-    if hasattr(graph, "steps"):
-        for step in graph.steps:
-            if hasattr(step, "output") and hasattr(step, "inputs"):
-                target_id = node_ids.get(id(step.output))
+    for step in steps:
+        output = step.output
+        if output is None:
+            continue
+        target_id = node_ids.get(id(output))
+        if target_id:
+            for input_node in step.inputs:
+                source_id = node_ids.get(id(input_node))
+                if source_id:
+                    key = (source_id, target_id)
+                    if key not in seen_edges:
+                        seen_edges.add(key)
+                        edges_list.append((source_id, target_id))
+
+    # Add edges for last node
+    if last_step is not None:
+        included_in_steps = last_step in steps
+        if not included_in_steps:
+            last_output = last_step.output
+            if last_output is not None:
+                target_id = node_ids.get(id(last_output))
                 if target_id:
-                    for input_node in step.inputs:
+                    for input_node in last_step.inputs:
                         source_id = node_ids.get(id(input_node))
                         if source_id:
                             key = (source_id, target_id)
                             if key not in seen_edges:
                                 seen_edges.add(key)
-                                edges_list.append({
-                                    "from": source_id,
-                                    "to": target_id
-                                })
-
-    # Add edges for last node
-    if hasattr(graph, "last") and hasattr(graph.last, "inputs"):
-        included_in_steps = hasattr(graph, "steps") and graph.last in graph.steps
-        if not included_in_steps:
-            target_id = node_ids.get(id(graph.last.output))
-            if target_id:
-                for input_node in graph.last.inputs:
-                    source_id = node_ids.get(id(input_node))
-                    if source_id:
-                        key = (source_id, target_id)
-                        if key not in seen_edges:
-                            seen_edges.add(key)
-                            edges_list.append({
-                                "from": source_id,
-                                "to": target_id
-                            })
+                                edges_list.append((source_id, target_id))
 
     # Build adjacency for deterministic layout
     adjacency: dict[int, set[int]] = {node["id"]: set() for node in nodes}
     indegree: dict[int, int] = {node["id"]: 0 for node in nodes}
 
-    for edge in edges_list:
-        source_id = edge["from"]
-        target_id = edge["to"]
+    for source_id, target_id in edges_list:
         if target_id not in adjacency[source_id]:
             adjacency[source_id].add(target_id)
             indegree[target_id] += 1
-
-    import heapq
 
     level_map: dict[int, int] = {}
     topo_order: list[int] = []
@@ -242,9 +244,8 @@ def build_graph_snapshot(
     nodes.sort(key=lambda node: (node.get("level", 0), node.get("x", 0)))
 
     # Add arrows to edges
-    for edge in edges_list:
-        edge["arrows"] = "to"
-        edges.append(edge)
+    for source_id, target_id in edges_list:
+        edges.append({"from": source_id, "to": target_id, "arrows": "to"})
 
     return {
         "nodes": nodes,

--- a/tests/core/test_sa008_correctness_p0.py
+++ b/tests/core/test_sa008_correctness_p0.py
@@ -51,3 +51,8 @@ def test_p0_python_run_boundary_no_to_generator_duck_accept() -> None:
     src = _read("doeff/rust_vm.py")
     assert 'inspect.getattr_static(program, "to_generator", None)' not in src
     assert "if callable(to_gen):" not in src
+
+
+def test_p0_graph_snapshot_has_no_hasattr_duck_checks() -> None:
+    src = _read("doeff/graph_snapshot.py")
+    assert "hasattr(" not in src

--- a/tests/test_graph_snapshot.py
+++ b/tests/test_graph_snapshot.py
@@ -1,0 +1,65 @@
+from doeff.graph_snapshot import build_graph_snapshot
+from doeff.types import WGraph, WNode, WStep
+
+
+def _labels_by_id(snapshot: dict[str, object]) -> dict[int, str]:
+    nodes = snapshot["nodes"]
+    assert isinstance(nodes, list)
+    mapping: dict[int, str] = {}
+    for node in nodes:
+        assert isinstance(node, dict)
+        node_id = node.get("id")
+        label = node.get("label")
+        assert isinstance(node_id, int)
+        assert isinstance(label, str)
+        mapping[node_id] = label
+    return mapping
+
+
+def test_build_graph_snapshot_uses_step_meta_label_and_edges() -> None:
+    source_node = WNode("source")
+    sink_node = WNode("sink")
+    source_step = WStep(inputs=(), output=source_node)
+    sink_step = WStep(inputs=(source_node,), output=sink_node, meta={"label": "Labeled sink"})
+    graph = WGraph(last=sink_step, steps=frozenset({source_step, sink_step}))
+
+    snapshot = build_graph_snapshot(graph)
+    labels = _labels_by_id(snapshot)
+    edges = snapshot["edges"]
+
+    assert set(labels.values()) == {"source", "Labeled sink"}
+    assert isinstance(edges, list)
+    assert len(edges) == 1
+    edge = edges[0]
+    assert isinstance(edge, dict)
+    source_id = edge.get("from")
+    sink_id = edge.get("to")
+    assert isinstance(source_id, int)
+    assert isinstance(sink_id, int)
+    assert labels[source_id] == "source"
+    assert labels[sink_id] == "Labeled sink"
+
+
+def test_build_graph_snapshot_adds_last_step_when_missing_from_steps() -> None:
+    source_node = WNode("source")
+    source_step = WStep(inputs=(), output=source_node)
+    final_step = WStep(inputs=(source_node,), output=WNode("final"))
+    graph = WGraph(last=final_step, steps=frozenset({source_step}))
+
+    snapshot = build_graph_snapshot(graph, mark_success=True)
+    labels = _labels_by_id(snapshot)
+    edges = snapshot["edges"]
+
+    assert isinstance(edges, list)
+    assert len(labels) == 2
+    assert len(edges) == 1
+
+    final_id = next(node_id for node_id, label in labels.items() if label == "final")
+    final_node = next(
+        node
+        for node in snapshot["nodes"]
+        if isinstance(node, dict) and node.get("id") == final_id
+    )
+    assert isinstance(final_node, dict)
+    assert final_node.get("font") == {"bold": True}
+    assert final_node.get("color") == {"background": "#bbf7d0", "border": "#16a34a"}


### PR DESCRIPTION
## Summary
- removed all `hasattr(...)` duck-typing checks from `doeff/graph_snapshot.py`
- switched snapshot construction to direct typed access over `WGraph`/`WStep`
- refactored edge assembly to tuple-based intermediate edges while preserving output format
- added regression guard test to ban `hasattr(` in `graph_snapshot.py`
- added functional tests for snapshot labels/edges and last-step handling

## Validation / Acceptance Criteria
Issue: `GRAPH-SNAPSHOT-HASATTR-001`

1. Zero `hasattr()` in `graph_snapshot.py`
- Command: `rg -n "hasattr\\(" doeff/graph_snapshot.py`
- Result: no matches

2. Type-based access used
- `build_graph_snapshot` now operates directly on typed `WGraph`/`WStep` fields (`steps`, `last`, `output`, `inputs`, `meta`) without duck-typing checks.

3. `uv run pyright` passes (or no new errors)
- Command: `UV_PYTHON=3.12 uv run pyright`
- Result: fails with many pre-existing repo-wide errors (808 reported), including pre-existing decorator typing issues in `doeff/graph_snapshot.py` unrelated to this change.

4. `uv run pytest` passes
- Command: `UV_PYTHON=3.12 uv run pytest`
- Result: `1035 passed, 1 skipped, 1 warning`

5. `make lint` clean
- Command: `UV_PYTHON=3.12 make lint`
- Result: fails in `lint-pyright` with pre-existing repo-wide pyright errors; lint run does not reach clean state.

## Targeted Tests Added/Run
- `UV_PYTHON=3.12 uv run pytest tests/core/test_sa008_correctness_p0.py::test_p0_graph_snapshot_has_no_hasattr_duck_checks -q`
- `UV_PYTHON=3.12 uv run pytest tests/test_graph_snapshot.py -q`

## Issue Reference
- GRAPH-SNAPSHOT-HASATTR-001
