### PR TITLE
Fix transfer FinallyBoundary duplication

### DIFF
--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -4515,6 +4515,24 @@ impl VM {
         self.gather_finally_cleanups_from_caller(self.continuation_caller_segment(k))
     }
 
+    fn skip_existing_finally_boundaries(&self, mut cursor: Option<SegmentId>) -> Option<SegmentId> {
+        while let Some(seg_id) = cursor {
+            let Some(seg) = self.segments.get(seg_id) else {
+                return None;
+            };
+            match &seg.kind {
+                SegmentKind::FinallyBoundary { .. } => {
+                    cursor = seg.caller;
+                }
+                SegmentKind::Normal
+                | SegmentKind::PromptBoundary { .. }
+                | SegmentKind::InterceptorBoundary { .. }
+                | SegmentKind::MaskBoundary { .. } => break,
+            }
+        }
+        cursor
+    }
+
     fn graft_continuation_finally_boundaries(
         &mut self,
         k: &Continuation,
@@ -4545,8 +4563,10 @@ impl VM {
         caller: Option<SegmentId>,
     ) -> Option<SegmentId> {
         match kind {
-            ContinuationActivationKind::Resume | ContinuationActivationKind::Transfer => {
-                self.graft_continuation_finally_boundaries(k, caller)
+            ContinuationActivationKind::Resume => self.graft_continuation_finally_boundaries(k, caller),
+            ContinuationActivationKind::Transfer => {
+                let base = self.skip_existing_finally_boundaries(caller);
+                self.graft_continuation_finally_boundaries(k, base)
             }
         }
     }

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -89,6 +89,7 @@ pub use continuation::Continuation;
 pub use dispatch::DispatchContext;
 pub use do_ctrl::DoCtrl;
 pub use doeff_generator::{DoeffGenerator, DoeffGeneratorFn};
+pub use doeff_vm_core::DoExprTag;
 pub use driver::{Mode, StepEvent};
 pub use effect::*;
 pub use error::VMError;
@@ -98,9 +99,8 @@ pub use ids::{ContId, DispatchId, Marker, PromiseId, RunnableId, SegmentId, Task
 pub use ir_stream::{IRStream, IRStreamRef, IRStreamStep, PythonGeneratorStream, StreamLocation};
 pub use kleisli::{Kleisli, KleisliDebugInfo, KleisliRef, PyKleisli, RustKleisli};
 pub use py_key::HashedPyKey;
-pub use doeff_vm_core::DoExprTag;
-pub use pyvm::PyVM;
 pub use python_call::{PendingPython, PyCallOutcome, PythonCall};
+pub use pyvm::PyVM;
 pub use rust_store::RustStore;
 pub use segment::{Segment, SegmentKind};
 pub use step::PyException;

--- a/tests/effects/test_finally_semaphore_over_release.py
+++ b/tests/effects/test_finally_semaphore_over_release.py
@@ -15,6 +15,7 @@ over-release.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 import signal
 from typing import Any
 
@@ -33,17 +34,21 @@ from doeff import (
     WithHandler,
     WithIntercept,
     async_run,
+    cache,
     default_async_handlers,
     default_handlers,
     do,
     run,
 )
-from doeff.effects import Await
+from doeff.effects import Await, GetExecutionContext
+from doeff.handlers import in_memory_cache_handler, sqlite_cache_handler
 from doeff.types import EffectGenerator
 
 TIMEOUT_SECONDS = 10
 TASK_COUNT = 20
 CONCURRENCY = 5
+LAYER5_TASK_COUNT = 85
+LAYER5_CONCURRENCY = 40
 
 
 def _timeout_handler(signum: int, frame: Any) -> None:
@@ -77,6 +82,26 @@ def _worker_with_tell(n: int):
     result = yield Await(_fake_api_call(n))
     yield Tell(f"done {n}")
     return result
+
+
+@do
+def _worker_with_execution_context(n: int):
+    _context = yield GetExecutionContext()
+    result = yield Await(_fake_api_call(n))
+    return result
+
+
+@do
+def _leaf_with_execution_context(n: int):
+    _context = yield GetExecutionContext()
+    result = yield Await(_fake_api_call(n))
+    return result
+
+
+@do
+def _nested_worker_with_execution_context(n: int):
+    first = yield _leaf_with_execution_context(n)
+    return first + n
 
 
 def _wrap_with_semaphore_finally(program, sem):
@@ -272,3 +297,60 @@ class TestLayer4FullStack:
         )
         assert result.is_ok(), result.display()
         assert result.value == [i * 10 for i in range(TASK_COUNT)]
+
+
+# -- Layer 5: + Transfer from GetExecutionContext inside throttled spawned tasks --
+
+
+class TestLayer5WithHandlerResume:
+    def test_minimal_get_execution_context_semaphore_bug(self) -> None:
+        programs = [_worker_with_execution_context(i) for i in range(LAYER5_TASK_COUNT)]
+        result = _run_sync_with_timeout(_throttled(programs, LAYER5_CONCURRENCY))
+        assert result.is_ok(), result.display()
+        assert result.value == [i * 10 for i in range(LAYER5_TASK_COUNT)]
+
+    def test_cache_decorator_in_memory_high_concurrency_sync(self) -> None:
+        calls = {"count": 0}
+
+        @cache()
+        @do
+        def _cached_worker(n: int):
+            calls["count"] += 1
+            return (yield Await(_fake_api_call(n)))
+
+        programs = [_cached_worker(i) for i in range(LAYER5_TASK_COUNT)]
+        program = WithHandler(in_memory_cache_handler(), _throttled(programs, LAYER5_CONCURRENCY))
+        result = _run_sync_with_timeout(program)
+        assert result.is_ok(), result.display()
+        assert result.value == [i * 10 for i in range(LAYER5_TASK_COUNT)]
+        assert calls["count"] == LAYER5_TASK_COUNT
+
+    def test_cache_decorator_nested_kleisli_high_concurrency_sync(self, tmp_path: Path) -> None:
+        calls = {"count": 0}
+
+        @cache()
+        @do
+        def _cached_leaf(n: int):
+            calls["count"] += 1
+            return (yield Await(_fake_api_call(n)))
+
+        @do
+        def _nested_worker(n: int):
+            first = yield _cached_leaf(n)
+            second = yield _cached_leaf(n)
+            return first + second
+
+        programs = [_nested_worker(i) for i in range(LAYER5_TASK_COUNT)]
+        db_path = tmp_path / "layer5_cache.sqlite3"
+        program = WithHandler(sqlite_cache_handler(db_path), _throttled(programs, LAYER5_CONCURRENCY))
+        result = _run_sync_with_timeout(program)
+        assert result.is_ok(), result.display()
+        assert result.value == [i * 20 for i in range(LAYER5_TASK_COUNT)]
+        assert calls["count"] == LAYER5_TASK_COUNT
+        assert db_path.exists()
+
+    def test_get_execution_context_in_nested_kleisli_high_concurrency_sync(self) -> None:
+        programs = [_nested_worker_with_execution_context(i) for i in range(LAYER5_TASK_COUNT)]
+        result = _run_sync_with_timeout(_throttled(programs, LAYER5_CONCURRENCY))
+        assert result.is_ok(), result.display()
+        assert result.value == [i * 11 for i in range(LAYER5_TASK_COUNT)]

--- a/tests/test_finally_doctrl.py
+++ b/tests/test_finally_doctrl.py
@@ -154,6 +154,33 @@ def test_finally_travels_with_transferred_continuation() -> None:
     assert result.value == ("handled:x", True)
 
 
+def test_transfer_does_not_duplicate_finally_cleanup() -> None:
+    @dataclass(frozen=True, kw_only=True)
+    class Ping(EffectBase):
+        label: str
+
+    @do
+    def ping_handler(effect: Effect, k: object):
+        if isinstance(effect, Ping):
+            yield Transfer(k, f"handled:{effect.label}")
+        yield Pass()
+
+    @do
+    def program():
+        yield Put("cleanup_count", 0)
+        yield Finally(Modify("cleanup_count", lambda n: (n or 0) + 1))
+        return (yield Ping(label="x"))
+
+    @do
+    def wrapper():
+        value = yield WithHandler(ping_handler, program())
+        cleanup_count = yield Get("cleanup_count")
+        return value, cleanup_count
+
+    result = run(wrapper(), handlers=default_handlers(), store={})
+    assert result.value == ("handled:x", 1)
+
+
 def test_abandoned_continuation_with_finally_logs_warning(
     capfd: pytest.CaptureFixture[str],
 ) -> None:


### PR DESCRIPTION
## Summary
- avoid duplicating `FinallyBoundary` segments when a started continuation is reactivated via `Transfer`
- add Layer 5 scheduler/cache regressions for the semaphore over-release bug
- add a focused transfer/finally unit test that proves cleanup runs exactly once

## Validation
- Acceptance 1-4:
  - `uv run pytest tests/test_finally_doctrl.py::test_transfer_does_not_duplicate_finally_cleanup tests/effects/test_finally_semaphore_over_release.py::TestLayer5WithHandlerResume -q`
  - Result: `5 passed in 15.87s`
- Acceptance 5:
  - `uv run pytest tests/effects/test_finally_semaphore_over_release.py tests/test_finally_doctrl.py -q`
  - Result: `23 passed in 15.59s`
- Acceptance 6:
  - `uv run pytest -q`
  - Result: `1102 passed, 1 warning in 46.64s`
- Acceptance 7 (external repo check):
  - Ran `proboscis_ema.doeff.experiments.exp_20250927.index_events` from `/Users/s22625/repos/proboscis-ema` against the patched local `doeff_vm` (Python 3.12 build).
  - First run with `_test_local_env()` failed on missing `structured_news_index_llm`, not on semaphore over-release.
  - Second run with `default_env` progressed into live OpenAI-backed indexing, including repeated `AcquireSemaphore`/cache/LLM activity, and did not reproduce `RuntimeError: semaphore released too many times` during observation.
  - Full end-to-end completion was not awaited in this session because the live job is long-running and costful.

## Issue
- Ref: `ISSUE-SCHED-010`
