### PR TITLE
Add doeff_vm stubs and remove Rust getattr fallbacks

### DIFF
--- a/doeff/__main__.py
+++ b/doeff/__main__.py
@@ -9,7 +9,7 @@ import os
 import sys
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from doeff import Program, RunResult
 from doeff.analysis import EffectCallTree
@@ -374,9 +374,11 @@ def _render_run_output(context: ResolvedRunContext, execution: RunExecutionResul
 
 
 def _run_result_report(run_result: RunResult[Any], *, verbose: bool) -> str:
-    display = getattr(run_result, "display", None)
+    run_result_any = cast(Any, run_result)
+    display = run_result_any.display if hasattr(run_result_any, "display") else None
     if callable(display):
-        return display(verbose=verbose)
+        rendered = display(verbose=verbose)
+        return rendered if isinstance(rendered, str) else str(rendered)
 
     status = "ok" if run_result.is_ok() else "error"
     lines = [f"RunResult status: {status}"]
@@ -384,16 +386,16 @@ def _run_result_report(run_result: RunResult[Any], *, verbose: bool) -> str:
     if run_result.is_ok():
         lines.append(f"Value: {run_result.value!r}")
     else:
-        error_value = getattr(run_result, "error", None)
+        error_value = run_result_any.error if hasattr(run_result_any, "error") else None
         if isinstance(error_value, BaseException):
             lines.append(f"Error: {error_value!r}")
         else:
             lines.append("Error: unavailable")
 
     if verbose:
-        log_entries = getattr(run_result, "log", None)
-        trace_entries = getattr(run_result, "trace", None)
-        store = getattr(run_result, "raw_store", None)
+        log_entries = run_result_any.log if hasattr(run_result_any, "log") else None
+        trace_entries = run_result_any.trace if hasattr(run_result_any, "trace") else None
+        store = run_result_any.raw_store if hasattr(run_result_any, "raw_store") else None
         if isinstance(log_entries, list):
             lines.append(f"Log entries: {len(log_entries)}")
         if isinstance(trace_entries, list):
@@ -505,9 +507,13 @@ def _unwrap_run_result(result: RunResult[Any]) -> Any:
         try:
             from doeff.traceback import attach_doeff_traceback
 
+            result_any = cast(Any, result)
+            traceback_data = (
+                result_any.traceback_data if hasattr(result_any, "traceback_data") else None
+            )
             doeff_tb = attach_doeff_traceback(
                 exc,
-                traceback_data=getattr(result, "traceback_data", None),
+                traceback_data=traceback_data,
             )
             if doeff_tb is not None:
                 setattr(exc, "doeff_traceback", doeff_tb)
@@ -526,10 +532,18 @@ def _json_safe(value: Any) -> Any:
 
 
 def _call_tree_ascii(run_result: RunResult[Any]) -> str | None:
-    observations = getattr(run_result, "effect_observations", None)
+    run_result_any = cast(Any, run_result)
+    observations = (
+        run_result_any.effect_observations
+        if hasattr(run_result_any, "effect_observations")
+        else None
+    )
     if observations is None:
-        context = getattr(run_result, "context", None)
-        observations = getattr(context, "effect_observations", None)
+        context = run_result_any.context if hasattr(run_result_any, "context") else None
+        if context is not None:
+            observations = (
+                context.effect_observations if hasattr(context, "effect_observations") else None
+            )
     if not observations:
         return None
 

--- a/doeff/_types_internal.py
+++ b/doeff/_types_internal.py
@@ -1011,15 +1011,17 @@ class _UserEffectStackSection(_BaseSection):
             # First, add frames from the program call stack (outer -> inner call chain).
             if entry.call_stack_snapshot:
                 for call_frame in entry.call_stack_snapshot:
-                    filename = getattr(call_frame, "source_file", None)
-                    if filename is None and isinstance(call_frame, dict):
+                    if isinstance(call_frame, dict):
                         filename = call_frame.get("source_file")
-                    line_no = getattr(call_frame, "source_line", None)
-                    if line_no is None and isinstance(call_frame, dict):
                         line_no = call_frame.get("source_line")
-                    function_name = getattr(call_frame, "function_name", None)
-                    if function_name is None and isinstance(call_frame, dict):
                         function_name = call_frame.get("function_name")
+                    else:
+                        try:
+                            filename = call_frame.source_file
+                            line_no = call_frame.source_line
+                            function_name = call_frame.function_name
+                        except AttributeError:
+                            continue
 
                     if not isinstance(filename, str) or not isinstance(line_no, int):
                         continue
@@ -1131,15 +1133,17 @@ class _ErrorSection(_BaseSection):
             return [self.indent(2, "📍 Raised at: <unknown>")]
 
         for call_frame in reversed(entry.call_stack_snapshot):
-            source_file = getattr(call_frame, "source_file", None)
-            if source_file is None and isinstance(call_frame, dict):
+            if isinstance(call_frame, dict):
                 source_file = call_frame.get("source_file")
-            source_line = getattr(call_frame, "source_line", None)
-            if source_line is None and isinstance(call_frame, dict):
                 source_line = call_frame.get("source_line")
-            function_name = getattr(call_frame, "function_name", None)
-            if function_name is None and isinstance(call_frame, dict):
                 function_name = call_frame.get("function_name")
+            else:
+                try:
+                    source_file = call_frame.source_file
+                    source_line = call_frame.source_line
+                    function_name = call_frame.function_name
+                except AttributeError:
+                    continue
 
             if not isinstance(source_file, str) or not isinstance(source_line, int):
                 continue

--- a/doeff/cache.py
+++ b/doeff/cache.py
@@ -117,9 +117,12 @@ def _call_site_from_program_frames(call_stack: list[Any] | tuple[Any, ...]) -> C
             source_line = frame.get("source_line")
             function_name = frame.get("function_name")
         else:
-            source_file = getattr(frame, "source_file", None)
-            source_line = getattr(frame, "source_line", None)
-            function_name = getattr(frame, "function_name", None)
+            try:
+                source_file = frame.source_file
+                source_line = frame.source_line
+                function_name = frame.function_name
+            except AttributeError:
+                continue
 
         if not isinstance(source_file, str) or not isinstance(source_line, int):
             continue

--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -248,8 +248,9 @@ def _register_vm_kleisli_types() -> None:
     except Exception:
         return
 
-    py_kleisli = getattr(vm, "PyKleisli", None)
-    if py_kleisli is None:
+    try:
+        py_kleisli = vm.PyKleisli
+    except AttributeError:
         return
     try:
         KleisliProgram.register(py_kleisli)

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -75,16 +75,13 @@ def _coerce_handler(
     role: str,
 ) -> Any:
     vm = _vm()
-    rust_handler_type = getattr(vm, "RustHandler", None)
-    if rust_handler_type is not None and isinstance(handler, rust_handler_type):
+    if isinstance(handler, vm.RustHandler):
         return handler
 
-    py_kleisli_type = getattr(vm, "PyKleisli", None)
-    if py_kleisli_type is not None and isinstance(handler, py_kleisli_type):
+    if isinstance(handler, vm.PyKleisli):
         return handler
 
-    doeff_generator_fn_type = getattr(vm, "DoeffGeneratorFn", None)
-    if doeff_generator_fn_type is not None and isinstance(handler, doeff_generator_fn_type):
+    if isinstance(handler, vm.DoeffGeneratorFn):
         return handler
     raise TypeError(_format_handler_type_error(api_name=api_name, role=role, value=handler))
 
@@ -97,8 +94,8 @@ def _coerce_program(program: Any) -> Any:
     if isinstance(program, vm.DoExpr):
         return program
 
-    doeff_generator_type = getattr(vm, "DoeffGenerator", None)
-    if doeff_generator_type is not None and isinstance(program, doeff_generator_type):
+    doeff_generator_type = vars(vm).get("DoeffGenerator")
+    if isinstance(doeff_generator_type, type) and isinstance(program, doeff_generator_type):
         raise TypeError(
             "program must be DoExpr; got DoeffGenerator. "
             "Pass the DoExpr program object (not .to_generator())."
@@ -230,8 +227,11 @@ def _with_intercept_metadata(interceptor: Any) -> dict[str, Any]:
 
 def _unhandled_effect_error_types(vm: Any) -> tuple[type[BaseException], ...]:
     error_types: list[type[BaseException]] = []
-    for name in ("UnhandledEffectError", "NoMatchingHandlerError"):
-        error_type = getattr(vm, name, None)
+    vm_attrs = vars(vm)
+    for error_type in (
+        vm_attrs.get("UnhandledEffectError"),
+        vm_attrs.get("NoMatchingHandlerError"),
+    ):
         if isinstance(error_type, type) and issubclass(error_type, BaseException):
             error_types.append(error_type)
     return tuple(error_types)
@@ -250,13 +250,22 @@ def _raise_unhandled_effect_if_present(run_result: Any, *, raise_unhandled: bool
 
 
 def _build_doeff_traceback_if_present(run_result: Any) -> Any | None:
-    is_err = getattr(run_result, "is_err", None)
+    try:
+        is_err = run_result.is_err
+    except AttributeError:
+        return None
     if not callable(is_err) or not is_err():
         return None
-    error = getattr(run_result, "error", None)
+    try:
+        error = run_result.error
+    except AttributeError:
+        return None
     if not isinstance(error, BaseException):
         return None
-    traceback_data = getattr(run_result, "traceback_data", None)
+    try:
+        traceback_data = run_result.traceback_data
+    except AttributeError:
+        return None
     if traceback_data is None:
         return None
     try:
@@ -343,8 +352,17 @@ async def _call_async_run_fn(run_fn: Any, program: Any, kwargs: dict[str, Any]) 
 def _core_handler_sentinels(vm: Any) -> list[Any]:
     """Return the shared core handler sentinel stack from doeff_vm."""
     required = ("state", "reader", "writer", "result_safe", "scheduler", "lazy_ask")
-    if all(hasattr(vm, name) for name in required):
-        return [getattr(vm, name) for name in required]
+    try:
+        return [
+            vm.state,
+            vm.reader,
+            vm.writer,
+            vm.result_safe,
+            vm.scheduler,
+            vm.lazy_ask,
+        ]
+    except AttributeError:
+        pass
     missing = [name for name in required if not hasattr(vm, name)]
     missing_txt = ", ".join(missing)
     raise RuntimeError(
@@ -401,9 +419,10 @@ def run(
     print_doeff_trace: bool = True,
 ) -> Any:
     vm = _vm()
-    run_fn = getattr(vm, "run", None)
-    if run_fn is None:
-        raise RuntimeError("Installed doeff_vm module does not expose run()")
+    try:
+        run_fn = vm.run
+    except AttributeError as exc:
+        raise RuntimeError("Installed doeff_vm module does not expose run()") from exc
     raise_unhandled = isinstance(program, vm.EffectBase)
     program = _coerce_program(program)
     program = _wrap_handlers(program, handlers, api_name="run()")
@@ -428,9 +447,10 @@ async def async_run(
     print_doeff_trace: bool = True,
 ) -> Any:
     vm = _vm()
-    run_fn = getattr(vm, "async_run", None)
-    if run_fn is None:
-        raise RuntimeError("Installed doeff_vm module does not expose async_run()")
+    try:
+        run_fn = vm.async_run
+    except AttributeError as exc:
+        raise RuntimeError("Installed doeff_vm module does not expose async_run()") from exc
     raise_unhandled = isinstance(program, vm.EffectBase)
     program = _coerce_program(program)
     program = _wrap_handlers(program, handlers, api_name="async_run()")
@@ -483,9 +503,11 @@ def WithIntercept(
 def __getattr__(name: str) -> Any:
     if name == "pass_":
         vm = _vm()
-        if not hasattr(vm, "Pass"):
+        vm_attrs = vars(vm)
+        pass_type = vm_attrs.get("Pass")
+        if pass_type is None:
             raise AttributeError("doeff_vm has no attribute 'Pass'")
-        return vm.Pass
+        return pass_type
     if name in {
         "RunResult",
         "DoeffTracebackData",
@@ -518,9 +540,11 @@ def __getattr__(name: str) -> Any:
         "await_handler",
     }:
         vm = _vm()
-        if not hasattr(vm, name):
+        vm_attrs = vars(vm)
+        value = vm_attrs.get(name)
+        if value is None:
             raise AttributeError(f"doeff_vm has no attribute '{name}'")
-        return getattr(vm, name)
+        return value
     raise AttributeError(name)
 
 

--- a/packages/doeff-vm/doeff_vm/__init__.pyi
+++ b/packages/doeff-vm/doeff_vm/__init__.pyi
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Generic, Protocol, TypeVar
+
+_T = TypeVar("_T")
+
+
+class CallFrame(Protocol):
+    source_file: str
+    source_line: int
+    function_name: str
+
+
+class DoExpr:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None: ...
+    def to_generator(self) -> Any: ...
+
+
+class EffectBase:
+    tag: int
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None: ...
+
+
+class DoCtrlBase(DoExpr):
+    tag: int
+
+
+class K:
+    def __repr__(self) -> str: ...
+
+
+class TraceFrame:
+    func_name: str
+    source_file: str
+    source_line: int
+    def __init__(self, func_name: str, source_file: str, source_line: int) -> None: ...
+
+
+class TraceHop:
+    frames: list[TraceFrame]
+    def __init__(self, frames: list[TraceFrame]) -> None: ...
+
+
+class Ok(Generic[_T]):
+    value: _T
+    def __init__(self, value: _T) -> None: ...
+    def is_ok(self) -> bool: ...
+    def is_err(self) -> bool: ...
+
+
+class Err(Generic[_T]):
+    error: _T
+    captured_traceback: Any
+    def __init__(self, error: _T, captured_traceback: Any | None = None) -> None: ...
+    def is_ok(self) -> bool: ...
+    def is_err(self) -> bool: ...
+
+
+class DoeffTracebackData:
+    entries: Any
+    active_chain: Any
+    def __init__(self, entries: Any, active_chain: Any | None = None) -> None: ...
+
+
+class RunResult(Generic[_T]):
+    traceback_data: DoeffTracebackData | None
+    raw_store: dict[str, Any]
+    log: list[Any]
+    trace: list[Any]
+    @property
+    def value(self) -> _T: ...
+    @property
+    def error(self) -> BaseException: ...
+    @property
+    def result(self) -> Ok[_T] | Err[Any]: ...
+    def is_ok(self) -> bool: ...
+    def is_err(self) -> bool: ...
+    def display(self, verbose: bool = False) -> str: ...
+
+
+class DoeffGeneratorFn:
+    callable: Any
+    function_name: str
+    source_file: str
+    source_line: int
+    get_frame: Callable[[Any], Any]
+    def __init__(
+        self,
+        callable: Callable[..., Any],
+        function_name: str,
+        source_file: str,
+        source_line: int,
+        get_frame: Callable[[Any], Any],
+    ) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> DoeffGenerator: ...
+
+
+class DoeffGenerator:
+    generator: Any
+    get_frame: Callable[[Any], Any]
+    factory: DoeffGeneratorFn | None
+    def __init__(
+        self,
+        generator: Any,
+        function_name: str | None = None,
+        source_file: str | None = None,
+        source_line: int | None = None,
+        get_frame: Callable[[Any], Any] | None = None,
+        factory: DoeffGeneratorFn | None = None,
+    ) -> None: ...
+    @property
+    def __doeff_inner__(self) -> Any: ...
+    @property
+    def function_name(self) -> str: ...
+    @property
+    def source_file(self) -> str: ...
+    @property
+    def source_line(self) -> int: ...
+
+
+class PyKleisli:
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        name: str,
+        file: str | None = None,
+        line: int | None = None,
+    ) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def __rshift__(self, binder: Any) -> Any: ...
+    def partial(self, *args: Any, **kwargs: Any) -> Any: ...
+    def and_then_k(self, binder: Any) -> Any: ...
+    def fmap(self, mapper: Any) -> Any: ...
+
+
+class RustHandler:
+    def __repr__(self) -> str: ...
+
+
+class WithHandler(DoCtrlBase):
+    handler: Any
+    expr: Any
+    types: tuple[type[Any], ...] | None
+    return_clause: Callable[..., Any] | None
+    handler_name: str | None
+    handler_file: str | None
+    handler_line: int | None
+    def __init__(
+        self,
+        handler: Any,
+        expr: Any,
+        return_clause: Callable[..., Any] | None = None,
+        *,
+        types: Iterable[type[Any]] | None = None,
+        handler_name: str | None = None,
+        handler_file: str | None = None,
+        handler_line: int | None = None,
+    ) -> None: ...
+
+
+class WithIntercept(DoCtrlBase):
+    f: Any
+    expr: Any
+    types: tuple[type[Any], ...] | None
+    mode: str
+    meta: dict[str, Any] | None
+    def __init__(
+        self,
+        f: Any,
+        expr: Any,
+        types: Iterable[type[Any]] | None = None,
+        mode: str = "include",
+        meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class Finally(DoCtrlBase):
+    cleanup: Any
+    def __init__(self, cleanup: Any) -> None: ...
+
+
+class Pure(DoCtrlBase):
+    value: Any
+    def __init__(self, value: Any) -> None: ...
+
+
+class Apply(DoCtrlBase):
+    f: Any
+    args: Any
+    kwargs: dict[str, Any]
+    meta: dict[str, Any] | None
+    evaluate_result: bool
+    def __init__(
+        self,
+        f: Any,
+        args: Any,
+        kwargs: dict[str, Any],
+        meta: dict[str, Any] | None = None,
+        evaluate_result: bool = True,
+    ) -> None: ...
+
+
+class Expand(DoCtrlBase):
+    factory: Any
+    args: Any
+    kwargs: dict[str, Any]
+    meta: dict[str, Any] | None
+    def __init__(
+        self,
+        factory: Any,
+        args: Any,
+        kwargs: dict[str, Any],
+        meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class Map(DoCtrlBase):
+    source: Any
+    mapper: Callable[..., Any]
+    mapper_meta: dict[str, Any]
+    def __init__(
+        self,
+        source: Any,
+        mapper: Callable[..., Any],
+        mapper_meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class FlatMap(DoCtrlBase):
+    source: Any
+    binder: Callable[..., Any]
+    binder_meta: dict[str, Any]
+    def __init__(
+        self,
+        source: Any,
+        binder: Callable[..., Any],
+        binder_meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class Eval(DoCtrlBase):
+    expr: Any
+    def __init__(self, expr: Any) -> None: ...
+
+
+class EvalInScope(DoCtrlBase):
+    expr: Any
+    scope: K
+    def __init__(self, expr: Any, scope: K) -> None: ...
+
+
+class Perform(DoCtrlBase):
+    effect: Any
+    def __init__(self, effect: EffectBase) -> None: ...
+
+
+class Resume(DoCtrlBase):
+    continuation: K
+    value: Any
+    def __init__(self, continuation: K, value: Any) -> None: ...
+
+
+class Delegate(DoCtrlBase):
+    def __init__(self) -> None: ...
+
+
+class Pass(DoCtrlBase):
+    def __init__(self) -> None: ...
+
+
+class Transfer(DoCtrlBase):
+    continuation: K
+    value: Any
+    def __init__(self, continuation: K, value: Any) -> None: ...
+
+
+class ResumeContinuation(DoCtrlBase):
+    continuation: K
+    value: Any
+    def __init__(self, continuation: K, value: Any) -> None: ...
+
+
+class CreateContinuation(DoCtrlBase):
+    program: Any
+    handlers: Any
+    def __init__(self, program: Any, handlers: Any) -> None: ...
+
+
+class GetContinuation(DoCtrlBase):
+    def __init__(self) -> None: ...
+
+
+class GetHandlers(DoCtrlBase):
+    def __init__(self) -> None: ...
+
+
+class GetTraceback(DoCtrlBase):
+    continuation: K
+    def __init__(self, continuation: K) -> None: ...
+
+
+class GetCallStack(DoCtrlBase):
+    def __init__(self) -> None: ...
+
+
+class PythonAsyncSyntaxEscape(DoCtrlBase):
+    action: Callable[..., Awaitable[Any]]
+    def __init__(self, action: Callable[..., Awaitable[Any]]) -> None: ...
+
+
+class _NestingStep:
+    def to_generator(self) -> Any: ...
+
+
+class _NestingGenerator:
+    def __iter__(self) -> _NestingGenerator: ...
+    def __next__(self) -> Any: ...
+    def send(self, value: Any) -> Any: ...
+    def throw(self, exc: BaseException) -> Any: ...
+
+
+class GetExecutionContext(EffectBase):
+    def __init__(self) -> None: ...
+
+
+class ExecutionContext:
+    entries: list[Any]
+    active_chain: Any | None
+    def __init__(self) -> None: ...
+    def add(self, entry: Any) -> None: ...
+    def set_active_chain(self, active_chain: Any | None) -> None: ...
+
+
+class PyGet(EffectBase):
+    key: str
+    def __init__(self, key: str) -> None: ...
+
+
+class PyPut(EffectBase):
+    key: str
+    value: Any
+    def __init__(self, key: str, value: Any) -> None: ...
+
+
+class PyModify(EffectBase):
+    key: str
+    func: Callable[[Any], Any]
+    def __init__(self, key: str, func: Callable[[Any], Any]) -> None: ...
+
+
+class PyAsk(EffectBase):
+    key: Any
+    def __init__(self, key: Any) -> None: ...
+
+
+class PyLocal(EffectBase):
+    env_update: Any
+    sub_program: Any
+    def __init__(self, env_update: Any, sub_program: Any) -> None: ...
+
+
+class PyTell(EffectBase):
+    message: Any
+    def __init__(self, message: Any) -> None: ...
+
+
+class SpawnEffect(EffectBase):
+    program: Any
+    options: Any
+    handlers: Any
+    store_mode: Any
+    priority: Any
+    def __init__(
+        self,
+        program: Any,
+        options: Any | None = None,
+        handlers: Any | None = None,
+        store_mode: Any | None = None,
+        priority: Any | None = None,
+    ) -> None: ...
+
+
+class GatherEffect(EffectBase):
+    items: Any
+    _partial_results: Any
+    def __init__(self, items: Any, _partial_results: Any | None = None) -> None: ...
+
+
+class RaceEffect(EffectBase):
+    futures: Any
+    def __init__(self, futures: Any) -> None: ...
+
+
+class CreatePromiseEffect(EffectBase):
+    def __init__(self) -> None: ...
+
+
+class CompletePromiseEffect(EffectBase):
+    promise: Any
+    value: Any
+    def __init__(self, promise: Any, value: Any) -> None: ...
+
+
+class FailPromiseEffect(EffectBase):
+    promise: Any
+    error: Any
+    def __init__(self, promise: Any, error: Any) -> None: ...
+
+
+class CreateExternalPromiseEffect(EffectBase):
+    def __init__(self) -> None: ...
+
+
+class PyCancelEffect(EffectBase):
+    task: Any
+    def __init__(self, task: Any) -> None: ...
+
+
+class _SchedulerTaskCompleted(EffectBase):
+    task: Any
+    task_id: Any
+    handle_id: Any
+    result: Any
+    def __init__(
+        self,
+        *,
+        task: Any | None = None,
+        task_id: Any | None = None,
+        handle_id: Any | None = None,
+        result: Any | None = None,
+    ) -> None: ...
+
+
+class CreateSemaphoreEffect(EffectBase):
+    permits: int
+    def __init__(self, permits: int) -> None: ...
+
+
+class AcquireSemaphoreEffect(EffectBase):
+    semaphore: Any
+    def __init__(self, semaphore: Any) -> None: ...
+
+
+class ReleaseSemaphoreEffect(EffectBase):
+    semaphore: Any
+    def __init__(self, semaphore: Any) -> None: ...
+
+
+class PythonAsyncioAwaitEffect(EffectBase):
+    awaitable: Awaitable[Any]
+    def __init__(self, awaitable: Awaitable[Any]) -> None: ...
+
+
+class ResultSafeEffect(EffectBase):
+    sub_program: Any
+    def __init__(self, sub_program: Any) -> None: ...
+
+
+class ProgramCallStackEffect(EffectBase):
+    def __init__(self) -> None: ...
+
+
+class ProgramCallFrameEffect(EffectBase):
+    depth: int
+    def __init__(self, depth: int = 0) -> None: ...
+
+
+class UnhandledEffectError(TypeError): ...
+class NoMatchingHandlerError(UnhandledEffectError): ...
+class TaskCancelledError(RuntimeError): ...
+
+
+class PyVM:
+    def __init__(self) -> None: ...
+    def run(self, program: Any) -> Any: ...
+    def run_with_result(self, program: Any) -> RunResult[Any]: ...
+    def state_items(self) -> dict[str, Any]: ...
+    def logs(self) -> list[Any]: ...
+    def put_state(self, key: str, value: Any) -> None: ...
+    def put_env(self, key: Any, value: Any) -> None: ...
+    def env_items(self) -> dict[Any, Any]: ...
+    def enable_debug(self, level: str) -> None: ...
+    def py_store(self) -> dict[str, Any] | None: ...
+    def set_store(self, key: str, value: Any) -> None: ...
+    def get_store(self, key: str) -> Any: ...
+    def build_run_result(self, value: Any) -> RunResult[Any]: ...
+    def build_run_result_error(
+        self, error: BaseException, traceback_data: Any | None = None
+    ) -> RunResult[Any]: ...
+    def start_program(self, program: Any) -> None: ...
+    def step_once(self) -> tuple[Any, ...]: ...
+    def feed_async_result(self, value: Any) -> None: ...
+    def feed_async_error(self, error_value: BaseException) -> None: ...
+
+
+def run(
+    program: Any,
+    env: dict[Any, Any] | None = None,
+    store: dict[str, Any] | None = None,
+    trace: bool = False,
+) -> RunResult[Any]: ...
+def async_run(
+    program: Any,
+    env: dict[Any, Any] | None = None,
+    store: dict[str, Any] | None = None,
+    trace: bool = False,
+) -> Awaitable[RunResult[Any]]: ...
+
+
+def _coerce_handler(handler: Any, *, api_name: str, role: str) -> Any: ...
+def _notify_semaphore_handle_dropped(state_id: int, semaphore_id: int) -> None: ...
+def _debug_scheduler_semaphore_count(state_id: int) -> int | None: ...
+
+
+DoThunkBase: type[Any] | None
+ResultOk: type[Ok[Any]]
+ResultErr: type[Err[Any]]
+
+state: RustHandler
+reader: RustHandler
+writer: RustHandler
+result_safe: RustHandler
+scheduler: RustHandler
+lazy_ask: RustHandler
+await_handler: RustHandler
+
+PySpawn: type[SpawnEffect]
+PyGather: type[GatherEffect]
+PyRace: type[RaceEffect]
+PyCreatePromise: type[CreatePromiseEffect]
+PyCompletePromise: type[CompletePromiseEffect]
+PyFailPromise: type[FailPromiseEffect]
+PyCreateExternalPromise: type[CreateExternalPromiseEffect]
+TaskCancelEffect: type[PyCancelEffect]
+PyTaskCompleted: type[_SchedulerTaskCompleted]
+
+TAG_PURE: int
+TAG_MAP: int
+TAG_FLAT_MAP: int
+TAG_WITH_HANDLER: int
+TAG_PERFORM: int
+TAG_RESUME: int
+TAG_TRANSFER: int
+TAG_DELEGATE: int
+TAG_PASS: int
+TAG_GET_CONTINUATION: int
+TAG_GET_HANDLERS: int
+TAG_GET_TRACEBACK: int
+TAG_WITH_INTERCEPT: int
+TAG_FINALLY: int
+TAG_GET_CALL_STACK: int
+TAG_EVAL: int
+TAG_EVAL_IN_SCOPE: int
+TAG_APPLY: int
+TAG_EXPAND: int
+TAG_CREATE_CONTINUATION: int
+TAG_RESUME_CONTINUATION: int
+TAG_ASYNC_ESCAPE: int
+TAG_EFFECT: int
+TAG_UNKNOWN: int
+
+__all__: list[str]


### PR DESCRIPTION
## Summary
- add `packages/doeff-vm/doeff_vm/__init__.pyi` with typed stubs for PyO3-exported runtime API (run/async_run, control classes, effect classes, RunResult/DoeffTracebackData, sentinels, errors, tags, aliases)
- replace Rust-type fallback `getattr(..., None)` access patterns with direct/typed access across runtime integration points
- keep dict fallbacks where call-frame snapshots can still be dict-backed

## Acceptance Criteria Evidence
1. `doeff_vm` stubs exist
   - `ls -l packages/doeff-vm/doeff_vm/__init__.pyi`
2. Category B `getattr` calls replaced
   - `rg -n "getattr\(vm,|getattr\(run_result," doeff packages/doeff-vm` -> no matches
   - `rg -n "getattr\((call_frame|frame)," doeff/_types_internal.py doeff/cache.py` -> no matches
3. Type checking
   - `uv run pyright` currently reports large pre-existing repository-wide errors (771 errors, 57 warnings), so full pass is not achievable in this branch
   - no new targeted regressions observed in modified Rust bridge files; updated code type-checks in context of existing baseline failures
4. Tests
   - `uv run pytest` -> `1033 passed, 1 warning`
5. Zero Rust-VM getattr patterns
   - verified by grep checks above

## Issue
- DOEFF-VM-STUBS-001
