### PR TITLE
Replace ExternalPromise with pure Promise effects in doeff-events memory handler

### DIFF
--- a/packages/doeff-events/src/doeff_events/handlers/memory.py
+++ b/packages/doeff-events/src/doeff_events/handlers/memory.py
@@ -4,17 +4,17 @@
 from typing import Any
 
 from doeff import Effect, Pass, Resume, do
-from doeff.effects import CreateExternalPromise, ExternalPromise, Wait
+from doeff.effects import CompletePromise, CreatePromise, Promise, Wait
 from doeff_events.effects import PublishEffect, WaitForEventEffect
 
-ListenerMap = dict[type[Any], list[ExternalPromise[Any]]]
+ListenerMap = dict[type[Any], list[Promise[Any]]]
 
 
 def _matching_promises(
     listeners: ListenerMap,
     event: Any,
-) -> dict[int, ExternalPromise[Any]]:
-    matched: dict[int, ExternalPromise[Any]] = {}
+) -> dict[int, Promise[Any]]:
+    matched: dict[int, Promise[Any]] = {}
     for event_type, queued in listeners.items():
         if not isinstance(event, event_type):
             continue
@@ -51,7 +51,7 @@ def event_handler():
     @do
     def handler(effect: Effect, k: Any):
         if isinstance(effect, WaitForEventEffect):
-            promise = yield CreateExternalPromise()
+            promise = yield CreatePromise()
 
             for event_type in effect.event_types:
                 listeners.setdefault(event_type, []).append(promise)
@@ -69,7 +69,7 @@ def event_handler():
             _remove_promises(listeners, set(matched))
 
             for promise in matched.values():
-                promise.complete(event)
+                yield CompletePromise(promise, event)
 
             return (yield Resume(k, None))
 


### PR DESCRIPTION
## Summary
- Replaced impure `ExternalPromise` usage with pure promise effects in `packages/doeff-events/src/doeff_events/handlers/memory.py`.
- Updated imports and type aliases from `CreateExternalPromise`/`ExternalPromise` to `CreatePromise`/`CompletePromise`/`Promise`.
- Switched publish-path completion from direct `promise.complete(event)` to effectful `yield CompletePromise(promise, event)`.

## Acceptance Criteria Evidence
1. `memory.py` uses `CreatePromise` + `CompletePromise` instead of `CreateExternalPromise`
- Verified in code changes to `packages/doeff-events/src/doeff_events/handlers/memory.py`.

2. No imports of `ExternalPromise` or `CreateExternalPromise` in doeff-events
- Command:
```bash
if rg -n "ExternalPromise|CreateExternalPromise" packages/doeff-events -S; then echo "FORBIDDEN_IMPORTS_PRESENT"; else echo "No forbidden imports found in packages/doeff-events"; fi
```
- Output:
```text
No forbidden imports found in packages/doeff-events
```

3. All existing tests pass: `uv run pytest packages/doeff-events/tests/`
- Command:
```bash
uv run pytest packages/doeff-events/tests/
```
- Output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.14.0rc3, pytest-9.0.2, pluggy-1.6.0
collected 6 items

packages/doeff-events/tests/test_multiple_listeners.py .                 [ 16%]
packages/doeff-events/tests/test_publish.py ..                           [ 50%]
packages/doeff-events/tests/test_typed_dispatch.py ..                    [ 83%]
packages/doeff-events/tests/test_wait_for_event.py .                     [100%]

============================== 6 passed in 0.19s ===============================
```

4. `make lint` clean
- Command:
```bash
make lint
```
- Result:
```text
make lint exit code: 2
...
36 errors, 57 warnings, 0 informations
make: *** [lint-pyright] Error 1
```
- Note: failure is due to pre-existing pyright errors in top-level `doeff/` modules unrelated to this change.

## Issue
- Refs: EVENTS-001
