### PR TITLE
Normalize doeff runbox argv for module replay

### DIFF
--- a/doeff/cli/runbox.py
+++ b/doeff/cli/runbox.py
@@ -13,6 +13,7 @@ import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 
 
 def is_runbox_available() -> bool:
@@ -96,6 +97,25 @@ class RunboxRecordResult:
     error_message: str | None = None
 
 
+def normalize_argv_for_replay(argv: Sequence[str]) -> list[str]:
+    """Normalize argv into a replayable executable form.
+
+    When doeff is launched as `python -m doeff ...`, Python exposes
+    `sys.argv[0]` as the package's `__main__.py` path. That path is not
+    directly executable, so convert it back into an explicit interpreter
+    invocation for replay.
+    """
+    normalized = list(argv)
+    if not normalized:
+        return normalized
+
+    argv0 = Path(normalized[0])
+    if argv0.name == "__main__.py" and argv0.parent.name == "doeff":
+        return [sys.executable, "-m", "doeff", *normalized[1:]]
+
+    return normalized
+
+
 def create_runbox_record(
     argv: Sequence[str],
     cwd: str | None = None,
@@ -126,10 +146,12 @@ def create_runbox_record(
     if cwd is None:
         cwd = os.getcwd()
 
+    normalized_argv = normalize_argv_for_replay(argv)
+
     # Build the record JSON
     record: dict = {
         "command": {
-            "argv": list(argv),
+            "argv": normalized_argv,
             "cwd": cwd,
         },
         "source": "doeff",

--- a/tests/cli/test_cli_runbox_e2e.py
+++ b/tests/cli/test_cli_runbox_e2e.py
@@ -53,6 +53,39 @@ def run_cli(
     )
 
 
+def run_cli_module(
+    *args: str, env_override: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run doeff CLI through `python -m doeff run`."""
+    command = ["uv", "run", "python", "-m", "doeff", "run", *args]
+    pythonpath = str(PROJECT_ROOT)
+    if "PYTHONPATH" in os.environ:
+        pythonpath = f"{PROJECT_ROOT}{os.pathsep}{os.environ['PYTHONPATH']}"
+
+    env = {
+        "PYTHONPATH": pythonpath,
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "DOEFF_DISABLE_DEFAULT_ENV": "1",
+        "DOEFF_DISABLE_PROFILE": "1",
+    }
+    for key in ("UV_PROJECT_ENVIRONMENT", "UV_CACHE_DIR", "VIRTUAL_ENV"):
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    if env_override:
+        env.update(env_override)
+
+    return subprocess.run(
+        command,
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
 def is_runbox_available() -> bool:
     """Check if runbox CLI is available in PATH."""
     return shutil.which("runbox") is not None
@@ -248,6 +281,39 @@ class TestRunboxIntegrationE2E:
         commit = record_data["git_state"]["commit"]
         assert len(commit) == 40, f"Commit should be 40 chars, got {len(commit)}"
         assert all(c in "0123456789abcdef" for c in commit.lower()), "Commit should be hex"
+
+    @pytest.mark.e2e
+    @pytest.mark.skipif(not is_runbox_available(), reason="runbox CLI not installed")
+    def test_python_module_invocation_records_replayable_argv(self) -> None:
+        """Test that `python -m doeff` records an executable argv."""
+        result = run_cli_module(
+            "--program",
+            "tests.cli_assets.sample_program",
+            "--interpreter",
+            "tests.cli_assets.sync_interpreter",
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+        record_id = None
+        for line in result.stderr.split("\n"):
+            if "[runbox] Record stored:" in line:
+                parts = line.split("rec_")
+                if len(parts) > 1:
+                    record_id = "rec_" + parts[1].split()[0]
+                    break
+
+        assert record_id is not None
+
+        record_file = get_runbox_records_dir() / f"{record_id}.json"
+        with open(record_file) as f:
+            record_data = json.load(f)
+
+        argv = record_data["command"]["argv"]
+        assert len(argv) >= 4
+        assert Path(argv[0]).name.startswith(
+            "python"
+        ), f"Expected python executable, got {argv[0]}"
+        assert argv[1:4] == ["-m", "doeff", "run"]
 
 
 class TestRunboxUnitIntegration:

--- a/tests/test_runbox_integration.py
+++ b/tests/test_runbox_integration.py
@@ -17,6 +17,7 @@ from doeff.cli.runbox import (
     is_runbox_available,
     log_runbox_record,
     maybe_create_runbox_record,
+    normalize_argv_for_replay,
 )
 
 
@@ -184,6 +185,34 @@ class TestCreateRunboxRecord:
             input_json = json.loads(mock_run.call_args[1]["input"])
             assert input_json["git_state"]["diff"] == "+added line"
 
+    def test_normalizes_module_invocation_for_replay(self) -> None:
+        """Test that python -m doeff invocations are recorded as replayable argv."""
+        mock_runbox_result = MagicMock()
+        mock_runbox_result.returncode = 0
+        mock_runbox_result.stdout = "Created record: rec_12345\n  Short ID: 12345"
+
+        with (
+            patch("doeff.cli.runbox.is_runbox_available", return_value=True),
+            patch("doeff.cli.runbox.get_head_commit", return_value="abc123"),
+            patch("doeff.cli.runbox.get_repo_url", return_value=None),
+            patch("doeff.cli.runbox.get_uncommitted_diff", return_value=None),
+            patch("doeff.cli.runbox.sys.executable", "/venv/bin/python"),
+            patch("subprocess.run", return_value=mock_runbox_result) as mock_run,
+        ):
+            create_runbox_record(
+                ["/venv/lib/python3.12/site-packages/doeff/__main__.py", "run", "--program", "x"]
+            )
+
+            input_json = json.loads(mock_run.call_args[1]["input"])
+            assert input_json["command"]["argv"] == [
+                "/venv/bin/python",
+                "-m",
+                "doeff",
+                "run",
+                "--program",
+                "x",
+            ]
+
     def test_handles_runbox_failure(self) -> None:
         """Test handling of runbox CLI failure."""
         mock_runbox_result = MagicMock()
@@ -295,3 +324,19 @@ class TestMaybeCreateRunboxRecord:
             mock_create.assert_called_once_with(
                 ["doeff", "run", "--program", "test.prog"], tags=None
             )
+
+
+class TestNormalizeArgvForReplay:
+    """Tests for replay argv normalization."""
+
+    def test_keeps_normal_executable_argv(self) -> None:
+        assert normalize_argv_for_replay(["/venv/bin/doeff", "run"]) == [
+            "/venv/bin/doeff",
+            "run",
+        ]
+
+    def test_rewrites_module_entrypoint_to_python_m(self) -> None:
+        with patch("doeff.cli.runbox.sys.executable", "/venv/bin/python"):
+            assert normalize_argv_for_replay(
+                ["/venv/lib/python3.12/site-packages/doeff/__main__.py", "run", "--program", "x"]
+            ) == ["/venv/bin/python", "-m", "doeff", "run", "--program", "x"]


### PR DESCRIPTION
## Summary
- normalize `python -m doeff ...` argv into `sys.executable -m doeff ...` before creating runbox records
- keep direct executable invocations unchanged
- add unit and CLI E2E coverage for the normalized replay argv

## Verification
- `uv run pytest tests/test_runbox_integration.py -q`
  - `26 passed`
- `uv run pytest tests/cli/test_cli_runbox_e2e.py -q`
  - `11 passed`
- Live smoke:
  - `RUNBOX_HOME=<tmp> uv run python -m doeff run --program tests.cli_assets.sample_program --interpreter tests.cli_assets.sync_interpreter`
  - saved record argv was `['.../python3', '-m', 'doeff', 'run', '--program', ...]`
