### PR TITLE
Fail closed on handler annotation errors

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -149,6 +149,24 @@ rules:
         - /tests/**
         - /packages/**/tests/**
 
+  - id: handler-filter-no-type-hint-fail-open
+    languages: [python]
+    severity: ERROR
+    message: >
+      Handler type-filter annotation resolution must inspect only the effect parameter.
+      Do not call get_type_hints() on the whole handler inside _extract_handler_effect_types(),
+      because unrelated broken annotations on k/return must not disable filtering.
+    patterns:
+      - pattern-inside: |
+          def _extract_handler_effect_types($HANDLER):
+              ...
+      - pattern-either:
+          - pattern: get_type_hints(...)
+          - pattern: _safe_get_type_hints(...)
+    paths:
+      include:
+        - /doeff/rust_vm.py
+
   - id: doeff-pinjected-no-intercept
     languages: [python]
     severity: ERROR

--- a/doeff/kleisli.py
+++ b/doeff/kleisli.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from collections.abc import Callable as TypingCallable
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, ClassVar, Generic, ParamSpec, TypeVar, get_type_hints
+from typing import Any, ClassVar, ForwardRef, Generic, ParamSpec, TypeVar, get_type_hints
 
 from doeff.program import (
     Program,
@@ -224,6 +224,70 @@ def _safe_signature(target: Any) -> inspect.Signature | None:
         return None
 
 
+def _safe_annotations(target: Any) -> dict[str, Any] | None:
+    if target is None:
+        return None
+    try:
+        annotations = target.__annotations__
+    except AttributeError:
+        return None
+    if isinstance(annotations, dict):
+        return annotations
+    return None
+
+
+def _annotation_namespaces(target: Any) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    globalns: dict[str, Any] = {}
+    localns: dict[str, Any] = {}
+    if target is None:
+        return globalns, None
+
+    module = inspect.getmodule(target)
+    if module is not None:
+        globalns.update(vars(module))
+
+    try:
+        target_globals = target.__globals__
+    except AttributeError:
+        target_globals = None
+    if isinstance(target_globals, dict):
+        globalns.update(target_globals)
+
+    if callable(target):
+        try:
+            closurevars = inspect.getclosurevars(target)
+        except (TypeError, ValueError):
+            closurevars = None
+        if closurevars is not None:
+            globalns.update(closurevars.globals)
+            localns.update(closurevars.nonlocals)
+
+    return globalns, localns or None
+
+
+def _resolve_annotation_only(annotation: Any, *targets: Any) -> Any:
+    if annotation is inspect._empty:
+        return annotation
+
+    raw_annotation: str | None = None
+    if isinstance(annotation, ForwardRef):
+        raw_annotation = annotation.__forward_arg__
+    elif isinstance(annotation, str):
+        raw_annotation = annotation
+
+    if raw_annotation is None:
+        return annotation
+
+    last_exc: Exception | None = None
+    for target in targets:
+        globalns, localns = _annotation_namespaces(target)
+        try:
+            return eval(raw_annotation, globalns, localns)
+        except Exception as exc:
+            last_exc = exc
+    raise TypeError(f"Failed to resolve effect annotation: {raw_annotation!r}") from last_exc
+
+
 def validate_do_handler_effect_annotation(handler: Any) -> None:
     if not bool(getattr(handler, "__doeff_do_decorated__", False)):
         return
@@ -238,15 +302,20 @@ def validate_do_handler_effect_annotation(handler: Any) -> None:
     if len(params) < 2:
         raise TypeError("@do handler must accept (effect, k)")
 
-    metadata_source = getattr(handler, "_metadata_source", None)
-    type_hints = _safe_get_type_hints(metadata_source)
-    if not type_hints:
-        type_hints = _safe_get_type_hints(getattr(handler, "func", None))
-    if not type_hints:
-        type_hints = _safe_get_type_hints(handler)
-
     effect_param = params[0]
-    effect_annotation = type_hints.get(effect_param.name, effect_param.annotation)
+    metadata_source = getattr(handler, "_metadata_source", None)
+    handler_name = getattr(handler, "__qualname__", getattr(handler, "__name__", repr(handler)))
+    func = getattr(handler, "func", None)
+    raw_annotation = effect_param.annotation
+    for candidate in (metadata_source, func, handler):
+        annotations = _safe_annotations(candidate)
+        if annotations is not None and effect_param.name in annotations:
+            raw_annotation = annotations[effect_param.name]
+            break
+    try:
+        effect_annotation = _resolve_annotation_only(raw_annotation, metadata_source, func, handler)
+    except TypeError as exc:
+        raise TypeError(f"Failed to resolve effect annotation for handler {handler_name}: {exc}") from exc
     if effect_annotation is inspect._empty or not _is_effect_annotation_kind(effect_annotation):
         raise TypeError("@do handler first parameter must be annotated as Effect")
 

--- a/doeff/program.py
+++ b/doeff/program.py
@@ -6,7 +6,6 @@ This module contains the Program wrapper class that represents a lazy computatio
 
 import inspect
 import types
-import warnings
 from abc import ABC, ABCMeta
 from collections.abc import Callable, Generator, Iterable, Mapping
 from dataclasses import dataclass
@@ -113,8 +112,7 @@ def _safe_get_type_hints(target: Any) -> dict[str, Any]:
         return {}
     try:
         return get_type_hints(target, include_extras=True)
-    except Exception as exc:
-        warnings.warn(f"Failed to resolve type hints for {target}: {exc}", stacklevel=2)
+    except Exception:
         return {}
 
 

--- a/doeff/rust_vm.py
+++ b/doeff/rust_vm.py
@@ -147,14 +147,68 @@ def _normalize_intercept_types(types: Any) -> tuple[type[Any], ...] | None:
     return normalized
 
 
-def _safe_get_type_hints(target: Any) -> dict[str, Any]:
+def _safe_annotations(target: Any) -> dict[str, Any] | None:
     if target is None:
-        return {}
+        return None
     try:
-        return get_type_hints(target, include_extras=True)
-    except Exception as exc:
-        warnings.warn(f"Failed to resolve type hints for {target}: {exc}", stacklevel=2)
-        return {}
+        annotations = target.__annotations__
+    except AttributeError:
+        return None
+    if isinstance(annotations, dict):
+        return annotations
+    return None
+
+
+def _annotation_namespaces(target: Any) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    globalns: dict[str, Any] = {}
+    localns: dict[str, Any] = {}
+    if target is None:
+        return globalns, None
+
+    module = inspect.getmodule(target)
+    if module is not None:
+        globalns.update(vars(module))
+
+    try:
+        target_globals = target.__globals__
+    except AttributeError:
+        target_globals = None
+    if isinstance(target_globals, dict):
+        globalns.update(target_globals)
+
+    if callable(target):
+        try:
+            closurevars = inspect.getclosurevars(target)
+        except (TypeError, ValueError):
+            closurevars = None
+        if closurevars is not None:
+            globalns.update(closurevars.globals)
+            localns.update(closurevars.nonlocals)
+
+    return globalns, localns or None
+
+
+def _resolve_annotation_only(annotation: Any, *targets: Any) -> Any:
+    if annotation is inspect._empty:
+        return annotation
+
+    raw_annotation: str | None = None
+    if isinstance(annotation, ForwardRef):
+        raw_annotation = annotation.__forward_arg__
+    elif isinstance(annotation, str):
+        raw_annotation = annotation
+
+    if raw_annotation is None:
+        return annotation
+
+    last_exc: Exception | None = None
+    for target in targets:
+        globalns, localns = _annotation_namespaces(target)
+        try:
+            return eval(raw_annotation, globalns, localns)
+        except Exception as exc:
+            last_exc = exc
+    raise TypeError(f"Unresolved handler effect annotation: {raw_annotation!r}") from last_exc
 
 
 def _safe_signature(target: Any) -> inspect.Signature | None:
@@ -180,10 +234,11 @@ def _resolve_handler_effect_types(annotation: Any) -> tuple[type[Any], ...] | No
     if annotation in (Any, Effect, EffectBase):
         return None
     if isinstance(annotation, ForwardRef):
-        # Unresolved forward references cannot be converted to runtime type filters safely.
-        return None
+        raise TypeError(
+            f"Unresolved handler effect annotation: {annotation.__forward_arg__!r}"
+        )
     if isinstance(annotation, str):
-        return None
+        raise TypeError(f"Unresolved handler effect annotation: {annotation!r}")
 
     origin = get_origin(annotation)
     if origin is Annotated:
@@ -250,11 +305,20 @@ def _extract_handler_effect_types(handler: Any) -> tuple[type[Any], ...] | None:
     metadata_source = (
         handler._metadata_source if isinstance(handler, _HandlerWithMetadataSource) else None
     )
-    type_hints = _safe_get_type_hints(metadata_source)
-    if not type_hints:
-        type_hints = _safe_get_type_hints(func)
-    annotation = type_hints.get(effect_param.name, effect_param.annotation)
-    return _resolve_handler_effect_types(annotation)
+    handler_name, _, _ = _handler_registration_metadata(handler)
+    raw_annotation = effect_param.annotation
+    for candidate in (metadata_source, func, handler):
+        annotations = _safe_annotations(candidate)
+        if annotations is not None and effect_param.name in annotations:
+            raw_annotation = annotations[effect_param.name]
+            break
+    try:
+        annotation = _resolve_annotation_only(raw_annotation, metadata_source, func, handler)
+        return _resolve_handler_effect_types(annotation)
+    except TypeError as exc:
+        raise TypeError(
+            f"Failed to resolve effect annotation for handler {handler_name}: {exc}"
+        ) from exc
 
 
 def _with_intercept_metadata(interceptor: Any) -> dict[str, Any]:

--- a/tests/program/test_handler_annotation_resolution.py
+++ b/tests/program/test_handler_annotation_resolution.py
@@ -53,3 +53,13 @@ def test_validate_do_handler_effect_annotation_resolves_quoted_subclass() -> Non
         yield Pass()
 
     validate_do_handler_effect_annotation(handler)
+
+
+def test_validate_do_handler_effect_annotation_ignores_unrelated_broken_annotations() -> None:
+    @do
+    def handler(effect: "_SubtypeEffect", k: "MissingContinuation") -> "MissingReturn":
+        if isinstance(effect, _SubtypeEffect):
+            return (yield Resume(k, effect.value))
+        yield Pass()
+
+    validate_do_handler_effect_annotation(handler)

--- a/tests/program/test_program_type_hints_warning.py
+++ b/tests/program/test_program_type_hints_warning.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import pytest
+import warnings
 
 import doeff.program as program_module
+import pytest
 
 
-def test_safe_get_type_hints_warns_on_resolution_failure(
+def test_safe_get_type_hints_returns_empty_dict_without_warning_on_resolution_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise_type_hint_error(*_args: object, **_kwargs: object) -> dict[str, object]:
@@ -16,7 +17,9 @@ def test_safe_get_type_hints_warns_on_resolution_failure(
 
     monkeypatch.setattr(program_module, "get_type_hints", _raise_type_hint_error)
 
-    with pytest.warns(UserWarning, match="Failed to resolve type hints for"):
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
         hints = program_module._safe_get_type_hints(sample)
 
     assert hints == {}
+    assert recorded == []

--- a/tests/test_with_handler_type_filter.py
+++ b/tests/test_with_handler_type_filter.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import warnings
 
 import doeff_vm
 import pytest
@@ -77,6 +78,14 @@ def test_extract_handler_effect_types() -> None:
     assert rust_vm._extract_handler_effect_types(no_annotation_handler) is None
 
 
+def test_extract_handler_effect_types_ignores_broken_other_annotations() -> None:
+    @do
+    def tell_handler(effect: TellFx, k: "MissingContinuation") -> "MissingReturn":
+        yield doeff_vm.Pass()
+
+    assert rust_vm._extract_handler_effect_types(tell_handler) == (TellFx,)
+
+
 def test_with_handler_passes_types_to_vm() -> None:
     @do
     def tell_handler(effect: TellFx, k):
@@ -109,6 +118,53 @@ def test_raw_doeff_vm_with_handler_validates_types_kwarg() -> None:
 
     with pytest.raises(TypeError, match="WithHandler.types must contain only Python type objects"):
         doeff_vm.WithHandler(tell_handler, _tell_program("x"), types=(TellFx, "bad"))
+
+
+def test_with_handler_rejects_unresolved_effect_annotation() -> None:
+    @do
+    def broken_handler(effect: "MissingEffect", k):
+        yield doeff_vm.Pass()
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError, match=r"MissingEffect|broken_handler|annotation"):
+            WithHandler(broken_handler, _tell_program("x"))
+    assert recorded == []
+
+
+def test_run_handlers_param_rejects_unresolved_effect_annotation() -> None:
+    @do
+    def broken_handler(effect: "MissingEffect", k):
+        yield doeff_vm.Pass()
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError, match=r"MissingEffect|broken_handler|annotation"):
+            run(_tell_program("x"), handlers=[broken_handler, fallback_handler])
+    assert recorded == []
+
+
+def test_with_handler_accepts_valid_effect_annotation_with_broken_other_annotations() -> None:
+    @do
+    def tell_handler(effect: TellFx, k: "MissingContinuation") -> "MissingReturn":
+        yield doeff_vm.Pass()
+
+    ctrl = WithHandler(tell_handler, _tell_program("x"))
+    assert ctrl.types == (TellFx,)
+
+
+def test_run_handlers_param_accepts_valid_effect_annotation_with_broken_other_annotations() -> None:
+    seen: list[str] = []
+
+    @do
+    def tell_handler(effect: TellFx, k: "MissingContinuation") -> "MissingReturn":
+        seen.append(type(effect).__name__)
+        return (yield doeff_vm.Resume(k, f"handled_tell:{effect.message}"))
+
+    result = run(_tell_program("x"), handlers=[fallback_handler, tell_handler])
+    assert result.is_ok()
+    assert result.value == "handled_tell:x"
+    assert seen == ["TellFx"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #260

## Summary
- make handler type-filter resolution fail closed only on the effect annotation
- stop unrelated broken annotations on `k` / return type from disabling filtering
- tighten validator/test coverage for unresolved effect annotations and unrelated annotation failures
- add a semgrep guard for the fail-open pattern in `doeff.rust_vm`

## Validation
- `PYTHONPATH=/Users/s22625/.codex/worktrees/issues/260-doeff/packages/doeff-vm /Users/s22625/.codex/worktrees/3e66/doeff/.venv/bin/python -m pytest tests/test_with_handler_type_filter.py tests/program/test_program_type_hints_warning.py tests/program/test_handler_annotation_resolution.py tests/public_api/test_types_001_handler_protocol.py -q`
- `semgrep --config .semgrep.yaml doeff/rust_vm.py`
