### PR TITLE
Fix PyKleisli env round-trip

### DIFF
--- a/packages/doeff-core-effects/src/sentinels.rs
+++ b/packages/doeff-core-effects/src/sentinels.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 /// Opaque sentinel wrapping a Rust handler factory.
 #[pyclass(frozen, name = "RustHandler")]
 pub struct PyRustHandlerSentinel {
-    kleisli: KleisliRef,
+    pub kleisli: KleisliRef,
 }
 
 impl PyRustHandlerSentinel {

--- a/packages/doeff-vm-core/src/kleisli.rs
+++ b/packages/doeff-vm-core/src/kleisli.rs
@@ -65,6 +65,11 @@ pub trait Kleisli: std::fmt::Debug + Send + Sync {
         None
     }
 
+    /// Optional Python object used when a Kleisli is resumed back to Python as a value.
+    fn py_roundtrip_value(&self) -> Option<PyShared> {
+        None
+    }
+
     /// Whether this handler is a Rust builtin handler.
     fn is_rust_builtin(&self) -> bool {
         false
@@ -120,6 +125,66 @@ impl Kleisli for IdentityKleisli {
 
     fn py_identity(&self) -> Option<PyShared> {
         Some(self.identity.clone())
+    }
+
+    fn py_roundtrip_value(&self) -> Option<PyShared> {
+        self.inner.py_roundtrip_value()
+    }
+
+    fn is_rust_builtin(&self) -> bool {
+        self.inner.is_rust_builtin()
+    }
+
+    fn can_handle(&self, effect: &DispatchEffect) -> Result<bool, VMError> {
+        self.inner.can_handle(effect)
+    }
+
+    fn supports_error_context_conversion(&self) -> bool {
+        self.inner.supports_error_context_conversion()
+    }
+
+    fn on_run_end(&self, run_token: u64) {
+        self.inner.on_run_end(run_token);
+    }
+}
+
+/// Kleisli wrapper that preserves a Python object for value round-tripping only.
+#[derive(Debug, Clone)]
+pub struct RoundtripKleisli {
+    inner: KleisliRef,
+    value: PyShared,
+}
+
+impl RoundtripKleisli {
+    pub fn new(inner: KleisliRef, value: PyShared) -> Self {
+        Self { inner, value }
+    }
+}
+
+impl Kleisli for RoundtripKleisli {
+    fn apply(&self, py: Python<'_>, args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        self.inner.apply(py, args)
+    }
+
+    fn apply_with_run_token(
+        &self,
+        py: Python<'_>,
+        args: Vec<Value>,
+        run_token: Option<u64>,
+    ) -> Result<DoCtrl, VMError> {
+        self.inner.apply_with_run_token(py, args, run_token)
+    }
+
+    fn debug_info(&self) -> KleisliDebugInfo {
+        self.inner.debug_info()
+    }
+
+    fn py_identity(&self) -> Option<PyShared> {
+        self.inner.py_identity()
+    }
+
+    fn py_roundtrip_value(&self) -> Option<PyShared> {
+        Some(self.value.clone())
     }
 
     fn is_rust_builtin(&self) -> bool {

--- a/packages/doeff-vm-core/src/pyvm.rs
+++ b/packages/doeff-vm-core/src/pyvm.rs
@@ -8,8 +8,8 @@ use pyo3::types::{PyDict, PyTuple};
 
 use crate::do_ctrl::DoCtrl;
 use crate::driver::PyException;
-use crate::vm::VM;
 pub use crate::effect::PyEffectBase;
+use crate::vm::VM;
 
 /// Discriminant stored as `tag: u8` on control/effect base classes.
 #[repr(u8)]
@@ -156,7 +156,7 @@ pub struct PyDoCtrlBase {
 #[pymethods]
 impl PyDoCtrlBase {
     #[new]
-    fn new() -> PyClassInitializer<Self> {
+    pub fn new() -> PyClassInitializer<Self> {
         PyClassInitializer::from(PyDoExprBase).add_subclass(PyDoCtrlBase {
             tag: DoExprTag::Unknown as u8,
         })
@@ -312,7 +312,8 @@ pub fn is_effect_base_like(obj: &Bound<'_, PyAny>) -> bool {
 }
 
 pub fn is_doexpr_like(obj: &Bound<'_, PyAny>) -> bool {
-    obj.is_instance_of::<PyDoExprBase>() || obj.is_instance_of::<crate::doeff_generator::DoeffGenerator>()
+    obj.is_instance_of::<PyDoExprBase>()
+        || obj.is_instance_of::<crate::doeff_generator::DoeffGenerator>()
 }
 
 pub fn doctrl_tag(obj: &Bound<'_, PyAny>) -> Option<DoExprTag> {
@@ -321,11 +322,8 @@ pub fn doctrl_tag(obj: &Bound<'_, PyAny>) -> Option<DoExprTag> {
         .and_then(|base| DoExprTag::try_from(base.tag).ok())
 }
 
-pub type ClassifyYieldedHook = for<'py> fn(
-    &VM,
-    Python<'py>,
-    &Bound<'py, PyAny>,
-) -> Result<DoCtrl, PyException>;
+pub type ClassifyYieldedHook =
+    for<'py> fn(&VM, Python<'py>, &Bound<'py, PyAny>) -> Result<DoCtrl, PyException>;
 
 pub type DoctrlToPyexprHook = fn(&DoCtrl) -> Result<Option<Py<PyAny>>, PyException>;
 

--- a/packages/doeff-vm-core/src/value.rs
+++ b/packages/doeff-vm-core/src/value.rs
@@ -13,7 +13,7 @@ use crate::capture::{
 };
 use crate::frame::CallMetadata;
 use crate::ids::{PromiseId, TaskId};
-use crate::kleisli::KleisliRef;
+use crate::kleisli::{KleisliRef, RoundtripKleisli};
 use crate::py_shared::PyShared;
 use crate::pyvm::{PyTraceFrame, PyTraceHop};
 
@@ -367,7 +367,13 @@ impl Value {
                 }
                 Ok(list.into_any())
             }
-            Value::Kleisli(_) => Ok(py.None().into_bound(py)),
+            Value::Kleisli(kleisli) => {
+                if let Some(value) = kleisli.py_roundtrip_value() {
+                    Ok(value.bind(py).clone())
+                } else {
+                    Ok(py.None().into_bound(py))
+                }
+            }
             Value::Task(handle) => {
                 let dict = pyo3::types::PyDict::new(py);
                 dict.set_item("type", "Task")?;
@@ -465,7 +471,11 @@ impl Value {
             return Value::String(s);
         }
         if let Ok(kleisli) = obj.extract::<PyRef<'_, crate::kleisli::PyKleisli>>() {
-            return Value::Kleisli(Arc::new(kleisli.clone()));
+            let inner: KleisliRef = Arc::new(kleisli.clone());
+            return Value::Kleisli(Arc::new(RoundtripKleisli::new(
+                inner,
+                PyShared::new(obj.clone().unbind()),
+            )));
         }
         Value::Python(obj.clone().unbind())
     }

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -13,15 +13,10 @@ use crate::effect::{
     dispatch_from_shared, dispatch_ref_as_python, PyExecutionContext, PyGetExecutionContext,
     PyProgramCallStack,
 };
-use crate::ir_stream::{IRStream, PythonGeneratorStream};
-use doeff_vm_core::{
-    install_vm_hooks, DoExprTag, PyDoCtrlBase, PyDoExprBase, PyEffectBase, PyK, PyResultErr,
-    PyResultOk, PyTraceFrame, PyTraceHop, VmHooks,
-};
-use doeff_core_effects::sentinels::PyRustHandlerSentinel;
 use crate::error::VMError;
 use crate::frame::CallMetadata;
 use crate::ids::Marker;
+use crate::ir_stream::{IRStream, PythonGeneratorStream};
 use crate::kleisli::{DgfnKleisli, IdentityKleisli, KleisliRef, PyKleisli};
 use crate::py_key::HashedPyKey;
 use crate::py_shared::PyShared;
@@ -30,6 +25,11 @@ use crate::segment::{Segment, SegmentKind};
 use crate::step::{Mode, PendingPython, PyCallOutcome, PyException, PythonCall, StepEvent};
 use crate::value::Value;
 use crate::vm::VM;
+use doeff_core_effects::sentinels::PyRustHandlerSentinel;
+use doeff_vm_core::{
+    install_vm_hooks, DoExprTag, PyDoCtrlBase, PyDoExprBase, PyEffectBase, PyK, PyResultErr,
+    PyResultOk, PyTraceFrame, PyTraceHop, VmHooks,
+};
 
 fn ensure_vm_core_hooks_installed() {
     install_vm_hooks(VmHooks {
@@ -666,7 +666,6 @@ impl PyVM {
             .receive_python_result(PyCallOutcome::GenError(py_exc));
         Ok(())
     }
-
 }
 
 impl PyVM {

--- a/tests/effects/test_spawn_env_pykleisli.py
+++ b/tests/effects/test_spawn_env_pykleisli.py
@@ -31,6 +31,17 @@ class TestAskEnvPyKleisli:
         assert result.is_ok(), result.display()
         assert result.value == 420
 
+    def test_pykleisli_in_env_via_ask_preserves_identity(self) -> None:
+        @do
+        def program():
+            return (yield Ask("injected"))
+
+        result = run(program(), handlers=default_handlers(), env={"injected": _kleisli_func})
+        assert result.is_ok(), (
+            f"PyKleisli identity should survive Ask round-trip: {result.display()}"
+        )
+        assert result.value is _kleisli_func
+
     def test_pykleisli_in_env_via_ask_returns_none(self) -> None:
         @do
         def program():


### PR DESCRIPTION
## Summary
- preserve the original Python `PyKleisli` object when env/store values cross into the Rust VM
- round-trip only env/store `Value::Kleisli` values back to Python, without changing handler identity semantics
- add an identity regression test so `Ask("injected")` returns the same `PyKleisli` object
- make two existing Rust test helpers public across crates so `cargo test` can compile and run cleanly

## Evidence
- `uv run pytest tests/effects/test_spawn_env_pykleisli.py`
  - `6 passed in 0.02s`
- `cargo test` (in `packages/doeff-vm`)
  - `30 passed; 0 failed`
- `uv run pytest -q`
  - `1057 passed, 1 warning in 30.00s`
- direct repro after rebuild:
  - `ok True`
  - `is_same True`
  - `type PyKleisli`

## Acceptance Criteria
- [x] `test_pykleisli_in_env_via_ask_returns_none` now passes
- [x] `test_pykleisli_in_local_env_via_ask_returns_none` now passes
- [x] `test_pykleisli_in_spawn_returns_none` now passes
- [x] `cargo test` passes
- [x] `uv run pytest` passes

## Issue
- ISSUE-VM-005
