### PR TITLE
VM-CATCHALL-AUDIT-001: Replace default/silent catch-alls with exhaustive matches

### DIFF
--- a/packages/doeff-core-effects/src/handlers/mod.rs
+++ b/packages/doeff-core-effects/src/handlers/mod.rs
@@ -1111,7 +1111,22 @@ impl IRStreamProgram for LazyAskHandlerProgram {
                 let Some(semaphore) = semaphore else {
                     let semaphore = match value {
                         Value::Python(_) => value,
-                        _ => {
+                        Value::Unit
+                        | Value::Int(_)
+                        | Value::String(_)
+                        | Value::Bool(_)
+                        | Value::None
+                        | Value::Continuation(_)
+                        | Value::Handlers(_)
+                        | Value::Kleisli(_)
+                        | Value::Task(_)
+                        | Value::Promise(_)
+                        | Value::ExternalPromise(_)
+                        | Value::CallStack(_)
+                        | Value::Trace(_)
+                        | Value::Traceback(_)
+                        | Value::ActiveChain(_)
+                        | Value::List(_) => {
                             return IRStreamStep::Throw(PyException::type_error(
                                 "CreateSemaphore must return a semaphore handle".to_string(),
                             ));

--- a/packages/doeff-core-effects/src/scheduler/mod.rs
+++ b/packages/doeff-core-effects/src/scheduler/mod.rs
@@ -351,7 +351,31 @@ fn step_targets_cont_id(step: &IRStreamStep, cont_id: ContId) -> bool {
         | IRStreamStep::Yield(DoCtrl::ResumeContinuation { continuation, .. }) => {
             continuation.cont_id == cont_id
         }
-        _ => false,
+        IRStreamStep::Yield(
+            DoCtrl::Pure { .. }
+            | DoCtrl::Map { .. }
+            | DoCtrl::FlatMap { .. }
+            | DoCtrl::Perform { .. }
+            | DoCtrl::WithHandler { .. }
+            | DoCtrl::WithIntercept { .. }
+            | DoCtrl::Finally { .. }
+            | DoCtrl::Delegate { .. }
+            | DoCtrl::Pass { .. }
+            | DoCtrl::GetContinuation
+            | DoCtrl::GetHandlers
+            | DoCtrl::GetTraceback { .. }
+            | DoCtrl::CreateContinuation { .. }
+            | DoCtrl::PythonAsyncSyntaxEscape { .. }
+            | DoCtrl::Apply { .. }
+            | DoCtrl::Expand { .. }
+            | DoCtrl::IRStream { .. }
+            | DoCtrl::Eval { .. }
+            | DoCtrl::EvalInScope { .. }
+            | DoCtrl::GetCallStack,
+        )
+        | IRStreamStep::Return(_)
+        | IRStreamStep::Throw(_)
+        | IRStreamStep::NeedsPython(_) => false,
     }
 }
 
@@ -1156,7 +1180,7 @@ impl SchedulerState {
         let task_exists = self.tasks.contains_key(&task_id);
         let cont_id = match self.tasks.get(&task_id) {
             Some(TaskState::Pending { cont, .. }) => Some(cont.cont_id),
-            _ => None,
+            Some(TaskState::Done { .. }) | None => None,
         };
         if let Some(cont_id) = cont_id {
             self.clear_waiters_for_owner(Some(task_id), cont_id);
@@ -1214,7 +1238,7 @@ impl SchedulerState {
         let task_id = self.current_task?;
         match self.tasks.get(&task_id) {
             Some(TaskState::Pending { priority, .. }) => Some(*priority),
-            _ => None,
+            Some(TaskState::Done { .. }) | None => None,
         }
     }
 
@@ -1467,7 +1491,7 @@ impl SchedulerState {
                     *pending_log_merge_items = merge_items;
                     *priority
                 }
-                _ => return None,
+                Some(TaskState::Done { .. }) | None => return None,
             };
 
             self.enqueue_ready_task(waiting_task, priority);
@@ -1516,7 +1540,7 @@ impl SchedulerState {
                         Some(current_max) if current_max.priority >= woken.priority => {
                             Some(current_max)
                         }
-                        _ => Some(woken),
+                        Some(_) | None => Some(woken),
                     };
                 }
             }
@@ -1629,7 +1653,7 @@ impl SchedulerState {
     pub fn task_cont(&self, task_id: TaskId) -> Option<Continuation> {
         match self.tasks.get(&task_id) {
             Some(TaskState::Pending { cont, .. }) => Some(cont.clone()),
-            _ => None,
+            Some(TaskState::Done { .. }) | None => None,
         }
     }
 
@@ -1640,13 +1664,13 @@ impl SchedulerState {
                 Waitable::Task(task_id) => match self.tasks.get(task_id) {
                     Some(TaskState::Done { result: Ok(v), .. }) => results.push(v.clone()),
                     Some(TaskState::Done { result: Err(_), .. }) => return None,
-                    _ => return None,
+                    Some(TaskState::Pending { .. }) | None => return None,
                 },
                 Waitable::Promise(pid) | Waitable::ExternalPromise(pid) => {
                     match self.promises.get(pid) {
                         Some(PromiseState::Done(Ok(v))) => results.push(v.clone()),
                         Some(PromiseState::Done(Err(_))) => return None,
-                        _ => return None,
+                        Some(PromiseState::Pending) | None => return None,
                     }
                 }
             }
@@ -1729,7 +1753,7 @@ impl SchedulerState {
                 Waitable::Task(task_id) => {
                     let task_result = match self.tasks.get(task_id) {
                         Some(TaskState::Done { result, .. }) => result.clone(),
-                        _ => return None,
+                        Some(TaskState::Pending { .. }) | None => return None,
                     };
                     match task_result {
                         Ok(value) => results.push(value),
@@ -1743,7 +1767,7 @@ impl SchedulerState {
                     match self.promises.get(pid) {
                         Some(PromiseState::Done(Ok(v))) => results.push(v.clone()),
                         Some(PromiseState::Done(Err(e))) => return Some(Err(e.clone())),
-                        _ => return None,
+                        Some(PromiseState::Pending) | None => return None,
                     }
                 }
             }
@@ -1758,7 +1782,7 @@ impl SchedulerState {
                 Waitable::Task(task_id) => {
                     let task_result = match self.tasks.get(task_id) {
                         Some(TaskState::Done { result, .. }) => result.clone(),
-                        _ => continue,
+                        Some(TaskState::Pending { .. }) | None => continue,
                     };
                     if task_result.is_err() {
                         self.execution_context_task_override = Some(*task_id);
@@ -2560,7 +2584,22 @@ impl IRStreamProgram for SchedulerProgram {
             SchedulerPhase::SpawnAwaitTraceback { k_user, effect } => {
                 let traceback = match value {
                     Value::Traceback(hops) => hops,
-                    _ => {
+                    Value::Python(_)
+                    | Value::Unit
+                    | Value::Int(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::None
+                    | Value::Continuation(_)
+                    | Value::Handlers(_)
+                    | Value::Kleisli(_)
+                    | Value::Task(_)
+                    | Value::Promise(_)
+                    | Value::ExternalPromise(_)
+                    | Value::CallStack(_)
+                    | Value::Trace(_)
+                    | Value::ActiveChain(_)
+                    | Value::List(_) => {
                         return IRStreamStep::Throw(PyException::type_error(
                             "scheduler Spawn expected GetTraceback result".to_string(),
                         ));
@@ -2651,7 +2690,22 @@ impl IRStreamProgram for SchedulerProgram {
             } => {
                 let handlers = match value {
                     Value::Handlers(hs) => hs,
-                    _ => {
+                    Value::Python(_)
+                    | Value::Unit
+                    | Value::Int(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::None
+                    | Value::Continuation(_)
+                    | Value::Kleisli(_)
+                    | Value::Task(_)
+                    | Value::Promise(_)
+                    | Value::ExternalPromise(_)
+                    | Value::CallStack(_)
+                    | Value::Trace(_)
+                    | Value::Traceback(_)
+                    | Value::ActiveChain(_)
+                    | Value::List(_) => {
                         return IRStreamStep::Throw(PyException::type_error(
                             "scheduler Spawn expected GetHandlers result".to_string(),
                         ));
@@ -2683,7 +2737,22 @@ impl IRStreamProgram for SchedulerProgram {
                 // Value should be the continuation created by CreateContinuation
                 let cont = match value {
                     Value::Continuation(c) => c,
-                    _ => {
+                    Value::Python(_)
+                    | Value::Unit
+                    | Value::Int(_)
+                    | Value::String(_)
+                    | Value::Bool(_)
+                    | Value::None
+                    | Value::Handlers(_)
+                    | Value::Kleisli(_)
+                    | Value::Task(_)
+                    | Value::Promise(_)
+                    | Value::ExternalPromise(_)
+                    | Value::CallStack(_)
+                    | Value::Trace(_)
+                    | Value::Traceback(_)
+                    | Value::ActiveChain(_)
+                    | Value::List(_) => {
                         return IRStreamStep::Throw(PyException::type_error(
                             "expected continuation from CreateContinuation, got unexpected type"
                                 .to_string(),
@@ -2780,7 +2849,10 @@ impl IRStreamProgram for SchedulerProgram {
             SchedulerPhase::PreemptiveTransfer { k_user } => {
                 self.continue_preemptive_transfer(Err(exc), k_user, store)
             }
-            _ => IRStreamStep::Throw(exc),
+            SchedulerPhase::Idle
+            | SchedulerPhase::SpawnAwaitTraceback { .. }
+            | SchedulerPhase::SpawnAwaitHandlers { .. }
+            | SchedulerPhase::SpawnAwaitContinuation { .. } => IRStreamStep::Throw(exc),
         }
     }
 }

--- a/packages/doeff-vm-core/src/kleisli.rs
+++ b/packages/doeff-vm-core/src/kleisli.rs
@@ -346,7 +346,22 @@ impl PyKleisli {
             Value::Continuation(k) => Bound::new(py, PyK::from_cont_id(k.cont_id))
                 .map(|obj| obj.into_any())
                 .map_err(Self::map_pyerr),
-            _ => value.to_pyobject(py).map_err(Self::map_pyerr),
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::String(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => value.to_pyobject(py).map_err(Self::map_pyerr),
         }
     }
 }

--- a/packages/doeff-vm-core/src/trace_state.rs
+++ b/packages/doeff-vm-core/src/trace_state.rs
@@ -73,7 +73,9 @@ impl ActiveChainAssemblyState {
         self.dispatches.get(&dispatch_id).is_some_and(|dispatch| {
             matches!(
                 dispatch.result,
-                EffectResult::Resumed { .. } | EffectResult::Transferred { .. } | EffectResult::Threw { .. }
+                EffectResult::Resumed { .. }
+                    | EffectResult::Transferred { .. }
+                    | EffectResult::Threw { .. }
             )
         })
     }
@@ -377,7 +379,18 @@ impl TraceState {
                     ..
                 },
             ) => Python::attach(|py| lhs_value.bind(py).as_ptr() == rhs_value.bind(py).as_ptr()),
-            _ => false,
+            (
+                PyException::Materialized { .. },
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+            )
+            | (
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+                PyException::Materialized { .. },
+            )
+            | (PyException::RuntimeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::RuntimeError { .. }, PyException::TypeError { .. })
+            | (PyException::TypeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::TypeError { .. }, PyException::TypeError { .. }) => false,
         }
     }
 
@@ -994,12 +1007,7 @@ impl TraceState {
                 else {
                     continue;
                 };
-                Self::upsert_frame_state_from_metadata(
-                    frame_stack,
-                    stream,
-                    metadata,
-                    handler_kind,
-                );
+                Self::upsert_frame_state_from_metadata(frame_stack, stream, metadata, handler_kind);
             }
         }
     }
@@ -1028,12 +1036,7 @@ impl TraceState {
             else {
                 continue;
             };
-            Self::upsert_frame_state_from_metadata(
-                frame_stack,
-                stream,
-                metadata,
-                handler_kind,
-            );
+            Self::upsert_frame_state_from_metadata(frame_stack, stream, metadata, handler_kind);
         }
     }
 
@@ -1179,14 +1182,19 @@ impl TraceState {
                 }
             })
             .or_else(|| {
-                state.dispatch_order.iter().rev().copied().find_map(|dispatch_id| {
-                    let dispatch = state.dispatches.get(&dispatch_id)?;
-                    if Self::is_visible_dispatch(dispatch) {
-                        Some(dispatch_id)
-                    } else {
-                        None
-                    }
-                })
+                state
+                    .dispatch_order
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find_map(|dispatch_id| {
+                        let dispatch = state.dispatches.get(&dispatch_id)?;
+                        if Self::is_visible_dispatch(dispatch) {
+                            Some(dispatch_id)
+                        } else {
+                            None
+                        }
+                    })
             })
     }
 
@@ -1308,7 +1316,12 @@ impl TraceState {
             })
             .or_else(|| dispatch.handler_stack.last());
         let Some(handler) = handler else {
-            return (MISSING_UNKNOWN.to_string(), HandlerKind::RustBuiltin, None, None);
+            return (
+                MISSING_UNKNOWN.to_string(),
+                HandlerKind::RustBuiltin,
+                None,
+                None,
+            );
         };
         (
             handler.handler_name.clone(),
@@ -1347,16 +1360,15 @@ impl TraceState {
     }
 
     fn is_adjacent_duplicate(lhs: &ActiveChainEntry, rhs: &ActiveChainEntry) -> bool {
-        match (lhs, rhs) {
-            (
-                ActiveChainEntry::ProgramYield {
-                    function_name: lhs_function_name,
-                    source_file: lhs_source_file,
-                    source_line: lhs_source_line,
-                    args_repr: lhs_args_repr,
-                    sub_program_repr: lhs_sub_program_repr,
-                    handler_kind: lhs_handler_kind,
-                },
+        match lhs {
+            ActiveChainEntry::ProgramYield {
+                function_name: lhs_function_name,
+                source_file: lhs_source_file,
+                source_line: lhs_source_line,
+                args_repr: lhs_args_repr,
+                sub_program_repr: lhs_sub_program_repr,
+                handler_kind: lhs_handler_kind,
+            } => match rhs {
                 ActiveChainEntry::ProgramYield {
                     function_name: rhs_function_name,
                     source_file: rhs_source_file,
@@ -1364,24 +1376,26 @@ impl TraceState {
                     args_repr: rhs_args_repr,
                     sub_program_repr: rhs_sub_program_repr,
                     handler_kind: rhs_handler_kind,
-                },
-            ) => {
-                lhs_function_name == rhs_function_name
-                    && lhs_source_file == rhs_source_file
-                    && lhs_source_line == rhs_source_line
-                    && lhs_args_repr == rhs_args_repr
-                    && lhs_sub_program_repr == rhs_sub_program_repr
-                    && lhs_handler_kind == rhs_handler_kind
-            }
-            (
-                ActiveChainEntry::EffectYield {
-                    function_name: lhs_function_name,
-                    source_file: lhs_source_file,
-                    source_line: lhs_source_line,
-                    effect_repr: lhs_effect_repr,
-                    handler_stack: lhs_handler_stack,
-                    result: lhs_result,
-                },
+                } => {
+                    lhs_function_name == rhs_function_name
+                        && lhs_source_file == rhs_source_file
+                        && lhs_source_line == rhs_source_line
+                        && lhs_args_repr == rhs_args_repr
+                        && lhs_sub_program_repr == rhs_sub_program_repr
+                        && lhs_handler_kind == rhs_handler_kind
+                }
+                ActiveChainEntry::EffectYield { .. }
+                | ActiveChainEntry::ContextEntry { .. }
+                | ActiveChainEntry::ExceptionSite { .. } => false,
+            },
+            ActiveChainEntry::EffectYield {
+                function_name: lhs_function_name,
+                source_file: lhs_source_file,
+                source_line: lhs_source_line,
+                effect_repr: lhs_effect_repr,
+                handler_stack: lhs_handler_stack,
+                result: lhs_result,
+            } => match rhs {
                 ActiveChainEntry::EffectYield {
                     function_name: rhs_function_name,
                     source_file: rhs_source_file,
@@ -1389,38 +1403,43 @@ impl TraceState {
                     effect_repr: rhs_effect_repr,
                     handler_stack: rhs_handler_stack,
                     result: rhs_result,
-                },
-            ) => {
-                lhs_function_name == rhs_function_name
-                    && lhs_source_file == rhs_source_file
-                    && lhs_source_line == rhs_source_line
-                    && lhs_effect_repr == rhs_effect_repr
-                    && lhs_handler_stack == rhs_handler_stack
-                    && lhs_result == rhs_result
-            }
-            (
-                ActiveChainEntry::ExceptionSite {
-                    function_name: lhs_function_name,
-                    source_file: lhs_source_file,
-                    source_line: lhs_source_line,
-                    exception_type: lhs_exception_type,
-                    message: lhs_message,
-                },
+                } => {
+                    lhs_function_name == rhs_function_name
+                        && lhs_source_file == rhs_source_file
+                        && lhs_source_line == rhs_source_line
+                        && lhs_effect_repr == rhs_effect_repr
+                        && lhs_handler_stack == rhs_handler_stack
+                        && lhs_result == rhs_result
+                }
+                ActiveChainEntry::ProgramYield { .. }
+                | ActiveChainEntry::ContextEntry { .. }
+                | ActiveChainEntry::ExceptionSite { .. } => false,
+            },
+            ActiveChainEntry::ContextEntry { .. } => false,
+            ActiveChainEntry::ExceptionSite {
+                function_name: lhs_function_name,
+                source_file: lhs_source_file,
+                source_line: lhs_source_line,
+                exception_type: lhs_exception_type,
+                message: lhs_message,
+            } => match rhs {
                 ActiveChainEntry::ExceptionSite {
                     function_name: rhs_function_name,
                     source_file: rhs_source_file,
                     source_line: rhs_source_line,
                     exception_type: rhs_exception_type,
                     message: rhs_message,
-                },
-            ) => {
-                lhs_function_name == rhs_function_name
-                    && lhs_source_file == rhs_source_file
-                    && lhs_source_line == rhs_source_line
-                    && lhs_exception_type == rhs_exception_type
-                    && lhs_message == rhs_message
-            }
-            _ => false,
+                } => {
+                    lhs_function_name == rhs_function_name
+                        && lhs_source_file == rhs_source_file
+                        && lhs_source_line == rhs_source_line
+                        && lhs_exception_type == rhs_exception_type
+                        && lhs_message == rhs_message
+                }
+                ActiveChainEntry::ProgramYield { .. }
+                | ActiveChainEntry::EffectYield { .. }
+                | ActiveChainEntry::ContextEntry { .. } => false,
+            },
         }
     }
 
@@ -1439,10 +1458,10 @@ impl TraceState {
         };
 
         let exception_site = Self::exception_site(exception);
-        let exception_function_name = match &exception_site {
-            ActiveChainEntry::ExceptionSite { function_name, .. } => function_name.as_str(),
-            _ => "",
+        let ActiveChainEntry::ExceptionSite { function_name, .. } = &exception_site else {
+            unreachable!("exception_site() must return ActiveChainEntry::ExceptionSite")
         };
+        let exception_function_name = function_name.as_str();
         let exception_function_is_visible = active_chain.iter().any(|entry| match entry {
             ActiveChainEntry::ProgramYield { function_name, .. }
             | ActiveChainEntry::EffectYield { function_name, .. }

--- a/packages/doeff-vm-core/src/value.rs
+++ b/packages/doeff-vm-core/src/value.rs
@@ -14,8 +14,8 @@ use crate::capture::{
 use crate::frame::CallMetadata;
 use crate::ids::{PromiseId, TaskId};
 use crate::kleisli::KleisliRef;
-use crate::pyvm::{PyTraceFrame, PyTraceHop};
 use crate::py_shared::PyShared;
+use crate::pyvm::{PyTraceFrame, PyTraceHop};
 
 /// Opaque handle to a spawned task.
 #[derive(Clone, Copy, Debug)]
@@ -489,7 +489,22 @@ impl Value {
     pub fn as_int(&self) -> Option<i64> {
         match self {
             Value::Int(i) => Some(*i),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::String(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 
@@ -497,7 +512,22 @@ impl Value {
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Value::String(s) => Some(s),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 
@@ -505,7 +535,22 @@ impl Value {
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Value::Bool(b) => Some(*b),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::String(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Handlers(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 
@@ -513,7 +558,22 @@ impl Value {
     pub fn as_handlers(&self) -> Option<&[KleisliRef]> {
         match self {
             Value::Handlers(h) => Some(h),
-            _ => None,
+            Value::Python(_)
+            | Value::Unit
+            | Value::Int(_)
+            | Value::String(_)
+            | Value::Bool(_)
+            | Value::None
+            | Value::Continuation(_)
+            | Value::Kleisli(_)
+            | Value::Task(_)
+            | Value::Promise(_)
+            | Value::ExternalPromise(_)
+            | Value::CallStack(_)
+            | Value::Trace(_)
+            | Value::Traceback(_)
+            | Value::ActiveChain(_)
+            | Value::List(_) => None,
         }
     }
 }

--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -411,7 +411,11 @@ impl VM {
                     types,
                     ..
                 } if *handled_marker == marker => Some((seg_id, handler.clone(), types.clone())),
-                _ => None,
+                SegmentKind::PromptBoundary { .. }
+                | SegmentKind::Normal
+                | SegmentKind::InterceptorBoundary { .. }
+                | SegmentKind::MaskBoundary { .. }
+                | SegmentKind::FinallyBoundary { .. } => None,
             })
     }
 
@@ -472,7 +476,9 @@ impl VM {
                     mode: *mode,
                     metadata: metadata.clone(),
                 })),
-                _ => {
+                SegmentKind::Normal
+                | SegmentKind::MaskBoundary { .. }
+                | SegmentKind::FinallyBoundary { .. } => {
                     assert!(
                         self.interceptor_state.get_entry(seg.marker).is_none(),
                         "normal segment marker {} unexpectedly has interceptor state entry",
@@ -1203,7 +1209,14 @@ impl VM {
         // provenance correctly propagates handler context to nested sub-program frames.
         self.current_seg().frames.last().and_then(|frame| match frame {
             Frame::Program { handler_kind, .. } => *handler_kind,
-            _ => None,
+            Frame::InterceptorApply(_)
+            | Frame::InterceptorEval(_)
+            | Frame::HandlerDispatch { .. }
+            | Frame::EvalReturn(_)
+            | Frame::MapReturn { .. }
+            | Frame::FlatMapBindResult
+            | Frame::FlatMapBindSource { .. }
+            | Frame::InterceptBodyReturn { .. } => None,
         })
     }
 
@@ -1220,7 +1233,14 @@ impl VM {
                         stream: snapshot_stream,
                         ..
                     } => Arc::ptr_eq(snapshot_stream, stream),
-                    _ => false,
+                    Frame::InterceptorApply(_)
+                    | Frame::InterceptorEval(_)
+                    | Frame::HandlerDispatch { .. }
+                    | Frame::EvalReturn(_)
+                    | Frame::MapReturn { .. }
+                    | Frame::FlatMapBindResult
+                    | Frame::FlatMapBindSource { .. }
+                    | Frame::InterceptBodyReturn { .. } => false,
                 })
             })
     }
@@ -1585,7 +1605,7 @@ impl VM {
                         Mode::Throw(exc) => {
                             self.begin_finally_cleanup(cleanup, FinallyOutcome::Throw(exc))
                         }
-                        _ => StepEvent::Error(VMError::internal(
+                        Mode::HandleYield(_) | Mode::Return(_) => StepEvent::Error(VMError::internal(
                             "invalid mode while resolving FinallyBoundary",
                         )),
                     };
@@ -1721,7 +1741,18 @@ impl VM {
                     ..
                 },
             ) => Python::attach(|py| lhs_value.bind(py).as_ptr() == rhs_value.bind(py).as_ptr()),
-            _ => false,
+            (
+                PyException::Materialized { .. },
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+            )
+            | (
+                PyException::RuntimeError { .. } | PyException::TypeError { .. },
+                PyException::Materialized { .. },
+            )
+            | (PyException::RuntimeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::RuntimeError { .. }, PyException::TypeError { .. })
+            | (PyException::TypeError { .. }, PyException::RuntimeError { .. })
+            | (PyException::TypeError { .. }, PyException::TypeError { .. }) => false,
         }
     }
 
@@ -3200,7 +3231,10 @@ impl VM {
         let prompt_seg = self.segments.get_mut(prompt_seg_id)?;
         match &mut prompt_seg.kind {
             SegmentKind::PromptBoundary { return_clause, .. } => return_clause.take(),
-            _ => None,
+            SegmentKind::Normal
+            | SegmentKind::InterceptorBoundary { .. }
+            | SegmentKind::MaskBoundary { .. }
+            | SegmentKind::FinallyBoundary { .. } => None,
         }
     }
 
@@ -3413,7 +3447,7 @@ impl VM {
                 self.current_seg_mut().mode =
                     self.mode_after_generror(GenErrorSite::CallFuncReturn, exception, false);
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -3456,7 +3490,7 @@ impl VM {
             PyCallOutcome::GenError(exception) => {
                 self.receive_expand_gen_error(handler_return, exception);
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -3490,7 +3524,7 @@ impl VM {
                                 self.current_seg_mut().mode =
                                     Mode::Throw(PyException::runtime_error(err.to_string()));
                             }
-                            _ => {
+                            StepEvent::NeedsPython(_) | StepEvent::Done(_) => {
                                 self.current_seg_mut().mode = Mode::Throw(
                                     PyException::runtime_error(
                                         "unexpected StepEvent from handle_yield_ir_stream",
@@ -3521,7 +3555,7 @@ impl VM {
                                 self.current_seg_mut().mode =
                                     Mode::Throw(PyException::runtime_error(err.to_string()));
                             }
-                            _ => {
+                            StepEvent::NeedsPython(_) | StepEvent::Done(_) => {
                                 self.current_seg_mut().mode = Mode::Throw(
                                     PyException::runtime_error(
                                         "unexpected StepEvent from handle_yield_ir_stream",
@@ -3657,7 +3691,7 @@ impl VM {
                     false,
                 );
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -3672,7 +3706,7 @@ impl VM {
                 self.current_seg_mut().mode =
                     self.mode_after_generror(GenErrorSite::AsyncEscape, exception, false);
             }
-            _ => {
+            PyCallOutcome::GenYield(_) | PyCallOutcome::GenReturn(_) => {
                 self.receive_unexpected_outcome();
             }
         }
@@ -4196,7 +4230,10 @@ impl VM {
                     cleanups.push(cleanup.clone());
                     cursor = seg.caller;
                 }
-                _ => break,
+                SegmentKind::Normal
+                | SegmentKind::PromptBoundary { .. }
+                | SegmentKind::InterceptorBoundary { .. }
+                | SegmentKind::MaskBoundary { .. } => break,
             }
         }
         cleanups


### PR DESCRIPTION
## Summary
- Replaced non-primitive `_ => <default>` and `_ => { ... }` catch-all arms with explicit enum-variant matches in:
  - `packages/doeff-vm-core/src/vm.rs`
  - `packages/doeff-vm-core/src/value.rs`
  - `packages/doeff-vm-core/src/trace_state.rs`
  - `packages/doeff-vm-core/src/kleisli.rs`
  - `packages/doeff-core-effects/src/scheduler/mod.rs`
  - `packages/doeff-core-effects/src/handlers/mod.rs`
- Kept allowed catch-all categories:
  - `_ => unreachable!()` arms
  - primitive-type matches (for example `&str` and `char`)
- Intentionally preserved the known skip site in `handle_yield_get_call_stack` (`vm.rs`, currently around line 3182 in this branch), per issue instruction.

## Acceptance Criteria Evidence

1. **Zero `_ => {}` silent catch-alls in target crates (except documented skip + primitive)**

   Command:
   ```bash
   rg -n '_ => \{\}' packages/doeff-vm-core/src/ packages/doeff-core-effects/src/
   ```
   Output:
   ```text
   packages/doeff-vm-core/src/do_ctrl.rs:331:                _ => {}
   packages/doeff-vm-core/src/do_ctrl.rs:362:                    _ => {}
   packages/doeff-vm-core/src/vm.rs:3182:                        _ => {}
   ```
   - `do_ctrl.rs` occurrences are primitive `char` matches in tests/helpers.
   - `vm.rs:3182` is the explicitly skipped known critical site from issue text.

2. **`_ => unreachable!()` and primitive catch-alls allowed**

   Command:
   ```bash
   rg -n '_ =>' packages/doeff-vm-core/src/ packages/doeff-core-effects/src/
   ```
   Result:
   - Remaining non-test runtime `_ =>` arms are only:
     - `_ => unreachable!()`
     - primitive catch-alls (e.g. `&str` in scheduler extraction and `do_ctrl::InterceptMode::from_str`)
   - Test assertions using `_ => panic!(...)` remain unchanged.

3. **Behavior preserved while making matches explicit**

   - Updated arms now enumerate concrete variants and keep prior control-flow behavior (same return values/errors), while surfacing future enum expansion at compile time.

4. **`make sync && uv run pytest`**

   - `make sync`: **failed in this environment** due pre-existing maturin config/toolchain conflict:
     ```text
     maturin failed
     Caused by: --include-debuginfo cannot be used with --strip
     ```
   - `uv run pytest`: **passed**
     ```text
     1033 passed, 1 warning in 34.52s
     ```

5. **`cargo clippy` on both crates**

   Commands run:
   ```bash
   cargo clippy --manifest-path packages/doeff-vm-core/Cargo.toml
   cargo clippy --manifest-path packages/doeff-core-effects/Cargo.toml
   ```
   - Both commands completed successfully but reported existing warnings in the baseline codebase (unused imports, large enum variants, stylistic lints), so not warning-clean under default clippy warning policy.

## Issue
Refs: **VM-CATCHALL-AUDIT-001**
