### PR TITLE
HANDLER-UNWRAP-SAFETY-001: remove ambiguous take().unwrap panics

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -256,6 +256,17 @@ rules:
         - "**/packages/doeff-vm/src/handler.rs"
         - "**/packages/doeff-vm/src/scheduler.rs"
 
+  - id: no-state-handler-take-unwrap
+    pattern: $X.take().unwrap()
+    message: >
+      BANNED: StateHandler Modify resume invariants must use explicit expect messages,
+      not ambiguous Option::unwrap panic text. See HANDLER-UNWRAP-SAFETY-001.
+    severity: ERROR
+    languages: [rust]
+    paths:
+      include:
+        - "**/packages/doeff-core-effects/src/handlers/mod.rs"
+
   - id: no-python-effect-class-shadowing
     pattern-either:
       - pattern: |

--- a/packages/doeff-core-effects/src/handlers/mod.rs
+++ b/packages/doeff-core-effects/src/handlers/mod.rs
@@ -641,9 +641,15 @@ impl IRStreamProgram for StateHandlerProgram {
         }
         // Modify case: store modifier result but resume caller with OLD value.
         // SPEC-008 L1271: Modify is read-then-modify, returns the old value.
-        let key = self.pending_key.take().unwrap();
-        let continuation = self.pending_k.take().unwrap();
-        let old_value = self.pending_old_value.take().unwrap();
+        let key = self.pending_key.take().expect(
+            "StateHandler Modify invariant violated: pending key missing during resume",
+        );
+        let continuation = self.pending_k.take().expect(
+            "StateHandler Modify invariant violated: pending continuation missing during resume",
+        );
+        let old_value = self.pending_old_value.take().expect(
+            "StateHandler Modify invariant violated: pending old_value missing during resume",
+        );
         store.put(key, value);
         IRStreamStep::Yield(DoCtrl::Resume {
             continuation,
@@ -1909,6 +1915,21 @@ mod tests {
         assert_eq!(store.get("count").and_then(Value::as_int), Some(8));
         let location = IRStream::debug_location(&program).expect("state debug location");
         assert_eq!(location.phase.as_deref(), Some("Idle"));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "StateHandler Modify invariant violated: pending continuation missing during resume"
+    )]
+    fn test_state_modify_resume_invariant_message_for_missing_continuation() {
+        let mut store = RustStore::new();
+        let mut scope = ScopeStore::default();
+        let mut program = StateHandlerProgram::new();
+
+        program.pending_key = Some("count".to_string());
+        program.pending_old_value = Some(Value::Int(5));
+
+        let _ = IRStream::resume(&mut program, Value::Int(8), &mut store, &mut scope);
     }
 
     #[test]

--- a/tests/core/test_state_handler_unwrap_invariant_messages.py
+++ b/tests/core/test_state_handler_unwrap_invariant_messages.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HANDLERS_RS = ROOT / "packages" / "doeff-core-effects" / "src" / "handlers" / "mod.rs"
+
+
+def _handler_source() -> str:
+    return HANDLERS_RS.read_text(encoding="utf-8")
+
+
+def test_modify_resume_does_not_use_ambiguous_take_unwrap() -> None:
+    source = _handler_source()
+    assert "self.pending_key.take().unwrap()" not in source
+    assert "self.pending_k.take().unwrap()" not in source
+    assert "self.pending_old_value.take().unwrap()" not in source
+
+
+def test_modify_resume_has_explicit_invariant_messages() -> None:
+    source = _handler_source()
+    assert "self.pending_key.take().expect(" in source
+    assert "self.pending_k.take().expect(" in source
+    assert "self.pending_old_value.take().expect(" in source
+    assert "StateHandler Modify invariant violated: pending key missing during resume" in source
+    assert "StateHandler Modify invariant violated: pending continuation missing during resume" in source
+    assert "StateHandler Modify invariant violated: pending old_value missing during resume" in source


### PR DESCRIPTION
## Summary
- Replaced `StateHandlerProgram::resume` Modify-path `.take().unwrap()` calls with explicit `expect(...)` invariant messages.
- Added a Rust unit test in `handlers/mod.rs` that asserts invariant panic text for a broken pending-state path.
- Added a source-audit pytest guard (`tests/core/test_state_handler_unwrap_invariant_messages.py`) to enforce:
  - no `self.pending_*.take().unwrap()` in the StateHandler Modify resume path
  - presence of explicit invariant context messages
- Added semgrep ERROR rule `no-state-handler-take-unwrap` scoped to `packages/doeff-core-effects/src/handlers/mod.rs`.

Reference issue: `HANDLER-UNWRAP-SAFETY-001`

## Acceptance Criteria Evidence
1. Three Modify-path `.take().unwrap()` calls removed
   - Command: `rg -n "\\.take\\(\\)\\.unwrap\\(" packages/doeff-core-effects/src/handlers/mod.rs`
   - Output: `no take().unwrap() matches`

2. Failure mode now provides explicit invariant context
   - `expect(...)` messages now include:
     - `pending key missing during resume`
     - `pending continuation missing during resume`
     - `pending old_value missing during resume`

3. New failing test passes after implementation
   - Pre-fix run (captured before implementation):
     - `uv run pytest tests/core/test_state_handler_unwrap_invariant_messages.py -q`
     - Result: `2 failed`
   - Post-fix run:
     - `uv run pytest tests/core/test_state_handler_unwrap_invariant_messages.py -q`
     - Result: `2 passed`

4. Semgrep guard passes
   - Pre-fix run (captured before implementation):
     - `semgrep --config .semgrep.yaml packages/doeff-core-effects/src/handlers/mod.rs --error`
     - Result: `3 findings (blocking)`
   - Post-fix run:
     - same command
     - Result: `0 findings`

5. `uv run pytest packages/doeff-core-effects` (or workspace equivalent) passes
   - `uv run pytest packages/doeff-core-effects` returns `collected 0 items` / exit 5 because there are no pytest files under that package directory.
   - Workspace-equivalent targeted guard test passes:
     - `uv run pytest tests/core/test_state_handler_unwrap_invariant_messages.py -q`
     - Result: `2 passed`

6. `make lint` passes
   - Executed: `make lint`
   - Current branch state: fails in `pyright` with pre-existing unrelated errors in `doeff/` (e.g. `doeff/__init__.py`, `doeff/__main__.py`, `doeff/_types_internal.py`, etc.).
   - No new lint issues introduced by this PR's changed files.
