### PR TITLE
TRACE-TOMBSTONE-001: remove ProgramTrace tombstone

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -2036,18 +2036,18 @@ rules:
     languages: [rust]
     severity: ERROR
 
-  - id: trace-no-program-trace-import
-    pattern-regex: 'from\s+doeff\.effects\.trace\s+import\s+.*\bProgramTrace\b'
-    paths:
-      include:
-        - "**/doeff/**"
-      exclude:
-        - "**/tests/**"
-    message: |
-      BANNED: ProgramTrace effect was removed in TRACE-CAPTURE-LOG-SEPARATION.
-      Use GetTraceback(k) inside handlers for traceback introspection.
+  - id: ban-program-trace-import
     languages: [python]
     severity: ERROR
+    message: >
+      ProgramTrace is removed. Use GetExecutionContext() instead.
+      Ref: TRACE-TOMBSTONE-001.
+    pattern-either:
+      - pattern: from doeff.effects.trace import ProgramTrace
+      - pattern: from doeff import ProgramTrace
+    paths:
+      exclude:
+        - tests/
 
   - id: trace-no-assemble-trace
     pattern-regex: 'fn\s+assemble_trace\s*\('

--- a/doeff/effects/trace.py
+++ b/doeff/effects/trace.py
@@ -1,12 +1,4 @@
 """Trace introspection effects."""
 
 
-def ProgramTrace():
-    """Removed in TRACE-CAPTURE-LOG-SEPARATION."""
-
-    raise NotImplementedError(
-        "ProgramTrace was removed. Use GetTraceback(k) for handler-scoped introspection."
-    )
-
-
 __all__: list[str] = []

--- a/tests/core/test_program_trace_removed.py
+++ b/tests/core/test_program_trace_removed.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
-import doeff
 import doeff_vm
-import pytest
+
+import doeff
 
 
 def test_program_trace_effect_removed() -> None:
-    import doeff.effects as effects
+    from doeff import effects
+    from doeff.effects import trace as trace_effects
 
     assert not hasattr(doeff, "ProgramTrace")
     assert not hasattr(effects, "ProgramTrace")
-
-    import doeff.effects.trace as trace_effects
-
-    if hasattr(trace_effects, "ProgramTrace"):
-        with pytest.raises(NotImplementedError):
-            trace_effects.ProgramTrace()
+    assert not hasattr(trace_effects, "ProgramTrace")
 
 
 def test_get_trace_doctrl_removed() -> None:


### PR DESCRIPTION
## Summary
- Removed dead `ProgramTrace()` tombstone from `doeff/effects/trace.py`.
- Tightened regression coverage so `doeff.effects.trace.ProgramTrace` must not exist.
- Replaced prior ProgramTrace import rule with `ban-program-trace-import` per TRACE-TOMBSTONE-001, covering:
  - `from doeff.effects.trace import ProgramTrace`
  - `from doeff import ProgramTrace`

## Acceptance Criteria Evidence (TRACE-TOMBSTONE-001)
1. `ProgramTrace` function deleted
- File diff removes function from `doeff/effects/trace.py`.
- Verified no symbol remains in key public API modules:
  - `rg -n "ProgramTrace|ProgramTraceEffect" doeff/effects/trace.py doeff/effects/__init__.py doeff/__init__.py`
  - Output: no matches.

2. Removed from all `__all__` lists
- `ProgramTrace`/`ProgramTraceEffect` are absent from:
  - `doeff/effects/trace.py`
  - `doeff/effects/__init__.py`
  - `doeff/__init__.py`
- Same `rg` verification above returns no matches.

3. Semgrep rule bans future imports
- Added rule `ban-program-trace-import` in `.semgrep.yaml`.
- Verified repo has no violations with this rule:
  - `repo_semgrep_exit=0`
- Verified rule blocks banned import on synthetic file:
  - `sample_semgrep_exit=1`
  - Finding: `tmp.ban-program-trace-import` on `from doeff import ProgramTrace`.

4. All existing tests pass
- `DOEFF_INDEXER_SKIP_CLI_BUILD=1 make test`
- Result: `1033 passed, 1 warning`.

5. `make lint` clean
- Attempted: `DOEFF_INDEXER_SKIP_CLI_BUILD=1 make lint`
- Current branch reports pre-existing pyright errors unrelated to this change and fails before completion.
- Also ran `make lint-semgrep`; it reports many pre-existing findings across the repository unrelated to this issue.

## TDD Evidence
- Tightened `tests/core/test_program_trace_removed.py` first, then ran:
  - `PYTHONPATH=. uv run --no-project --with pytest --with ./packages/doeff-vm --with frozendict --with loguru --with cloudpickle pytest tests/core/test_program_trace_removed.py::test_program_trace_effect_removed -q`
  - Initial result: failing assertion because `ProgramTrace` existed.
- After implementation:
  - `DOEFF_INDEXER_SKIP_CLI_BUILD=1 uv run pytest tests/core/test_program_trace_removed.py -q`
  - Result: `2 passed`.

Ref: TRACE-TOMBSTONE-001
