### PR TITLE
GRAPH-SNAPSHOT-HASATTR-001: remove hasattr duck typing from graph snapshot

### DIFF
--- a/doeff/graph_snapshot.py
+++ b/doeff/graph_snapshot.py
@@ -49,127 +49,118 @@ def build_graph_snapshot(
     node_ids: dict[int, int] = {}  # Map WNode id() to node ID
     node_lookup: dict[int, dict[str, Any]] = {}
 
+    def _label_for(value: Any, meta: dict[str, Any], fallback: str) -> str:
+        label = str(value) if value is not None else fallback
+        meta_label = meta.get("label")
+        if meta_label is not None:
+            label = str(meta_label)
+        if len(label) > 30:
+            return label[:27] + "..."
+        return label
+
     # First pass: create nodes for all steps
-    if hasattr(graph, "steps"):
-        for step in graph.steps:
-            node_id = node_counter
-            node_counter += 1
+    for step in graph.steps:
+        node_id = node_counter
+        node_counter += 1
 
-            # Map output node to ID
-            if hasattr(step, "output"):
-                node_ids[id(step.output)] = node_id
+        # Map output node to ID
+        node_ids[id(step.output)] = node_id
 
-            # WStep has output (WNode) which has value
-            value = step.output.value if hasattr(step, "output") and hasattr(step.output, "value") else None
+        value = step.output.value
+        label = _label_for(value, step.meta, f"Step {node_id}")
 
-            # Try to get a label from value or meta
-            label = str(value) if value is not None else f"Step {node_id}"
-            if hasattr(step, "meta") and step.meta and "label" in step.meta:
-                label = step.meta["label"]
-
-            # Truncate label if too long
-            if len(label) > 30:
-                label = label[:27] + "..."
-
-            node_data = {
-                "id": node_id,
-                "label": label,
-                "title": repr(value) if value is not None else "",  # Tooltip
-                "color": {
-                    "background": "#dbeafe",
-                    "border": "#60a5fa"
-                }
+        node_data = {
+            "id": node_id,
+            "label": label,
+            "title": repr(value) if value is not None else "",  # Tooltip
+            "color": {
+                "background": "#dbeafe",
+                "border": "#60a5fa"
             }
+        }
 
-            nodes.append(node_data)
-            node_lookup[node_id] = node_data
+        nodes.append(node_data)
+        node_lookup[node_id] = node_data
 
     # Process last node (which is also a WStep)
-    if hasattr(graph, "last") and graph.last:
-        # Check if last node already exists
-        if hasattr(graph.last, "output") and id(graph.last.output) in node_ids:
-            last_node_id = node_ids[id(graph.last.output)]
-            # Mark existing node as last
-            for node in nodes:
-                if node["id"] == last_node_id:
-                    if mark_success:
-                        node["color"] = {
-                            "background": "#bbf7d0",
-                            "border": "#16a34a"
-                        }
-                    node["font"] = {"bold": True}
-                    break
-        else:
-            # Create new node for last
-            node_id = node_counter
-            last_node_id = node_id
+    last_step = graph.last
+    # Check if last node already exists
+    if id(last_step.output) in node_ids:
+        last_node_id = node_ids[id(last_step.output)]
+        # Mark existing node as last
+        for node in nodes:
+            if node["id"] == last_node_id:
+                if mark_success:
+                    node["color"] = {
+                        "background": "#bbf7d0",
+                        "border": "#16a34a"
+                    }
+                node["font"] = {"bold": True}
+                break
+    else:
+        # Create new node for last
+        node_id = node_counter
+        last_node_id = node_id
 
-            # Map output node to ID
-            if hasattr(graph.last, "output"):
-                node_ids[id(graph.last.output)] = node_id
+        # Map output node to ID
+        node_ids[id(last_step.output)] = node_id
 
-            value = graph.last.output.value if hasattr(graph.last, "output") and hasattr(graph.last.output, "value") else None
+        value = last_step.output.value
+        label = _label_for(value, last_step.meta, "Complete")
 
-            label = str(value) if value is not None else "Complete"
-            if hasattr(graph.last, "meta") and graph.last.meta and "label" in graph.last.meta:
-                label = graph.last.meta["label"]
+        node_data = {
+            "id": node_id,
+            "label": label,
+            "title": repr(value) if value is not None else "",
+            "font": {"bold": True}
+        }
 
-            if len(label) > 30:
-                label = label[:27] + "..."
-
-            node_data = {
-                "id": node_id,
-                "label": label,
-                "title": repr(value) if value is not None else "",
-                "font": {"bold": True}
+        if mark_success:
+            node_data["color"] = {
+                "background": "#bbf7d0",
+                "border": "#16a34a"
             }
 
-            if mark_success:
-                node_data["color"] = {
-                    "background": "#bbf7d0",
-                    "border": "#16a34a"
-                }
-
-            nodes.append(node_data)
-            node_lookup[node_id] = node_data
+        nodes.append(node_data)
+        node_lookup[node_id] = node_data
 
     # Second pass: create edges and determine levels
     # Build edges list first
-    edges_list: list[dict[str, int]] = []
+    edges_list: list[dict[str, Any]] = []
     seen_edges: set[tuple[int, int]] = set()
 
-    if hasattr(graph, "steps"):
-        for step in graph.steps:
-            if hasattr(step, "output") and hasattr(step, "inputs"):
-                target_id = node_ids.get(id(step.output))
-                if target_id:
-                    for input_node in step.inputs:
-                        source_id = node_ids.get(id(input_node))
-                        if source_id:
-                            key = (source_id, target_id)
-                            if key not in seen_edges:
-                                seen_edges.add(key)
-                                edges_list.append({
-                                    "from": source_id,
-                                    "to": target_id
-                                })
+    for step in graph.steps:
+        target_id = node_ids.get(id(step.output))
+        if target_id is None:
+            continue
+        for input_node in step.inputs:
+            source_id = node_ids.get(id(input_node))
+            if source_id is None:
+                continue
+            key = (source_id, target_id)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                edges_list.append({
+                    "from": source_id,
+                    "to": target_id
+                })
 
     # Add edges for last node
-    if hasattr(graph, "last") and hasattr(graph.last, "inputs"):
-        included_in_steps = hasattr(graph, "steps") and graph.last in graph.steps
-        if not included_in_steps:
-            target_id = node_ids.get(id(graph.last.output))
-            if target_id:
-                for input_node in graph.last.inputs:
-                    source_id = node_ids.get(id(input_node))
-                    if source_id:
-                        key = (source_id, target_id)
-                        if key not in seen_edges:
-                            seen_edges.add(key)
-                            edges_list.append({
-                                "from": source_id,
-                                "to": target_id
-                            })
+    included_in_steps = last_step in graph.steps
+    if not included_in_steps:
+        target_id = node_ids.get(id(last_step.output))
+        if target_id is not None:
+            for input_node in last_step.inputs:
+                source_id = node_ids.get(id(input_node))
+                if source_id is None:
+                    continue
+                key = (source_id, target_id)
+                if key not in seen_edges:
+                    seen_edges.add(key)
+                    edges_list.append({
+                        "from": source_id,
+                        "to": target_id
+                    })
 
     # Build adjacency for deterministic layout
     adjacency: dict[int, set[int]] = {node["id"]: set() for node in nodes}

--- a/tests/core/test_graph_snapshot_no_hasattr.py
+++ b/tests/core/test_graph_snapshot_no_hasattr.py
@@ -1,0 +1,25 @@
+"""Regression coverage for graph snapshot typing and structure."""
+
+import inspect
+
+from doeff import graph_snapshot
+from doeff._vendor import WGraph, WNode, WStep
+
+
+def test_build_graph_snapshot_does_not_use_hasattr() -> None:
+    source = inspect.getsource(graph_snapshot.build_graph_snapshot)
+    assert "hasattr(" not in source
+
+
+def test_build_graph_snapshot_builds_nodes_and_edges() -> None:
+    first_node = WNode("seed")
+    second_node = WNode("result")
+    first_step = WStep(inputs=(), output=first_node, meta={"label": "Seed"})
+    second_step = WStep(inputs=(first_node,), output=second_node, meta={"label": "Result"})
+    graph = WGraph(last=second_step, steps=frozenset({first_step, second_step}))
+
+    snapshot = graph_snapshot.build_graph_snapshot(graph, mark_success=True)
+
+    assert len(snapshot["nodes"]) == 2
+    assert len(snapshot["edges"]) == 1
+    assert snapshot["edges"][0]["arrows"] == "to"


### PR DESCRIPTION
## Summary
- Removed all `hasattr(...)` duck-typing checks from `doeff/graph_snapshot.py`.
- Switched `build_graph_snapshot` to direct typed access over `WGraph`/`WStep` data (`steps`, `last`, `inputs`, `output`, `meta`).
- Added regression tests to lock this down:
  - source-level guard that `build_graph_snapshot` contains no `hasattr(`
  - basic graph build assertion for nodes/edges/arrows

## Issue
- GRAPH-SNAPSHOT-HASATTR-001

## Acceptance Criteria Evidence
1. Zero `hasattr()` calls in `graph_snapshot.py`
   - Command: `rg -n "hasattr\\(" doeff/graph_snapshot.py`
   - Result: no matches
2. Proper Protocol/type-based access
   - `build_graph_snapshot` now uses concrete `WGraph` structure directly (`graph.steps`, `graph.last`, `step.output`, `step.inputs`, `step.meta`) with no duck-typing probes.
3. `uv run pyright` passes (or no new errors)
   - Command: `uv run pyright`
   - Result: fails due broad pre-existing repository type errors unrelated to this issue (baseline failures across many modules).
   - Local update from this PR: removed a local edge-dict typing issue introduced during refactor; remaining `graph_snapshot.py` pyright errors are existing `@do` typing errors already present before this change.
4. `uv run pytest` passes
   - Command: `uv run pytest`
   - Result: `1035 passed, 1 warning`
5. `make lint` clean
   - Command: `make lint`
   - Result: fails in baseline on existing pyright errors (not specific to this issue).
   - Additional evidence: `make lint-ruff`, `make lint-semgrep`, `make lint-doeff` all report substantial pre-existing violations.

## Commands Run
- `uv run pytest tests/core/test_graph_snapshot_no_hasattr.py -q` (red phase, then green phase)
- `rg -n "hasattr\\(" doeff/graph_snapshot.py`
- `uv run pyright`
- `uv run pytest`
- `make lint`
- `make lint-ruff`
- `make lint-semgrep`
- `make lint-doeff`
