### PR TITLE
Fix returned handler control primitive errors

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -233,6 +233,50 @@ rules:
       category: architecture
       issue: MIGRATE-PASS-005
 
+  - id: doeff-no-return-control-primitives-in-handlers
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              @do
+              def $HANDLER($EFFECT, $K):
+                  ...
+          - pattern-inside: |
+              @do
+              def $HANDLER($EFFECT: $EFFECT_T, $K: $K_T):
+                  ...
+      - pattern-either:
+          - pattern: return Pass()
+          - pattern: return $MOD.Pass()
+          - pattern: return Resume($K, $VALUE)
+          - pattern: return $MOD.Resume($K, $VALUE)
+          - pattern: return Delegate()
+          - pattern: return $MOD.Delegate()
+          - pattern: return Transfer($K, $VALUE)
+          - pattern: return $MOD.Transfer($K, $VALUE)
+          - pattern: return Discontinue($K)
+          - pattern: return $MOD.Discontinue($K)
+          - pattern: return Discontinue($K, $EXN)
+          - pattern: return $MOD.Discontinue($K, $EXN)
+          - pattern: return ResumeContinuation($K, $VALUE)
+          - pattern: return $MOD.ResumeContinuation($K, $VALUE)
+    paths:
+      include:
+        - /doeff/**
+        - /packages/**
+      exclude:
+        - /tests/**
+        - /packages/**/tests/**
+    message: |
+      Control primitives must be yielded from @do handlers, not returned.
+      Change `return Pass()/Resume()/Delegate()/Transfer()/Discontinue()/ResumeContinuation()`
+      to `yield ...` so the VM processes the directive instead of treating it as
+      the handler's return value. See ISSUE-VM-008.
+    metadata:
+      category: architecture
+      issue: ISSUE-VM-008
+
   - id: doeff-no-python-side-cancel-state
     patterns:
       - pattern-either:

--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -33,7 +33,10 @@ use crate::ir_stream::{IRStream, IRStreamRef, IRStreamStep, PythonGeneratorStrea
 use crate::kleisli::{IdentityKleisli, KleisliRef};
 use crate::py_shared::PyShared;
 use crate::python_call::{PendingPython, PyCallOutcome, PythonCall};
-use crate::pyvm::{classify_yielded_for_vm, doctrl_to_pyexpr_for_vm, PyDoExprBase, PyEffectBase};
+use crate::pyvm::{
+    classify_yielded_for_vm, doctrl_tag, doctrl_to_pyexpr_for_vm, DoExprTag, PyDoExprBase,
+    PyEffectBase,
+};
 use crate::segment::{Segment, SegmentKind};
 use crate::trace_state::TraceState;
 use crate::value::Value;
@@ -456,8 +459,7 @@ impl VM {
                     mode: *mode,
                     metadata: metadata.clone(),
                 })),
-                SegmentKind::Normal
-                | SegmentKind::MaskBoundary { .. } => {
+                SegmentKind::Normal | SegmentKind::MaskBoundary { .. } => {
                     assert!(
                         self.interceptor_state.get_entry(seg.marker).is_none(),
                         "normal segment marker {} unexpectedly has interceptor state entry",
@@ -2634,17 +2636,14 @@ impl VM {
             next_idx,
             ..
         } = continuation;
-        let transformed = match self.classify_interceptor_eval_result(
-            value,
-            &original_obj,
-            original_yielded,
-        ) {
-            Ok(expr) => expr,
-            Err(exc) => {
-                self.pop_interceptor_skip(marker);
-                return Mode::Throw(exc);
-            }
-        };
+        let transformed =
+            match self.classify_interceptor_eval_result(value, &original_obj, original_yielded) {
+                Ok(expr) => expr,
+                Err(exc) => {
+                    self.pop_interceptor_skip(marker);
+                    return Mode::Throw(exc);
+                }
+            };
         self.pop_interceptor_skip(marker);
         self.continue_interceptor_chain_mode(
             transformed,
@@ -2701,7 +2700,7 @@ impl VM {
                 body,
                 types,
                 return_clause,
-            } => self.handle_yield_with_handler(handler, *body, types, return_clause),
+            } => self.handle_with_handler(handler, *body, types, return_clause),
             DoCtrl::WithIntercept {
                 interceptor,
                 body,
@@ -2820,16 +2819,6 @@ impl VM {
         exception: PyException,
     ) -> StepEvent {
         self.handle_transfer_throw_non_terminal(continuation, exception)
-    }
-
-    fn handle_yield_with_handler(
-        &mut self,
-        handler: KleisliRef,
-        body: DoCtrl,
-        types: Option<Vec<PyShared>>,
-        return_clause: Option<PyShared>,
-    ) -> StepEvent {
-        self.handle_with_handler(handler, body, types, return_clause)
     }
 
     fn handle_yield_with_intercept(
@@ -3608,6 +3597,28 @@ impl VM {
         }
     }
 
+    fn returned_control_primitive_signature(value: &Value) -> Option<&'static str> {
+        let Value::Python(result_obj) = value else {
+            return None;
+        };
+
+        Python::attach(|py| match doctrl_tag(result_obj.bind(py)) {
+            Some(DoExprTag::Pass) => Some("Pass()"),
+            Some(DoExprTag::Resume) => Some("Resume(k, value)"),
+            Some(DoExprTag::Delegate) => Some("Delegate()"),
+            Some(DoExprTag::Transfer) => Some("Transfer(k, value)"),
+            Some(DoExprTag::Discontinue) => Some("Discontinue(k, exn)"),
+            Some(DoExprTag::ResumeContinuation) => Some("ResumeContinuation(k, value)"),
+            _ => None,
+        })
+    }
+
+    fn returned_control_primitive_exception(value: &Value) -> Option<PyException> {
+        let signature = Self::returned_control_primitive_signature(value)?;
+        Some(PyException::runtime_error(format!(
+            "Handler returned {signature} but control primitives must be yielded, not returned.\n  Change: return {signature}  ->  yield {signature}"
+        )))
+    }
     fn receive_expand_result(
         &mut self,
         metadata: Option<CallMetadata>,
@@ -3766,6 +3777,12 @@ impl VM {
             PyCallOutcome::GenReturn(value) => {
                 if let Some(ref m) = metadata {
                     self.emit_frame_exited(m);
+                }
+                if handler_kind == Some(HandlerKind::Python) {
+                    if let Some(exception) = Self::returned_control_primitive_exception(&value) {
+                        self.current_seg_mut().mode = Mode::Throw(exception);
+                        return;
+                    }
                 }
                 self.current_seg_mut().mode = Mode::Deliver(value);
             }
@@ -4825,10 +4842,15 @@ impl VM {
             let ctx = self.dispatch_state.find_by_dispatch_id(dispatch_id)?;
             let marker = *ctx.handler_chain.get(ctx.handler_idx)?;
             let (_, kind, _, _) = self.marker_handler_trace_info(marker)?;
-            Some((dispatch_id, kind == HandlerKind::Python, ctx.k_current.cont_id))
+            Some((
+                dispatch_id,
+                kind == HandlerKind::Python,
+                ctx.k_current.cont_id,
+            ))
         });
         if let Some((_dispatch_id, true, cont_id)) = active_python_handler {
-            if self.continuation_registry.contains_key(&cont_id) && !self.is_one_shot_consumed(cont_id)
+            if self.continuation_registry.contains_key(&cont_id)
+                && !self.is_one_shot_consumed(cont_id)
             {
                 self.mark_one_shot_consumed(cont_id);
                 return self.throw_runtime_error(&format!(

--- a/packages/doeff-vm/tests/test_pyvm.py
+++ b/packages/doeff-vm/tests/test_pyvm.py
@@ -449,6 +449,62 @@ def test_handler_abandon_continuation():
         vm.run(main())
 
 
+@pytest.mark.parametrize(
+    ("primitive_name", "expected_snippet"),
+    [
+        ("Pass", "return Pass()  ->  yield Pass()"),
+        ("Resume", "return Resume(k, value)  ->  yield Resume(k, value)"),
+        ("Delegate", "return Delegate()  ->  yield Delegate()"),
+        ("Transfer", "return Transfer(k, value)  ->  yield Transfer(k, value)"),
+        ("Discontinue", "return Discontinue(k, exn)  ->  yield Discontinue(k, exn)"),
+        (
+            "ResumeContinuation",
+            "return ResumeContinuation(k, value)  ->  yield ResumeContinuation(k, value)",
+        ),
+    ],
+)
+def test_handler_returning_control_primitive_raises_clear_error(
+    primitive_name: str, expected_snippet: str
+) -> None:
+    from doeff_vm import PyVM
+
+    vm = PyVM()
+
+    @do
+    def bad_handler(effect: Effect, k):
+        if isinstance(effect, CustomEffect):
+            if primitive_name == "Pass":
+                return doeff_vm.Pass()
+            if primitive_name == "Resume":
+                return doeff_vm.Resume(k, effect.value * 2)
+            if primitive_name == "Delegate":
+                return doeff_vm.Delegate()
+            if primitive_name == "Transfer":
+                return doeff_vm.Transfer(k, effect.value * 3)
+            if primitive_name == "Discontinue":
+                return doeff_vm.Discontinue(k, ValueError("reason"))
+            if primitive_name == "ResumeContinuation":
+                return doeff_vm.ResumeContinuation(k, effect.value * 4)
+            raise AssertionError(f"unexpected primitive {primitive_name}")
+        yield doeff_vm.Delegate()
+
+    @do
+    def body() -> Program[int]:
+        return (yield CustomEffect(7))
+
+    @do
+    def main() -> Program[int]:
+        return (yield doeff_vm.WithHandler(bad_handler, body()))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        vm.run(main())
+
+    message = str(exc_info.value)
+    assert f"Handler returned {primitive_name}" in message
+    assert "control primitives must be yielded, not returned" in message
+    assert expected_snippet in message
+
+
 def test_discontinue_basic():
     from doeff_vm import PyVM
 
@@ -919,7 +975,6 @@ def test_run_rejects_raw_generator():
 
 class GetHandlers:
     """Control primitive: request the current handler chain."""
-
 
 
 class UnknownThing:


### PR DESCRIPTION
## Summary
- detect Python handler generators that `return` control primitives and raise a clear actionable runtime error instead of the generic abandoned-continuation message
- add regression coverage for `Pass`, `Resume`, `Delegate`, `Transfer`, and `ResumeContinuation`
- add a semgrep guard that bans returning those control primitives from production `@do` handlers

## Acceptance Criteria Evidence
1. VM raises a clear error for each forbidden returned primitive.
   - Command: `uv run pytest packages/doeff-vm/tests/test_pyvm.py -k 'handler_returning_control_primitive_raises_clear_error or handler_abandon_continuation'`
   - Result: `6 passed, 81 deselected`
2. Error message tells the user exactly what to change.
   - The new regression test asserts all of: `Handler returned <primitive>`, `control primitives must be yielded, not returned`, and the `return ...  ->  yield ...` rewrite hint.
3. Existing surrounding handler tests still pass.
   - Command: `uv run pytest packages/doeff-vm/tests/test_pyvm.py -k 'not handler_returning_program_base' tests/public_api/test_doeff13_hang_regression.py tests/public_api/test_types_001_handler_protocol.py tests/test_try_finally_in_do.py`
   - Result: `115 passed, 1 deselected`
   - Note: the deselected test is `packages/doeff-vm/tests/test_pyvm.py::test_handler_returning_program_base`, which is already documented in-file as an unrelated gap-detection test outside ISSUE-VM-008.
4. Lint-time regression guard added.
   - Synthetic semgrep check against a temporary bad handler produced the expected finding for `return Pass()`.
   - Command: `semgrep scan --config <tmp ISSUE-VM-008 rule> doeff/ packages/ --error`
   - Result: `0 findings` for production paths with tests excluded.

## Validation Notes
- `make sync` currently fails in this worktree because `packages/doeff-vm/pyproject.toml` sets `strip = true` and the local `maturin develop` invocation adds `--include-debuginfo`; I rebuilt the extension successfully with `uv pip install -e packages/doeff-vm --reinstall-package doeff-vm` instead.

Refs: ISSUE-VM-008
