### PR TITLE
VENDOR-RESULT-ERROR-001: fix Result.error typing in _vendor

### DIFF
--- a/doeff/_vendor.py
+++ b/doeff/_vendor.py
@@ -64,16 +64,18 @@ class Result(Generic[T_co]):
         if isinstance(self, Ok):
             return self.value
 
+        err = cast(Err, self)
         if message:
-            raise RuntimeError(f"{message}: {self.error}") from self.error
-        raise self.error
+            raise RuntimeError(f"{message}: {err.error}") from err.error
+        raise err.error
 
     def unwrap(self) -> T_co:
         """Return the value or raise the stored error."""
 
         if isinstance(self, Ok):
             return self.value
-        raise self.error
+        err = cast(Err, self)
+        raise err.error
 
     def unwrap_err(self) -> Exception:
         """Return the error or raise ``RuntimeError`` if this is a success."""
@@ -111,7 +113,8 @@ class Result(Generic[T_co]):
 
         if isinstance(self, Ok):
             return self.value
-        return default_fn(self.error)
+        err = cast(Err, self)
+        return default_fn(err.error)
 
     def and_then(self, f: "Callable[[T_co], Result[U]]") -> "Result[U]":
         """Chain computations that return ``Result``."""
@@ -144,7 +147,8 @@ class Result(Generic[T_co]):
         if isinstance(self, Ok):
             return kleisli(self.value)
 
-        error = self.error
+        err = cast(Err, self)
+        error = err.error
 
         def fail_generator() -> Any:
             raise error
@@ -172,7 +176,8 @@ class Result(Generic[T_co]):
 
         if isinstance(self, Ok):
             return Program.pure(self.value)
-        return kleisli(self.error)
+        err = cast(Err, self)
+        return kleisli(err.error)
 
     def recover(self, f: Callable[[Exception], T_co]) -> "Result[T_co]":
         """Recover from an error by computing a new value.
@@ -187,7 +192,8 @@ class Result(Generic[T_co]):
         """
         if isinstance(self, Ok):
             return self
-        return Ok(f(self.error))
+        err = cast(Err, self)
+        return Ok(f(err.error))
 
     def or_program(self, fallback: "Program[T_co]") -> "Program[T_co]":
         """Use a fallback program if this is an error.

--- a/tests/misc/test_vendor_typing.py
+++ b/tests/misc/test_vendor_typing.py
@@ -1,0 +1,24 @@
+"""Typing regressions for vendored utility module."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_vendor_module_passes_pyright() -> None:
+    pyright = shutil.which("pyright")
+    assert pyright is not None, "pyright executable is required for typing regression checks"
+
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [pyright, "doeff/_vendor.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part.strip())
+    assert result.returncode == 0, output


### PR DESCRIPTION
## Summary
- Fix pyright attribute-access failures in `doeff/_vendor.py` by explicitly narrowing error branches with `cast(Err, self)` before reading `.error`.
- Keep runtime behavior unchanged for `expect`, `unwrap`, `unwrap_or_else`, `and_then_k`, `recover_k`, and `recover`.
- Add typing regression test `tests/misc/test_vendor_typing.py` that runs `pyright doeff/_vendor.py` and fails on typing regressions.

## Evidence for Acceptance Criteria
1. `uv run pyright doeff/_vendor.py`
   - Result: `0 errors, 0 warnings, 0 informations`
2. No behavior regression in Result/Ok/Err methods
   - Change is type-only narrowing (`cast`) in existing error branches; control flow and raised exceptions are unchanged.
   - Full test suite passes (see #4).
3. No new type suppressions
   - No `# type: ignore` or `Any` suppressions were added.
4. `uv run pytest`
   - Result: `1038 passed, 1 warning in 47.30s`

## Issue
- References: `VENDOR-RESULT-ERROR-001`
