### PR TITLE
ISSUE-CORE-521: show only error-path effects in default traceback

### DIFF
--- a/doeff/traceback.py
+++ b/doeff/traceback.py
@@ -395,6 +395,28 @@ else:
                 return f"⇢ {result.handler_name} transferred to {result.target_repr}"
             return "⇢ active"
 
+        def _is_final_exception_type(self, exception_repr: str) -> bool:
+            rendered_type = exception_repr.split("(", 1)[0].strip()
+            if not rendered_type:
+                # Keep ambiguous rows visible rather than hiding potentially relevant context.
+                return True
+
+            final_type = type(self.exception)
+            final_name = final_type.__name__
+            final_qualified = f"{final_type.__module__}.{final_type.__qualname__}"
+            return (
+                rendered_type in (final_name, final_qualified)
+                or rendered_type.endswith(f".{final_name}")
+            )
+
+        def _should_render_effect_entry(self, entry: EffectYield) -> bool:
+            result = entry.result
+            if isinstance(result, EffectResultResumed):
+                return False
+            if isinstance(result, EffectResultThrew):
+                return self._is_final_exception_type(result.exception_repr)
+            return True
+
         @staticmethod
         def _format_spawn_boundary(boundary: SpawnBoundary) -> str:
             if boundary.spawn_site is not None:
@@ -424,6 +446,8 @@ else:
                     continue
 
                 if isinstance(entry, EffectYield):
+                    if not self._should_render_effect_entry(entry):
+                        continue
                     if (
                         previous_handler_stack is not None
                         and entry.handler_stack == previous_handler_stack

--- a/tests/core/test_spec_trace_001_examples.py
+++ b/tests/core/test_spec_trace_001_examples.py
@@ -83,13 +83,13 @@ def _assert_basic_structure(rendered: str, *, exception_type: str) -> list[str]:
     lines = rendered.strip().splitlines()
     assert lines[0] == "doeff Traceback (most recent call last):"
     assert any("()" in line for line in lines)
-    assert any("yield " in line for line in lines)
+    assert any("yield " in line for line in lines) or any("raise " in line for line in lines)
 
     handler_markers = [
         line.strip() for line in lines if line.strip() in {"handlers:", "(same handlers)"}
     ]
-    assert handler_markers
-    assert any("→ resumed" in line or "✗ " in line or "⇢ " in line for line in lines)
+    if handler_markers:
+        assert any("✗ " in line or "⇢ " in line for line in lines)
     assert lines[-1].startswith(exception_type)
     return lines
 
@@ -179,21 +179,14 @@ def test_example_2_custom_handler_with_withhandler() -> None:
         raise ConnectionError("timeout")
 
     rendered = _render_failure(WithHandler(auth_handler, WithHandler(rate_limiter, call_api())))
-    lines = _assert_basic_structure(rendered, exception_type="ConnectionError")
+    _assert_basic_structure(rendered, exception_type="ConnectionError")
 
-    rate_limit_handlers = _handler_lines_after_effect(
-        lines,
-        effect_fragment="Ask(",
-        detail_fragment="rate_limit",
-    )
-    assert rate_limit_handlers
-    assert any("rate_limiter ✓" in line for line in rate_limit_handlers)
-    assert any("pending" in line for line in rate_limit_handlers)
-    _assert_default_handlers_visible(rate_limit_handlers)
     assert "Ask('token')" not in rendered
     assert 'Ask("token")' not in rendered
-    assert "→ resumed with" in rendered
-    assert "100" in rendered
+    assert "Ask('rate_limit')" not in rendered
+    assert 'Ask("rate_limit")' not in rendered
+    assert "rate_limiter ✓" not in rendered
+    assert "→ resumed with" not in rendered
     assert "ConnectionError: timeout" in rendered
 
 
@@ -271,13 +264,9 @@ def test_example_5_handler_stack_changes() -> None:
     rendered = _render_failure(outer(), store={"x": 0, "y": 0})
     lines = _assert_basic_structure(rendered, exception_type="ValueError")
 
-    outer_handlers = _handler_lines_after_effect(lines, effect_fragment="Put(", detail_fragment='"x"')
-    inner_handlers = _handler_lines_after_effect(lines, effect_fragment="Put(", detail_fragment='"y"')
-    assert outer_handlers != inner_handlers
-    assert not any("my_handler" in line for line in outer_handlers)
-    assert any("my_handler" in line for line in inner_handlers)
-    _assert_default_handlers_visible(outer_handlers)
-    _assert_default_handlers_visible(inner_handlers)
+    assert "yield Put(" not in rendered
+    assert "my_handler" not in rendered
+    assert any("raise ValueError('inner error')" in line for line in lines)
 
 
 def test_example_8_spawn_chain() -> None:

--- a/tests/core/test_traceback_format_default.py
+++ b/tests/core/test_traceback_format_default.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import inspect
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,12 +27,37 @@ from doeff.trace import ProgramYield
 from doeff.traceback import attach_doeff_traceback, build_doeff_traceback
 
 
+def _exception_for_chain(active_chain: list[dict[str, object]]) -> BaseException:
+    for entry in reversed(active_chain):
+        if entry.get("kind") != "exception_site":
+            continue
+        exception_type = str(entry.get("exception_type", "ValueError"))
+        message = str(entry.get("message", "boom"))
+        exception_class = getattr(builtins, exception_type, None)
+        if isinstance(exception_class, type) and issubclass(exception_class, BaseException):
+            return exception_class(message)
+        return ValueError(message)
+    return ValueError("boom")
+
+
 def _tb(
     active_chain: list[dict[str, object]],
     trace: list[dict[str, object]] | None = None,
 ) -> object:
     return build_doeff_traceback(
-        ValueError("boom"),
+        _exception_for_chain(active_chain),
+        trace or [],
+        active_chain,
+    )
+
+
+def _tb_with_exception(
+    exception: BaseException,
+    active_chain: list[dict[str, object]],
+    trace: list[dict[str, object]] | None = None,
+) -> object:
+    return build_doeff_traceback(
+        exception,
         trace or [],
         active_chain,
     )
@@ -79,10 +105,14 @@ def _render_single_delegated_handler(handler_name: str) -> str:
                     {
                         "handler_name": "user_handler",
                         "handler_kind": "python",
-                        "status": "resumed",
+                        "status": "threw",
                     },
                 ],
-                "result": {"kind": "resumed", "value_repr": "1"},
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "user_handler",
+                    "exception_repr": "RuntimeError('boom')",
+                },
             },
             {
                 "kind": "exception_site",
@@ -186,7 +216,7 @@ def test_format_default_distinguishes_passed_and_delegated_markers() -> None:
                     },
                     {"handler_name": "h_resumed", "handler_kind": "python", "status": "resumed"},
                 ],
-                "result": {"kind": "resumed", "value_repr": "1"},
+                "result": {"kind": "active"},
             },
             {
                 "kind": "exception_site",
@@ -298,9 +328,13 @@ def test_format_default_effect_yield_with_markers() -> None:
                 "effect_repr": 'Put("key", 1)',
                 "handler_stack": [
                     {"handler_name": "h1", "handler_kind": "python", "status": "delegated"},
-                    {"handler_name": "h2", "handler_kind": "python", "status": "resumed"},
+                    {"handler_name": "h2", "handler_kind": "python", "status": "threw"},
                 ],
-                "result": {"kind": "resumed", "value_repr": "None"},
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "h2",
+                    "exception_repr": "ValueError('boom')",
+                },
             },
             {
                 "kind": "exception_site",
@@ -315,8 +349,8 @@ def test_format_default_effect_yield_with_markers() -> None:
 
     rendered = tb.format_default()
     assert "h1 ⇆" in rendered
-    assert "h2 ✓" in rendered
-    assert "→ resumed with None" in rendered
+    assert "h2 ✗" in rendered
+    assert "✗ h2 raised ValueError('boom')" in rendered
 
 
 def test_format_default_handler_stack_same() -> None:
@@ -333,7 +367,7 @@ def test_format_default_handler_stack_same() -> None:
                 "source_line": 1,
                 "effect_repr": "Ping()",
                 "handler_stack": stack,
-                "result": {"kind": "resumed", "value_repr": "1"},
+                "result": {"kind": "active"},
             },
             {
                 "kind": "effect_yield",
@@ -342,7 +376,7 @@ def test_format_default_handler_stack_same() -> None:
                 "source_line": 2,
                 "effect_repr": "Ping()",
                 "handler_stack": stack,
-                "result": {"kind": "resumed", "value_repr": "2"},
+                "result": {"kind": "active"},
             },
             {
                 "kind": "exception_site",
@@ -432,7 +466,7 @@ def test_format_default_handler_stack_collapses_pending_groups() -> None:
                     {"handler_name": "pending_4", "handler_kind": "python", "status": "pending"},
                     {"handler_name": "pending_5", "handler_kind": "python", "status": "pending"},
                 ],
-                "result": {"kind": "resumed", "value_repr": "1"},
+                "result": {"kind": "active"},
             },
             {
                 "kind": "exception_site",
@@ -540,7 +574,7 @@ def test_format_default_handler_stack_mixed_pending_groups_keep_order() -> None:
     assert first_pending < delegated < middle_pending < threw < trailing_pending
 
 
-def test_format_default_keeps_duplicate_handler_names_from_vm_chain() -> None:
+def test_format_default_filters_resumed_effects_with_duplicate_handler_names() -> None:
     @do
     def same_name_handler(_effect: Effect, _k: object):
         yield Pass()
@@ -558,7 +592,9 @@ def test_format_default_keeps_duplicate_handler_names_from_vm_chain() -> None:
     assert result.is_err()
 
     rendered = _tb_from_run_result(result).format_default()
-    assert rendered.count("same_name_handler ↗") >= 2
+    assert "same_name_handler" not in rendered
+    assert "yield Put(" not in rendered
+    assert "raise ValueError('boom')" in rendered
 
 
 def test_format_default_duplicate_name_throw_marks_correct_handler() -> None:
@@ -636,7 +672,7 @@ def test_format_default_renders_all_handlers() -> None:
     assert "user_handler" in rendered
 
 
-def test_format_default_resume_value_truncated_80() -> None:
+def test_format_default_filters_resumed_effect_with_long_value() -> None:
     long_value = "x" * 120
     tb = _tb(
         [
@@ -663,7 +699,8 @@ def test_format_default_resume_value_truncated_80() -> None:
     )
 
     rendered = tb.format_default()
-    assert "..." in rendered
+    assert "yield Ping()" not in rendered
+    assert "→ resumed with" not in rendered
     assert long_value not in rendered
 
 
@@ -877,6 +914,157 @@ def test_format_default_effect_repr_human_readable() -> None:
     assert 'yield Put("key", 1)' in tb.format_default()
 
 
+def test_traceback_filters_resumed_effects() -> None:
+    tb = _tb(
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "frame_one",
+                "source_file": "trace.py",
+                "source_line": 10,
+                "effect_repr": "FirstEffect()",
+                "handler_stack": [
+                    {"handler_name": "h1", "handler_kind": "python", "status": "threw"}
+                ],
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "h1",
+                    "exception_repr": "ValueError('boom')",
+                },
+            },
+            {
+                "kind": "effect_yield",
+                "function_name": "frame_two",
+                "source_file": "trace.py",
+                "source_line": 11,
+                "effect_repr": "NoisyCompletedEffect()",
+                "handler_stack": [
+                    {"handler_name": "h2", "handler_kind": "python", "status": "resumed"}
+                ],
+                "result": {"kind": "resumed", "value_repr": "123"},
+            },
+            {
+                "kind": "effect_yield",
+                "function_name": "frame_three",
+                "source_file": "trace.py",
+                "source_line": 12,
+                "effect_repr": "LastEffect()",
+                "handler_stack": [
+                    {"handler_name": "h3", "handler_kind": "python", "status": "threw"}
+                ],
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "h3",
+                    "exception_repr": "ValueError('boom')",
+                },
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "frame_three",
+                "source_file": "trace.py",
+                "source_line": 13,
+                "exception_type": "ValueError",
+                "message": "boom",
+            },
+        ]
+    )
+
+    rendered = tb.format_default()
+    assert "yield FirstEffect()" in rendered
+    assert "yield LastEffect()" in rendered
+    assert "NoisyCompletedEffect()" not in rendered
+    assert "→ resumed with" not in rendered
+
+
+def test_traceback_filters_recovered_exceptions() -> None:
+    class GeminiStructuredOutputError(Exception):
+        pass
+
+    tb = _tb_with_exception(
+        GeminiStructuredOutputError("non-json"),
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "ask",
+                "source_file": "client.py",
+                "source_line": 213,
+                "effect_repr": "Ask('gemini_api_key')",
+                "handler_stack": [
+                    {"handler_name": "ReaderHandler", "handler_kind": "rust_builtin", "status": "threw"}
+                ],
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "ReaderHandler",
+                    "exception_repr": "MissingEnvKeyError('gemini_api_key')",
+                },
+            },
+            {
+                "kind": "effect_yield",
+                "function_name": "_lower_analyze_video",
+                "source_file": "video.py",
+                "source_line": 160,
+                "effect_repr": "LLMStructuredQuery(...)",
+                "handler_stack": [
+                    {
+                        "handler_name": "gemini_production_handler",
+                        "handler_kind": "python",
+                        "status": "threw",
+                    }
+                ],
+                "result": {
+                    "kind": "threw",
+                    "handler_name": "gemini_production_handler",
+                    "exception_repr": "GeminiStructuredOutputError('non-json')",
+                },
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "process_structured_response",
+                "source_file": "structured_llm.py",
+                "source_line": 585,
+                "exception_type": "GeminiStructuredOutputError",
+                "message": "non-json",
+            },
+        ],
+    )
+
+    rendered = tb.format_default()
+    assert "Ask('gemini_api_key')" not in rendered
+    assert "MissingEnvKeyError" not in rendered
+    assert "yield LLMStructuredQuery(...)" in rendered
+    assert "GeminiStructuredOutputError: non-json" in rendered
+
+
+def test_traceback_keeps_active_effects() -> None:
+    tb = _tb(
+        [
+            {
+                "kind": "effect_yield",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 50,
+                "effect_repr": "InFlightEffect()",
+                "handler_stack": [
+                    {"handler_name": "h_active", "handler_kind": "python", "status": "active"}
+                ],
+                "result": {"kind": "active"},
+            },
+            {
+                "kind": "exception_site",
+                "function_name": "runner",
+                "source_file": "program.py",
+                "source_line": 51,
+                "exception_type": "ValueError",
+                "message": "boom",
+            },
+        ]
+    )
+
+    rendered = tb.format_default()
+    assert "yield InFlightEffect()" in rendered
+    assert "⇢ active" in rendered
+
+
 def test_existing_formats_unchanged() -> None:
     trace = [
         {
@@ -1034,7 +1222,7 @@ def test_format_default_shows_program_yield_chain() -> None:
 
     rendered = _tb_from_run_result(result).format_default()
     source_file = str(Path(__file__).resolve())
-    assert "outer()" in rendered
+    assert "outer()" not in rendered
     assert "inner()" in rendered
     assert "yield Boom" in rendered
     assert "crash_handler ✗" in rendered
@@ -1280,7 +1468,7 @@ def test_runtime_nested_dispatch_preserves_handler_provenance() -> None:
     assert all(frame.handler_kind is None for frame in body_frames)
 
 
-def test_format_default_includes_resumed_effects() -> None:
+def test_format_default_filters_resumed_effects_by_default() -> None:
     @do
     def body() -> Program[int]:
         yield Put("k", 1)
@@ -1291,8 +1479,8 @@ def test_format_default_includes_resumed_effects() -> None:
     assert result.is_err()
 
     rendered = _tb_from_run_result(result).format_default()
-    assert "yield Put(" in rendered
-    assert "→ resumed with" in rendered
+    assert "yield Put(" not in rendered
+    assert "→ resumed with" not in rendered
     assert "raise ValueError('boom')" in rendered
     assert "/doeff/do.py:52" not in rendered
 

--- a/tests/core/test_traceback_spec_compliance.py
+++ b/tests/core/test_traceback_spec_compliance.py
@@ -115,13 +115,12 @@ def test_spec_example_2_with_handler_stack_markers() -> None:
 
     wrapped = WithHandler(auth_handler, WithHandler(rate_limiter, call_api()))
     rendered = _render_failure(wrapped)
-    assert "yield Ask('rate_limit')" in rendered or 'yield Ask("rate_limit")' in rendered
-    assert "rate_limiter ✓" in rendered
-    assert "pending" in rendered
-    assert "→ resumed with Int(100)" in rendered or "→ resumed with 100" in rendered
+    assert "yield Ask('rate_limit')" not in rendered
+    assert 'yield Ask("rate_limit")' not in rendered
+    assert "rate_limiter ✓" not in rendered
+    assert "→ resumed with" not in rendered
     assert "raise ConnectionError('timeout')" in rendered
     assert "ConnectionError: timeout" in rendered
-    _assert_default_handlers_visible(rendered)
 
 
 def test_spec_example_3_handler_throws() -> None:
@@ -183,13 +182,12 @@ def test_spec_example_6_handler_return_abandons_inner_chain() -> None:
         raise ValueError(f"Unexpected: {result}")
 
     rendered = _render_failure(outer(), store={"result": ""})
-    assert "yield Ask(" in rendered
-    assert "short_circuit_handler ✓" in rendered
+    assert "yield Ask(" not in rendered
+    assert "short_circuit_handler ✓" not in rendered
     assert "inner()" in rendered
     assert "raise ValueError(" in rendered
     assert "Unexpected: fallback" in rendered
     assert "ValueError: Unexpected: fallback" in rendered
-    _assert_default_handlers_visible(rendered)
 
 
 def test_spec_example_8_spawn_chain_during_gather() -> None:
@@ -227,7 +225,7 @@ def test_spec_example_8_spawn_chain_during_gather() -> None:
     )
     source_file = inspect.getsourcefile(process_batch.original_generator)
     assert source_file is not None
-    assert "main()" in rendered
+    assert "main()" not in rendered
     assert "process_batch()" in rendered
     assert "── in task " in rendered
     assert "_spawn_task()" not in rendered


### PR DESCRIPTION
## Summary
- Filter `DoeffTraceback.format_default()` to hide completed `EffectResultResumed` entries.
- Hide `EffectResultThrew` entries when their exception type does not match the final exception type (recovered throws).
- Keep `EffectResultActive`, `EffectResultTransferred`, and matching `EffectResultThrew` entries visible.
- Add focused regression tests for resumed filtering, recovered-throw filtering, and active-entry preservation.
- Update traceback spec tests to match the new default behavior (error-path focused output).

## Acceptance Criteria Evidence
1. `format_default()` skips `EffectYield` entries with `Resumed` results
   - Implemented in `doeff/traceback.py` via `_should_render_effect_entry()` (`EffectResultResumed -> False`).
   - Verified by `test_traceback_filters_resumed_effects` and `test_format_default_filters_resumed_effects_by_default`.

2. `format_default()` skips `EffectYield` entries with `Threw` results where exception type differs from final exception
   - Implemented via `_is_final_exception_type()` + `_should_render_effect_entry()` in `doeff/traceback.py`.
   - Verified by `test_traceback_filters_recovered_exceptions`.

3. `EffectYield` entries with `Active` or matching `Threw` results are preserved
   - Verified by `test_traceback_keeps_active_effects`.
   - Existing throw-path rendering coverage still passes in traceback suites.

4. `ExceptionSite` and bottom exception line are preserved
   - Verified by passing traceback formatter/spec suites (assertions on `raise ...` lines and final `ExceptionType: message` lines).

5. All existing traceback tests pass
6. New filtering tests pass
   - `uv run pytest tests/core/test_traceback_format_default.py tests/core/test_spec_trace_001_examples.py tests/core/test_traceback_spec_compliance.py`
     - Result: **59 passed**
   - `uv run pytest tests/core -k traceback`
     - Result: **62 passed, 294 deselected**
   - `uv run pytest tests/core/test_doeff_trace_stderr.py`
     - Result: **5 passed**

7. `make lint` clean
   - Attempted `make lint`, `make lint-ruff`, and `make lint-semgrep`.
   - Current branch/repo baseline has many pre-existing lint/type/semgrep failures unrelated to this issue (outside changed files), so full lint is not clean in this environment.
   - Changed files lint clean with:
     - `uv run ruff check doeff/traceback.py tests/core/test_traceback_format_default.py tests/core/test_spec_trace_001_examples.py tests/core/test_traceback_spec_compliance.py`
       - Result: **All checks passed**
     - `uv run pyright doeff/traceback.py`
       - Result: **0 errors, 1 warning** (`reportUnsupportedDunderAll` pre-existing pattern).

## Issue
- Ref: ISSUE-CORE-521
