### PR TITLE
GETATTR-LAZY-CLEANUP-001: replace lazy getattr with typed access

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -30,6 +30,77 @@ rules:
         - /packages/**/tests/**
         - /packages/**/python/temporal-sdk*/**
 
+  - id: no-lazy-getattr-cli-runresult-owned-types
+    languages: [python]
+    severity: ERROR
+    message: >
+      BANNED: lazy getattr fallback on RunResult in CLI code hides typing regressions.
+      Access typed attributes directly. (GETATTR-LAZY-CLEANUP-001)
+    pattern-either:
+      - pattern: getattr(run_result, "display", $DEFAULT)
+      - pattern: getattr(run_result, "error", $DEFAULT)
+      - pattern: getattr(run_result, "log", $DEFAULT)
+      - pattern: getattr(run_result, "trace", $DEFAULT)
+      - pattern: getattr(run_result, "raw_store", $DEFAULT)
+      - pattern: getattr(run_result, "effect_observations", $DEFAULT)
+      - pattern: getattr(run_result, "context", $DEFAULT)
+      - pattern: getattr(context, "effect_observations", $DEFAULT)
+      - pattern: getattr(result, "traceback_data", $DEFAULT)
+    paths:
+      include:
+        - "**/doeff/__main__.py"
+
+  - id: no-lazy-getattr-cli-argparse-owned-namespace
+    languages: [python]
+    severity: ERROR
+    message: >
+      BANNED: argparse Namespace values in CLI handlers should be accessed directly once
+      arguments are declared in build_parser(). (GETATTR-LAZY-CLEANUP-001)
+    pattern-either:
+      - pattern: getattr(args, "no_runbox", $DEFAULT)
+      - pattern: getattr(args, "apply", $DEFAULT)
+      - pattern: getattr(args, "transform", $DEFAULT)
+      - pattern: getattr(args, "report", $DEFAULT)
+      - pattern: getattr(args, "report_verbose", $DEFAULT)
+      - pattern: getattr(args, "code", $DEFAULT)
+      - pattern: getattr(args, "program", $DEFAULT)
+      - pattern: getattr(args, "script", $DEFAULT)
+      - pattern: getattr(args, "format", $DEFAULT)
+    paths:
+      include:
+        - "**/doeff/__main__.py"
+
+  - id: no-lazy-getattr-kleisli-owned-state
+    languages: [python]
+    severity: ERROR
+    message: >
+      BANNED: KleisliProgram internal state must use typed attributes, not lazy getattr defaults.
+      (GETATTR-LAZY-CLEANUP-001)
+    pattern-either:
+      - pattern: getattr(self, "__doeff_do_decorated__", $DEFAULT)
+      - pattern: getattr(self, "_auto_unwrap_strategy", $DEFAULT)
+      - pattern: getattr(self, "_metadata_source", $DEFAULT)
+      - pattern: getattr(self, "__name__", $DEFAULT)
+      - pattern: getattr(self, "_is_do_decorated", $DEFAULT)
+      - pattern: getattr(self, "_doeff_generator_factory", $DEFAULT)
+    paths:
+      include:
+        - "**/doeff/kleisli.py"
+
+  - id: no-lazy-getattr-rust-vm-handler-metadata
+    languages: [python]
+    severity: ERROR
+    message: >
+      BANNED: rust_vm handler metadata extraction must use typed handler narrowing,
+      not lazy getattr fallbacks. (GETATTR-LAZY-CLEANUP-001)
+    pattern-either:
+      - pattern: getattr(handler, "func", $DEFAULT)
+      - pattern: getattr(handler, "__signature__", $DEFAULT)
+      - pattern: getattr(handler, "_metadata_source", $DEFAULT)
+    paths:
+      include:
+        - "**/doeff/rust_vm.py"
+
   - id: no-make-typed-handler
     languages: [python]
     severity: ERROR

--- a/doeff/__main__.py
+++ b/doeff/__main__.py
@@ -9,7 +9,7 @@ import os
 import sys
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol, cast
 
 from doeff import Program, RunResult
 from doeff.analysis import EffectCallTree
@@ -69,6 +69,41 @@ class RunExecutionResult:
     final_value: Any
     run_result: RunResult[Any] | None
     call_tree_ascii: str | None
+
+
+class _RunResultContextWithObservations(Protocol):
+    effect_observations: list[Any] | None
+
+
+class _RunResultWithCliReport(Protocol):
+    log: list[Any]
+    trace: list[Any]
+
+    def display(self, *, verbose: bool = False) -> str: ...
+
+
+class _RunResultWithEffectObservations(Protocol):
+    effect_observations: list[Any] | None
+
+
+class _RunResultWithObservationContext(Protocol):
+    context: _RunResultContextWithObservations | None
+
+
+class RunCliArgs(argparse.Namespace):
+    func: Callable[["RunCliArgs"], int]
+    command: str
+    program: str | None
+    code: str | None
+    interpreter: str | None
+    envs: list[str] | None
+    apply: str | None
+    transform: list[str] | None
+    format: str
+    report: bool
+    report_verbose: bool
+    no_runbox: bool
+    script: str | None
 
 
 class SymbolResolver:
@@ -374,7 +409,8 @@ def _render_run_output(context: ResolvedRunContext, execution: RunExecutionResul
 
 
 def _run_result_report(run_result: RunResult[Any], *, verbose: bool) -> str:
-    display = getattr(run_result, "display", None)
+    run_result_with_meta = cast(_RunResultWithCliReport, run_result)
+    display = run_result_with_meta.display
     if callable(display):
         return display(verbose=verbose)
 
@@ -384,16 +420,16 @@ def _run_result_report(run_result: RunResult[Any], *, verbose: bool) -> str:
     if run_result.is_ok():
         lines.append(f"Value: {run_result.value!r}")
     else:
-        error_value = getattr(run_result, "error", None)
+        error_value = run_result.error
         if isinstance(error_value, BaseException):
             lines.append(f"Error: {error_value!r}")
         else:
             lines.append("Error: unavailable")
 
     if verbose:
-        log_entries = getattr(run_result, "log", None)
-        trace_entries = getattr(run_result, "trace", None)
-        store = getattr(run_result, "raw_store", None)
+        log_entries = run_result_with_meta.log
+        trace_entries = run_result_with_meta.trace
+        store = run_result.raw_store
         if isinstance(log_entries, list):
             lines.append(f"Log entries: {len(log_entries)}")
         if isinstance(trace_entries, list):
@@ -507,7 +543,7 @@ def _unwrap_run_result(result: RunResult[Any]) -> Any:
 
             doeff_tb = attach_doeff_traceback(
                 exc,
-                traceback_data=getattr(result, "traceback_data", None),
+                traceback_data=result.traceback_data,
             )
             if doeff_tb is not None:
                 setattr(exc, "doeff_traceback", doeff_tb)
@@ -526,10 +562,16 @@ def _json_safe(value: Any) -> Any:
 
 
 def _call_tree_ascii(run_result: RunResult[Any]) -> str | None:
-    observations = getattr(run_result, "effect_observations", None)
+    observations: list[Any] | None = None
+    if hasattr(run_result, "effect_observations"):
+        run_result_with_observations = cast(_RunResultWithEffectObservations, run_result)
+        observations = run_result_with_observations.effect_observations
     if observations is None:
-        context = getattr(run_result, "context", None)
-        observations = getattr(context, "effect_observations", None)
+        if hasattr(run_result, "context"):
+            run_result_with_context = cast(_RunResultWithObservationContext, run_result)
+            context = run_result_with_context.context
+            if context is not None:
+                observations = context.effect_observations
     if not observations:
         return None
 
@@ -642,7 +684,7 @@ def _detect_cwd_package() -> str | None:
     return None
 
 
-def handle_run_code(args: argparse.Namespace) -> int:
+def handle_run_code(args: RunCliArgs) -> int:
     from doeff.cli.code_runner import execute_doeff_code
 
     code = args.code
@@ -654,7 +696,7 @@ def handle_run_code(args: argparse.Namespace) -> int:
         return 1
 
     # Create runbox record before execution (if runbox CLI is available)
-    skip_runbox = getattr(args, "no_runbox", False)
+    skip_runbox = args.no_runbox
     maybe_create_runbox_record(skip_runbox=skip_runbox)
     program: Program[Any] = execute_doeff_code(code, filename="<doeff-code>")
 
@@ -663,11 +705,11 @@ def handle_run_code(args: argparse.Namespace) -> int:
         program_instance=program,
         interpreter_path=args.interpreter,
         env_paths=args.envs or [],
-        apply_path=getattr(args, "apply", None),
-        transformer_paths=getattr(args, "transform", None) or [],
+        apply_path=args.apply,
+        transformer_paths=args.transform or [],
         output_format=args.format,
-        report=getattr(args, "report", False),
-        report_verbose=getattr(args, "report_verbose", False),
+        report=args.report,
+        report_verbose=args.report_verbose,
     )
 
     command = RunCommand(context)
@@ -676,17 +718,17 @@ def handle_run_code(args: argparse.Namespace) -> int:
     return 0
 
 
-def handle_run(args: argparse.Namespace) -> int:
-    code_arg = getattr(args, "code", None)
+def handle_run(args: RunCliArgs) -> int:
+    code_arg = args.code
     if code_arg is not None:
         return handle_run_code(args)
 
-    if not getattr(args, "program", None):
+    if not args.program:
         print("Error: --program is required when not using -c", file=sys.stderr)
         return 1
 
     # Create runbox record before execution (if runbox CLI is available)
-    skip_runbox = getattr(args, "no_runbox", False)
+    skip_runbox = args.no_runbox
     maybe_create_runbox_record(skip_runbox=skip_runbox)
     context = RunContext(
         program_path=args.program,
@@ -696,11 +738,11 @@ def handle_run(args: argparse.Namespace) -> int:
         apply_path=args.apply,
         transformer_paths=args.transform or [],
         output_format=args.format,
-        report=getattr(args, "report", False),
-        report_verbose=getattr(args, "report_verbose", False),
+        report=args.report,
+        report_verbose=args.report_verbose,
     )
 
-    script = getattr(args, "script", None)
+    script = args.script
     if script == "-" or (script is not None and script.strip()):
         return handle_run_with_script(context, script)
 
@@ -819,7 +861,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
-    args = parser.parse_args(list(argv) if argv is not None else None)
+    args = cast(RunCliArgs, parser.parse_args(list(argv) if argv is not None else None))
     try:
         return args.func(args)
     except Exception as exc:
@@ -829,7 +871,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             if cause is not None:
                 doeff_tb = getattr(cause, "doeff_traceback", None)
         captured = capture_traceback(exc)
-        if getattr(args, "format", "text") == "json":
+        if args.format == "json":
             payload = {
                 "status": "error",
                 "error": exc.__class__.__name__,

--- a/doeff/do.py
+++ b/doeff/do.py
@@ -277,7 +277,7 @@ class DoYieldFunction(KleisliProgram[P, T]):
         if signature is not None:
             self.__signature__ = signature
 
-        self.__doeff_do_decorated__ = True
+        object.__setattr__(self, "__doeff_do_decorated__", True)
         object.__setattr__(self, "_is_do_decorated", True)
 
         strategy = _build_auto_unwrap_strategy(self)
@@ -411,9 +411,13 @@ def do(
     kleisli.__wrapped__ = func
     kleisli.original_func = func
     kleisli.original_generator = func
-    kleisli.__doeff_do_decorated__ = True
-    kleisli._is_do_decorated = True
-    kleisli._doeff_generator_factory = getattr(do_yield_fn, "_doeff_generator_factory", None)
+    object.__setattr__(kleisli, "__doeff_do_decorated__", True)
+    object.__setattr__(kleisli, "_is_do_decorated", True)
+    object.__setattr__(
+        kleisli,
+        "_doeff_generator_factory",
+        getattr(do_yield_fn, "_doeff_generator_factory", None),
+    )
 
     return cast(KleisliProgram[P, T], kleisli)
 

--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from collections.abc import Callable as TypingCallable
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Generic, ParamSpec, TypeVar, get_type_hints
+from typing import Any, ClassVar, Generic, ParamSpec, TypeVar, get_type_hints
 
 from doeff.program import (
     Program,
@@ -52,11 +52,16 @@ class KleisliProgram(ABC, Generic[P, T]):
     """
 
     func: Callable[P, Program[T]]
+    __doeff_do_decorated__: ClassVar[bool] = False
+    _auto_unwrap_strategy: ClassVar[Any] = None
+    _metadata_source: ClassVar[Any] = None
+    _is_do_decorated: ClassVar[bool] = False
+    _doeff_generator_factory: ClassVar[Any] = None
 
     def __post_init__(self) -> None:
         wrapped = getattr(self.func, "__wrapped__", self.func)
         object.__setattr__(self, "_metadata_source", wrapped)
-        is_do_decorated = bool(getattr(self, "__doeff_do_decorated__", False))
+        is_do_decorated = bool(self.__doeff_do_decorated__)
         object.__setattr__(self, "_is_do_decorated", is_do_decorated)
 
         signature = _safe_signature(wrapped) or _safe_signature(self.func)
@@ -88,7 +93,7 @@ class KleisliProgram(ABC, Generic[P, T]):
 
         from doeff.types import EffectBase
 
-        strategy = getattr(self, "_auto_unwrap_strategy", None)
+        strategy = self._auto_unwrap_strategy
         if strategy is None:
             strategy = _build_auto_unwrap_strategy(self)
             object.__setattr__(self, "_auto_unwrap_strategy", strategy)
@@ -110,11 +115,12 @@ class KleisliProgram(ABC, Generic[P, T]):
             for key, value in kwargs.items()
         }
 
-        metadata_source = getattr(self, "_metadata_source", self.func)
+        metadata_source = self._metadata_source or self.func
         code_obj = getattr(metadata_source, "__code__", None)
-        function_name = getattr(
-            self, "__name__", getattr(metadata_source, "__name__", "<anonymous>")
-        )
+        try:
+            function_name = self.__name__
+        except AttributeError:
+            function_name = getattr(metadata_source, "__name__", "<anonymous>")
         metadata = {
             "function_name": function_name,
             "source_file": getattr(code_obj, "co_filename", "<unknown>"),
@@ -123,8 +129,8 @@ class KleisliProgram(ABC, Generic[P, T]):
             "program_call": None,
         }
 
-        if bool(getattr(self, "_is_do_decorated", False)):
-            generator_factory = getattr(self, "_doeff_generator_factory", None)
+        if bool(self._is_do_decorated):
+            generator_factory = self._doeff_generator_factory
             if generator_factory is None:
                 raise TypeError(
                     "@do KleisliProgram is missing _doeff_generator_factory (DoeffGeneratorFn)"

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -3,7 +3,7 @@ import inspect
 import types as py_types
 import warnings
 from collections.abc import Sequence
-from typing import Annotated, Any, ForwardRef, Union, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, ForwardRef, Protocol, TypeGuard, Union, get_args, get_origin, get_type_hints
 
 
 def _vm() -> Any:
@@ -192,15 +192,30 @@ def _resolve_handler_effect_types(annotation: Any) -> tuple[type[Any], ...] | No
     return None
 
 
+class _HandlerWithMetadata(Protocol):
+    func: Any
+    __signature__: inspect.Signature | None
+    _metadata_source: Any | None
+
+
+def _is_handler_with_metadata(handler: Any) -> TypeGuard[_HandlerWithMetadata]:
+    return all(hasattr(handler, attr) for attr in ("func", "__signature__", "_metadata_source"))
+
+
 def _extract_handler_effect_types(handler: Any) -> tuple[type[Any], ...] | None:
     """Extract effect filter types from a handler's first parameter annotation.
 
     Returns None when the annotation implies "handle all effects" or cannot be
     resolved safely.
     """
-    func = getattr(handler, "func", handler)
+    func = handler
+    metadata_source: Any | None = None
+    signature: inspect.Signature | None = None
+    if _is_handler_with_metadata(handler):
+        func = handler.func
+        signature = handler.__signature__
+        metadata_source = handler._metadata_source
 
-    signature = getattr(handler, "__signature__", None)
     if signature is None:
         signature = _safe_signature(func) or _safe_signature(handler)
     if signature is None:
@@ -211,7 +226,6 @@ def _extract_handler_effect_types(handler: Any) -> tuple[type[Any], ...] | None:
         return None
 
     effect_param = params[0]
-    metadata_source = getattr(handler, "_metadata_source", None)
     type_hints = _safe_get_type_hints(metadata_source)
     if not type_hints:
         type_hints = _safe_get_type_hints(func)

--- a/tests/core/test_getattr_lazy_cleanup.py
+++ b/tests/core/test_getattr_lazy_cleanup.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_source(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_cli_run_result_uses_typed_access() -> None:
+    source = _read_source("doeff/__main__.py")
+    forbidden = (
+        'getattr(run_result, "display", None)',
+        'getattr(run_result, "error", None)',
+        'getattr(run_result, "log", None)',
+        'getattr(run_result, "trace", None)',
+        'getattr(run_result, "raw_store", None)',
+        'getattr(result, "traceback_data", None)',
+        'getattr(run_result, "effect_observations", None)',
+        'getattr(run_result, "context", None)',
+        'getattr(context, "effect_observations", None)',
+    )
+    for snippet in forbidden:
+        assert snippet not in source
+
+
+def test_cli_args_use_typed_access() -> None:
+    source = _read_source("doeff/__main__.py")
+    forbidden = (
+        'getattr(args, "no_runbox", False)',
+        'getattr(args, "apply", None)',
+        'getattr(args, "transform", None)',
+        'getattr(args, "report", False)',
+        'getattr(args, "report_verbose", False)',
+        'getattr(args, "code", None)',
+        'getattr(args, "program", None)',
+        'getattr(args, "script", None)',
+    )
+    for snippet in forbidden:
+        assert snippet not in source
+
+
+def test_kleisli_internal_state_uses_typed_access() -> None:
+    source = _read_source("doeff/kleisli.py")
+    forbidden = (
+        'getattr(self, "__doeff_do_decorated__", False)',
+        'getattr(self, "_auto_unwrap_strategy", None)',
+        'getattr(self, "_metadata_source", self.func)',
+        'getattr(self, "__name__", getattr(metadata_source, "__name__", "<anonymous>"))',
+        'getattr(self, "_is_do_decorated", False)',
+        'getattr(self, "_doeff_generator_factory", None)',
+    )
+    for snippet in forbidden:
+        assert snippet not in source
+
+
+def test_rust_vm_handler_metadata_uses_typed_access() -> None:
+    source = _read_source("doeff/rust_vm.py")
+    forbidden = (
+        'getattr(handler, "func", handler)',
+        'getattr(handler, "__signature__", None)',
+        'getattr(handler, "_metadata_source", None)',
+    )
+    for snippet in forbidden:
+        assert snippet not in source


### PR DESCRIPTION
## Summary
Implements GETATTR-LAZY-CLEANUP-001 by replacing lazy `getattr(..., default)` access with typed/direct access in the requested sites:
- `doeff/__main__.py` RunResult and argparse namespace access
- `doeff/kleisli.py` own-instance internal state access
- `doeff/rust_vm.py` handler metadata access

Also adds:
- regression tests that ban the legacy snippets (`tests/core/test_getattr_lazy_cleanup.py`)
- semgrep guard rules to prevent reintroduction of these patterns (`.semgrep.yaml`)

## Changes
- `doeff/__main__.py`
  - Added typed CLI args shape (`RunCliArgs`)
  - Replaced listed `getattr(args, ...)` calls with direct access
  - Replaced listed `RunResult` lazy access with typed/direct access
  - Kept compatibility for call-tree extraction via typed narrowing (`hasattr` + Protocol casts) because some `RunResult` implementations do not expose `effect_observations/context`
- `doeff/kleisli.py`
  - Declared typed internal state defaults as class attributes
  - Replaced listed lazy `getattr(self, ...)` calls with direct attribute reads
- `doeff/rust_vm.py`
  - Added typed handler metadata protocol + type guard
  - Replaced listed lazy handler metadata `getattr` calls with narrowed direct access
- `doeff/do.py`
  - Switched related internal assignments to `object.__setattr__` to stay compatible with frozen/classvar metadata fields
- `.semgrep.yaml`
  - Added 4 ERROR rules for the cleaned-up lazy-getattr patterns
- `tests/core/test_getattr_lazy_cleanup.py`
  - Added source-level regression tests for all issue-listed call sites

## Validation Evidence
### TDD red phase (new regression tests fail before fix)
- `uvx --from pytest pytest --noconftest tests/core/test_getattr_lazy_cleanup.py -q`
  - Result before implementation: `4 failed`

### Green phase after implementation
- `uvx --from pytest pytest --noconftest tests/core/test_getattr_lazy_cleanup.py -q`
  - Result: `4 passed`
- `uv run pytest tests/core/test_getattr_lazy_cleanup.py tests/test_with_handler_type_filter.py tests/program/test_handler_annotation_resolution.py`
  - Result: `26 passed`
- `uv run pytest`
  - Result: `1037 passed, 1 warning`

### Acceptance criteria checks
1. All listed Category C `getattr` call sites replaced: ✅
2. No new listed lazy `getattr` patterns introduced: ✅
3. `uv run pyright`: ⚠️ fails due pre-existing repository-wide pyright errors (outside this issue scope)
4. `uv run pytest`: ✅ pass (`1037 passed`)
5. `make lint`: ⚠️ fails due pre-existing repository-wide lint/pyright/semgrep findings unrelated to this patch

## Issue Reference
- GETATTR-LAZY-CLEANUP-001
