### PR TITLE
Rewrite trace spec to match incremental active-chain assembly

### DIFF
--- a/specs/core/SPEC-TRACE-001-implementation-notes.md
+++ b/specs/core/SPEC-TRACE-001-implementation-notes.md
@@ -1,80 +1,96 @@
 # SPEC-TRACE-001: Implementation Notes
 
-These are implementation-level notes for SPEC-TRACE-001. The spec itself defines **what** the traceback should look like; this document captures **how** to get there.
+These notes document the current traceback assembly architecture in this repository.
 
 ---
 
-## Effect creation site extraction (generic protocol)
+## Active-chain storage model
 
-Every Python effect object has `created_at: EffectCreationContext` set by `create_effect_with_trace()`. The Rust VM should read this at dispatch time:
+Traceback state is stored on `VM` as `trace_state: TraceState` (`packages/doeff-vm-core/src/vm.rs`).
+`TraceState` owns one `ActiveChainAssemblyState` (`packages/doeff-vm-core/src/trace_state.rs`)
+with:
 
-**In `start_dispatch()` (vm.rs):**
-1. Read `created_at` from the dispatched Python effect object via `getattr(effect, "created_at")`
-2. If present, extract `filename`, `line`, `function` from the `EffectCreationContext`
-3. Store as `Option<EffectCreationSite>` in `CaptureEvent::DispatchStarted` alongside `effect_repr` and handler chain snapshot
+- `frame_stack`
+- `dispatches`
+- `frame_dispatch`
+- `transfer_targets`
+- `dispatch_order`
 
-**In scheduler (scheduler.rs):**
-1. When handling `SchedulerEffect::Spawn`, read the creation site from the dispatch context (not from continuation frames)
-2. Store directly as `TaskMetadata.spawn_site`
-3. Delete `spawn_site_from_continuation` entirely — no frame walking, no position-based skipping
-
-This replaces the current pattern where the scheduler walks `k.frames_snapshot` and skips the first frame hoping it's the wrapper. The effect object already knows where it was created.
+State is reset per run by `VM::begin_run_session()` via `trace_state.clear()`.
 
 ---
 
-## Spawn boundary insertion (structural, not name-based)
+## Event application path
 
-The current `is_spawn_boundary_insertion_point` checks `handler_name == SCHEDULER_HANDLER_NAME` to decide where to insert `── in task N ──` separators. This is hardcoded name matching.
+VM execution emits transient `CaptureEvent` values through `TraceState::emit_*` helpers.
+Each event is immediately applied to `ActiveChainAssemblyState` by:
 
-**Fix**: Spawn boundaries carry their own metadata (`task_id`, `parent_task`, `spawn_site`). The insertion logic should use this structural data — not handler names — to determine position. The boundary knows which task it belongs to; the active chain entries know which dispatch they came from. Match by dispatch/task relationship, not by handler name string.
+1. `TraceState::apply_capture_event(...)`
+2. `TraceState::apply_active_chain_event(...)`
 
-Delete the `SCHEDULER_HANDLER_NAME` constant import in `vm.rs`. The scheduler's name is its own business — the VM's traceback assembly should not know or care what the scheduler is called.
-
----
-
-## `@do` wrapper inner generator access
-
-The current implementation stores the inner generator as a local variable `_doeff_inner = gen` in `do.py:45` and the Rust VM reads it via `f_locals.get_item("_doeff_inner")`. This is fragile — it reaches into Python locals by magic string name.
-
-**Fix**:
-1. In `do.py`: Set the inner generator as an **attribute on the wrapper generator object**: `wrapper_gen.__doeff_inner__ = gen` (after creating the wrapper generator, before yielding)
-2. In `vm.rs` (`generator_current_line`): Read via `generator.getattr("__doeff_inner__")` instead of `gi_frame.f_locals.get_item("_doeff_inner")`
-3. In `scheduler.rs` (`generator_current_line` helper): Same change
-
-This keeps the cross-language contract but makes it explicit — the attribute lives on the generator object itself, not buried in stack frame locals. It's visible via `dir()`, survives frame changes, and doesn't require the generator to be actively executing.
+`CaptureEvent` is not retained as a long-lived chronological log.
 
 ---
 
-## Strict validation in trace.py coercion functions
+## Assembly entrypoints
 
-The `_coerce_handler_status`, `_coerce_handler_kind`, `_coerce_dispatch_action`, and `_coerce_effect_result` functions in `trace.py` currently return silent defaults for unknown values (e.g., unknown status → `"active"`). This masks bugs in the Rust→Python data pipeline.
+### `assemble_active_chain`
 
-**Fix**: Raise `ValueError` on unknown values instead of returning defaults. If Rust sends an unrecognized status string, that's a bug that should surface immediately, not be silently coerced.
+`VM::assemble_active_chain(exception)` delegates to
+`TraceState::assemble_active_chain(...)`, which:
+
+1. Clones `active_chain_state`
+2. Merges live frame/line data from current segments and visible dispatch snapshots
+3. Finalizes unresolved visible dispatches as `Threw` when exception context exists
+4. Builds `ActiveChainEntry` rows from frame/dispatch snapshots
+5. Deduplicates adjacent identical rows
+6. Injects context entries and `ExceptionSite`
+
+### `assemble_traceback_entries`
+
+`VM::assemble_traceback_entries(exception)` returns `TraceEntry` rows for chained/sectioned
+rendering using the same incremental state model.
 
 ---
 
-## What changes in Rust VM
+## `GetExecutionContext` integration
 
-1. `supplement_with_live_state` already reads live `f_lineno` for active frames — this becomes the primary source of line numbers
-2. Handler stack snapshot per dispatch — when `DispatchStarted` is recorded, also record the full handler stack names at that point
-3. Effect repr — use Python `repr()` on the effect object, not the default `<builtins.X object at 0x...>`
-4. **Effect creation site** — read `created_at` from every dispatched Python effect and store in dispatch context (see above)
-5. **Scheduler: switch from Resume to Transfer for task switches** — `jump_to_continuation` should emit `DoCtrl::Transfer` (not `DoCtrl::Resume`) for started continuations during task switching. This prevents unbounded segment chain growth during cooperative scheduling. `Resume` chains segments via `caller: self.current_segment`; `Transfer` severs with `caller: None`.
-6. **Spawn chain tracking** — add `parent_task: Option<TaskId>` and spawn-site metadata to task state. Spawn site comes from the effect's `created_at` (see above), not from frame walking.
-7. **Task error trace capture** — when a spawned task fails, assemble its trace and attach it to the exception before storing in `TaskState::Done { result: Err(...) }`. This ensures the task's trace survives propagation through Gather/Wait/Race.
+`GetExecutionContext` dispatches are marked `is_execution_context_effect` and excluded from visible
+active-chain output.
 
-## What changes in Python projection
+When a handler returns `ExecutionContext`, VM calls
+`maybe_attach_active_chain_to_execution_context(...)`:
 
-1. New `format_default()` method on `DoeffTraceback` replacing `format_chained()` as the stderr output
-2. Frame selection: select active call chain only, not full chronological log
-3. Handler stack rendering with markers
-4. **Transfer chain reconstruction** — when a Transfer event is found in capture_log, include pre-transfer frames in the trace (not reachable from live segment walk due to `caller: None`)
-5. **Spawn chain rendering** — when an exception carries a task trace (from a spawned task), render the spawn chain with `── in task N (spawned at ...) ──` separators between parent and child trace sections
+1. Assemble `active_chain` snapshot (`assemble_active_chain(None)`)
+2. Append current `ExecutionContext.entries` as `ContextEntry`
+3. Set `ExecutionContext.active_chain` to the serialized tuple snapshot
 
-## What does NOT change
+During error enrichment, merged entries are attached to the original exception as
+`doeff_execution_context`; `assemble_active_chain(Some(exception))` injects those entries back
+into output.
 
-- `format_chained()` — kept as-is for full chronological debug view
-- `format_sectioned()` — kept as-is for structured summary
-- `format_short()` — kept as-is for one-liner logs
-- Capture model (SPEC-CORE-004) — only additive changes (handler stack snapshot per dispatch, effect creation site, spawn-site tracking)
-- `__doeff_traceback_data__` attachment mechanism unchanged
+---
+
+## Transfer and spawn notes
+
+### Transfer
+
+- `CaptureEvent::Transferred` stores destination text in `transfer_targets`
+- Terminal handler completion reads `transfer_targets` to produce
+  `EffectResult::Transferred { target_repr, ... }`
+- Pre-transfer chain visibility comes from incremental frame/dispatch state, not log backtracking
+
+### Spawn boundaries
+
+Scheduler propagates spawn metadata (`task_id`, `parent_task`, `spawn_site`) via execution-context
+entries (dict payload with `kind == "spawn_boundary"`). Python coercion promotes these to
+`SpawnBoundary` active-chain entries (`doeff/trace.py`).
+
+---
+
+## Invariants
+
+- No persisted event-log field in traceback assembly path
+- No legacy full-log assembler function in VM core traceback path
+- Traceback assembly is on-demand from `ActiveChainAssemblyState`
+- Python `format_default()` is render-only and does not reconstruct VM state

--- a/specs/core/SPEC-TRACE-001-traceback-visualization.md
+++ b/specs/core/SPEC-TRACE-001-traceback-visualization.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This spec defines the **default error traceback format** for doeff — what users see when a program fails. The current implementation dumps the full chronological event log, which is noisy and hard to read. This spec replaces it with a **call-stack-at-crash-time** view that shows only what matters.
+This spec defines the **default error traceback format** for doeff — what users see when a program fails. The VM now maintains incremental active-chain state and assembles traceback entries on-demand. This spec defines the **call-stack-at-crash-time** view shown to users.
 
 ---
 
@@ -23,6 +23,57 @@ This spec defines the **default error traceback format** for doeff — what user
 - Use **human-readable effect repr** (not `<builtins.PyPut object at 0x...>`)
 - **No hardcoded filtering or omission** — every handler in the chain is shown, regardless of name or action
 - No Python traceback section (the doeff trace IS the trace)
+
+---
+
+## Current VM Architecture
+
+### Runtime State (`TraceState`)
+
+The VM stores traceback capture state in `VM.trace_state: TraceState`. `TraceState` owns
+`ActiveChainAssemblyState`, which tracks:
+
+- `frame_stack`: active `Program` frame snapshots (`function_name`, `source_file`, `source_line`, args, etc.)
+- `dispatches`: per-dispatch `effect_repr`, handler stack, and terminal/non-terminal result
+- `frame_dispatch`: mapping from frame id to the dispatch currently associated with that frame
+- `transfer_targets`: transfer destination text keyed by `dispatch_id`
+- `dispatch_order`: dispatch ids in start order
+
+There is no persisted event-log field on `VM` for traceback assembly. State is reset per run via
+`VM::begin_run_session()` -> `trace_state.clear()`.
+
+### `CaptureEvent` Role (Transient)
+
+`CaptureEvent` is still the mutation carrier between VM control flow and
+`ActiveChainAssemblyState`, but it is transient:
+
+1. VM emitters (`emit_frame_entered`, `emit_dispatch_started`, `emit_handler_completed`, etc.) construct a `CaptureEvent`
+2. `TraceState::apply_capture_event()` immediately applies it with `apply_active_chain_event(...)`
+3. The event object is dropped (not retained in a chronological log)
+
+### `assemble_active_chain()` Algorithm
+
+`VM::assemble_active_chain()` delegates to `TraceState::assemble_active_chain(...)`, which:
+
+1. Clones the current `ActiveChainAssemblyState`
+2. Merges live line/stack data from current segments and visible dispatch snapshots
+3. If an exception is present, finalizes unresolved visible dispatches as `EffectResult::Threw`
+4. Builds ordered `ActiveChainEntry` values (`ProgramYield`, `EffectYield`, `ContextEntry`, `ExceptionSite`)
+5. Deduplicates adjacent identical entries
+6. Injects execution-context entries and exception-site metadata
+
+### `GetExecutionContext` Integration
+
+`GetExecutionContext` dispatches are marked `is_execution_context_effect` and hidden from visible
+trace entries. When a handler resumes with `ExecutionContext`, VM calls
+`maybe_attach_active_chain_to_execution_context(...)`:
+
+1. Assemble active chain snapshot (`assemble_active_chain(None)`)
+2. Append existing `ExecutionContext.entries` as `ContextEntry`
+3. Store the tuple on `ExecutionContext.active_chain`
+
+During error enrichment, merged `ExecutionContext.entries` are attached to the original exception
+(`doeff_execution_context`), and later injected back into the rendered active chain.
 
 ---
 
@@ -76,10 +127,10 @@ Each handler in the stack is annotated with what it did for that effect:
 | `·` | Pending | handler never saw this effect (downstream of the handler that resolved it) |
 
 > **Note**: Handler `return` (⏎ — abandon continuation) is not shown in the default format.
-> By the time a trace is captured (error or `GetStackTrace`), a handler return has already
+> By the time a trace is captured (error or `GetTraceback` / `GetExecutionContext`), a handler return has already
 > completed — the `WithHandler` delivered its value, the parent continued. The return is
-> historical, never in the active call chain. It only appears in the full chronological
-> event log (`format_chained()`).
+> historical, never in the active call chain. It only appears in the historical chained
+> projection (`format_chained()`).
 
 ### Handler Stack Display Rules
 
@@ -120,7 +171,10 @@ Handler program frames (`ProgramYield` entries where `handler_kind` is not `None
 
 Handler program frames remain available in `format_chained()` (full chronological view), rendered with the `⚙` prefix for visual distinction. The `handler_kind` field (`python` / `rust_builtin`) on `ProgramYield` entries is preserved in the trace data for programmatic access.
 
-**Exception — Transfer**: When a Transfer severs the caller chain (`caller: None`), the pre-transfer call chain is still shown. Pre-transfer frames are reconstructed from the **capture_log** (chronological event log), not from the live segment walk. The trace shows: pre-transfer chain → transfer (inline `⇢`) → post-transfer chain → crash.
+**Exception — Transfer**: When a Transfer severs the caller chain (`caller: None`), the pre-transfer
+call chain is still shown. Pre-transfer frames come from the incremental
+`ActiveChainAssemblyState` (`frame_stack` + dispatch snapshots), not from a chronological log scan.
+The trace shows: pre-transfer chain → transfer (inline `⇢`) → post-transfer chain → crash.
 
 **Exception — Spawn chain**: When a spawned task crashes, the trace includes:
 1. The **spawn chain** from root to the waiting site (Gather/Wait/Race)
@@ -500,7 +554,7 @@ Notes:
 - The pre-transfer chain (`trigger()`) is shown because the user needs to see how control arrived at `program_a`
 - The trace reads top-to-bottom: original chain → transfer → post-transfer execution → crash
 - No `── transfer ──` separator — Transfer is a regular handler action, shown inline
-- Pre-transfer frames come from **capture_log** (chronological), not from live segment walk (which stops at `caller: None`)
+- Pre-transfer frames come from incremental active-chain state, not from live segment walk alone (which stops at `caller: None`)
 
 ### Example 8: Spawn chain — task crash during Gather
 
@@ -662,50 +716,54 @@ def error_wrapper(effect, k):
 
 To render this format, the following data is needed per frame:
 
-### Active call chain (from live VM state)
+### Incremental active-chain state
 
-For each generator on the active segment chain:
-- `function_name` — from generator `__qualname__` or `__name__`
-- `source_file` — from generator `co_filename`
-- `source_line` — from generator **live `f_lineno`** (NOT `co_firstlineno`)
-- `current_yield_repr` — repr of what was yielded (effect or sub-program)
+`TraceState` stores an `ActiveChainAssemblyState` snapshot that is mutated incrementally. It
+contains:
 
-### Effect creation site (from effect object)
+- Active frame snapshots (`frame_stack`)
+- Per-dispatch snapshots (`dispatches`) including `effect_repr`, handler stack, and result
+- Frame->dispatch links (`frame_dispatch`)
+- Transfer destination text (`transfer_targets`)
+- Dispatch ordering (`dispatch_order`)
 
-Every effect carries its Python-side creation location via `EffectBase.created_at: EffectCreationContext`. This is set by `create_effect_with_trace()` at construction time and captures:
-- `function` — the function that constructed the effect (e.g., the user's `@do` function)
-- `filename` — source file path
-- `line` — line number of the constructor call
+This state is the source of truth for active-chain rendering.
 
-The VM reads `created_at` from every dispatched Python effect object at dispatch time. This is a **generic protocol** — it applies uniformly to all effects, not just specific ones like Spawn. The creation site is stored in `CaptureEvent::DispatchStarted` alongside the effect repr and handler chain snapshot.
+### Live frame supplement
 
-Consumers of the creation site:
-- **Spawn chain**: the scheduler reads the creation site from the Spawn effect's dispatch to populate `TaskMetadata.spawn_site` — no frame walking or positional heuristics needed
-- **Traceback rendering**: effect frames can show where the effect was constructed
-- **Capture log**: richer trace data for debugging
+Before rendering, `assemble_active_chain()` merges live runtime state into a clone of
+`ActiveChainAssemblyState`:
 
-### Last effect dispatch per frame (from capture log)
+- Segment caller chain (`SegmentArena` + `current_segment`) for active program frames
+- Visible dispatch continuation snapshots (`dispatch_stack`) as fallback when frame stack is empty
+- Live stream debug locations for accurate yield-site line numbers
+
+### Effect dispatch snapshot fields
 
 For the most recent effect yielded by each active generator:
+
 - `effect_repr` — human-readable repr of the effect
-- `effect_creation_site` — where the effect was constructed (from `created_at`)
-- `handler_stack` — ordered list of handler names from innermost to outermost
-- `handler_status` — per-handler: passed / delegated / resumed / threw / transferred / pending
-- `resume_value_repr` — value returned to the generator (if resumed)
+- `handler_stack` — ordered handler list with status (`active`/`pending`/`passed`/`delegated`/`resumed`/`transferred`/`returned`/`threw`)
+- `result` — `EffectResult::{Active, Resumed, Threw, Transferred}`
+- `function_name` / `source_file` / `source_line` for effect-site rendering
 
-### Transfer chain (from capture log)
+`CaptureEvent::DispatchStarted` currently also carries optional `creation_site` metadata, but
+active-chain rendering is driven by the dispatch snapshot fields above.
 
-When a Transfer severs the caller chain, pre-transfer frames are not reachable from the live segment walk (`caller: None`). The capture_log retains the full chronological history:
-- `CaptureEvent::Transferred` links the dispatch to the transfer target via `dispatch_id`
-- Pre-transfer frames are reconstructed by walking the capture_log backwards from the Transfer event
-- Multiple transfers create multiple segments in the trace, each linked by the Transfer event
+### Transfer chain reconstruction
+
+When Transfer severs the live caller chain (`caller: None`):
+
+- `CaptureEvent::Transferred` stores destination text in `transfer_targets[dispatch_id]`
+- Terminal handler completion sets `EffectResult::Transferred { target_repr, ... }`
+- Pre-transfer frames come from incremental frame/dispatch snapshots kept in `ActiveChainAssemblyState`
 
 ### Spawn chain
 
 To show the full path from root to a crashing spawned task, the VM must track:
 
 - `parent_task: Option<TaskId>` — which task spawned this one (stored at spawn time)
-- `spawn_site` — from the Spawn effect's `created_at` (see "Effect creation site" above). The scheduler reads the creation site from the dispatched SpawnEffect at task creation time and stores it in `TaskMetadata`. No frame walking or positional heuristics.
+- `spawn_site` — derived from traceback hops (`GetTraceback`) and stored in scheduler task metadata
 - `task_trace: Vec<TraceEntry>` — when a task fails, its assembled trace is captured and attached to the exception (via `__doeff_traceback_data__` or similar mechanism)
 
 When assembling a trace for an error propagated through Gather/Wait/Race:
@@ -737,15 +795,15 @@ When assembling a trace for an error propagated through Gather/Wait/Race:
 
 These are rendering concerns, not data concerns. Programmatic consumers (e.g., `DoeffTraceback.active_chain`) still see every handler and frame.
 
-### Effect Creation Site Protocol
+### Effect Dispatch Site Protocol
 
-Effect location metadata flows through a single, generic protocol — not per-effect-type heuristics:
+Dispatch-site metadata is captured from continuation/frame state, not from effect-object creation metadata:
 
-1. **Python**: `create_effect_with_trace()` captures the user's call site into `EffectBase.created_at` at construction time
-2. **Rust VM**: At dispatch time, reads `created_at` from the Python effect object and extracts `(function, filename, line)`
-3. **Consumers**: Any VM subsystem that needs to know where an effect was created reads it from the dispatch context
+1. **Rust VM**: At dispatch start, resolve site info from continuation snapshots (`TraceState::effect_site_from_continuation`)
+2. **Dispatch snapshot**: Store function/file/line on dispatch state (`CaptureEvent::DispatchStarted`)
+3. **Consumers**: Use dispatch snapshots and traceback hops for rendering/spawn-site attribution
 
-This protocol replaces any frame-walking, position-skipping, or continuation-inspection heuristics. The effect object is the single source of truth for its creation location. If a subsystem needs the creation site (e.g., scheduler for spawn site), it reads it from the dispatched effect — it does not reconstruct it from stack frames.
+This avoids per-effect object contracts and keeps traceback assembly sourced from VM execution state.
 
 ### No Hardcoded Handler/Effect Name Matching in VM Logic
 
@@ -784,7 +842,7 @@ Implementation-level notes (what changes in Rust VM, Python projection, etc.) ar
 
 ### Transfer
 10. Transfer shown inline with `⇢` marker on the handler that transferred
-11. Pre-transfer call chain included in trace (reconstructed from capture_log)
+11. Pre-transfer call chain included in trace (reconstructed from incremental active-chain state)
 12. No visual separator for Transfer — it's a regular handler action
 
 ### Spawn chain


### PR DESCRIPTION
## Summary
- Rewrote `SPEC-TRACE-001` architecture sections to match current VM traceback assembly:
  - incremental `ActiveChainAssemblyState`
  - transient `CaptureEvent` application
  - on-demand `assemble_active_chain()` flow
  - `GetExecutionContext` active-chain attachment path
- Removed stale references to retired architecture terms from the rewritten trace spec docs.
- Replaced outdated implementation notes with current state-driven assembly notes.

## Acceptance Criteria Evidence

### 1) Spec accurately describes current implementation
Updated docs now map directly to:
- `packages/doeff-vm-core/src/trace_state.rs`
- `packages/doeff-vm-core/src/vm.rs`
- `doeff/trace.py`, `doeff/traceback.py`

Concrete validation by behavior tests:
```bash
uv run pytest tests/core/test_traceback_spec_compliance.py tests/core/test_get_execution_context_effect.py
```
Result:
- `23 passed in 0.33s`

```bash
uv run pytest tests/core/test_traceback_format_default.py
```
Result:
- `43 passed in 0.10s`

### 2) No references to retired terms in rewritten spec docs
```bash
rg -n "capture_log|assemble_trace\\(|always-on|always on logging" \
  specs/core/SPEC-TRACE-001-traceback-visualization.md \
  specs/core/SPEC-TRACE-001-implementation-notes.md
```
Result:
- no matches

### 3) Spec references correct type/function names
```bash
rg -n "ActiveChainAssemblyState|assemble_active_chain|CaptureEvent|ActiveChainEntry|GetExecutionContext" \
  specs/core/SPEC-TRACE-001-traceback-visualization.md
```
Result: present and documented in architecture/data-requirements sections.

## Issue
- SPEC-CORE-004-REWRITE
