### PR TITLE
Remove import-time loader mutation

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -180,6 +180,19 @@ rules:
     paths:
       include:
         - /doeff/rust_vm.py
+  - id: no-import-state-mutation-in-doeff-loading
+    languages: [python]
+    severity: ERROR
+    message: >
+      Import-time loading for doeff must not rewrite sys.path or replace sys.modules entries.
+      Fail fast with a clear error instead of mutating interpreter-global import state.
+    pattern-either:
+      - pattern: sys.path = ...
+      - pattern: $SYS.modules["types"] = ...
+    paths:
+      include:
+        - /doeff/__init__.py
+        - /doeff/types.py
 
   - id: doeff-pinjected-no-intercept
     languages: [python]

--- a/doeff/__init__.py
+++ b/doeff/__init__.py
@@ -16,13 +16,6 @@ Example:
     ...     return count + 1
 """
 
-import os as _os
-import sys as _sys
-
-_PKG_DIR = _os.path.dirname(__file__)
-if _PKG_DIR in _sys.path:
-    _sys.path = [path for path in _sys.path if path != _PKG_DIR]
-
 from doeff.analysis import EffectCallTree
 from doeff.cache import (
     CACHE_PATH_ENV_KEY,

--- a/doeff/types.py
+++ b/doeff/types.py
@@ -1,101 +1,55 @@
 """
-Core types for the doeff effects system (with stdlib safety guard).
+Core types for the doeff effects system.
 
-This wrapper avoids shadowing the stdlib ``types`` module when tools run
-``runpy._run_module_as_main("doeff")`` and end up importing this file as
-``types`` instead of ``doeff.types``. If imported as top-level ``types``, we
-delegate to the real stdlib module; otherwise we re-export the full doeff
-types from ``_types_internal``.
+This module is only supported as ``doeff.types``. Importing this file as the
+top-level module ``types`` indicates an invalid import topology and must fail
+fast instead of rewriting interpreter-global import state.
 """
 
-
-import os
-import sys
-
-if __name__ != "types":
-    from typing import TYPE_CHECKING
-
-    if TYPE_CHECKING:
-        from doeff._types_internal import (  # noqa: F401
-            DEFAULT_REPR_LIMIT,
-            NOTHING,
-            REPR_LIMIT_KEY,
-            CallFrame,
-            CapturedTraceback,
-            Effect,
-            EffectBase,
-            EffectFailure,
-            EffectFailureError,
-            EffectGenerator,
-            EffectObservation,
-            EnvKey,
-            Err,
-            FrozenDict,
-            ListenResult,
-            Maybe,
-            Nothing,
-            Ok,
-            Program,
-            ProgramBase,
-            Result,
-            RunResult,
-            Some,
-            TraceError,
-            WGraph,
-            WNode,
-            WStep,
-            _intercept_value,
-            capture_traceback,
-            get_captured_traceback,
-            trace_err,
-        )
-
-if os.environ.get("DOEFF_DEBUG_TYPES"):
-    print(
-        f"[doeff.types] __name__={__name__} sys.path0={sys.path[0]}",
-        file=sys.stderr,
-    )
-
-
-def _load_stdlib_types() -> None:
-    """Load the stdlib ``types`` module into this namespace."""
-
-    stdlib_types_path = os.path.join(os.path.dirname(os.__file__), "types.py")
-
-    try:
-        with open(stdlib_types_path, encoding="utf-8") as handle:
-            source = handle.read()
-    except OSError:  # pragma: no cover - defensive fallback
-        mapping_proxy_type = type(type.__dict__)
-
-        class _DynamicClassAttribute(property):
-            pass
-
-        globals().update(
-            {
-                "MappingProxyType": mapping_proxy_type,
-                "DynamicClassAttribute": _DynamicClassAttribute,
-                "__all__": ["MappingProxyType", "DynamicClassAttribute"],
-            }
-        )
-        return
-
-    module = type(sys)("types")
-    module.__file__ = stdlib_types_path
-    exec(compile(source, stdlib_types_path, "exec"), module.__dict__)
-    sys.modules["types"] = module
-    globals().update(module.__dict__)
-
+from typing import TYPE_CHECKING
 
 if __name__ == "types":
-    _load_stdlib_types()
-else:
-    import importlib as _importlib
+    raise ImportError(
+        "doeff/types.py was imported as top-level 'types'. "
+        "Remove the package directory from sys.path and import 'doeff.types' instead."
+    )
 
-    _internal = _importlib.import_module("doeff._types_internal")
-    globals().update(_internal.__dict__)
-    if os.environ.get("DOEFF_DEBUG_TYPES"):
-        print(
-            f"[doeff.types] loaded internal EffectBase={'EffectBase' in globals()}",
-            file=sys.stderr,
-        )
+if TYPE_CHECKING:
+    from doeff._types_internal import (  # noqa: F401
+        DEFAULT_REPR_LIMIT,
+        NOTHING,
+        REPR_LIMIT_KEY,
+        CallFrame,
+        CapturedTraceback,
+        Effect,
+        EffectBase,
+        EffectFailure,
+        EffectFailureError,
+        EffectGenerator,
+        EffectObservation,
+        EnvKey,
+        Err,
+        FrozenDict,
+        ListenResult,
+        Maybe,
+        Nothing,
+        Ok,
+        Program,
+        ProgramBase,
+        Result,
+        RunResult,
+        Some,
+        TraceError,
+        WGraph,
+        WNode,
+        WStep,
+        _intercept_value,
+        capture_traceback,
+        get_captured_traceback,
+        trace_err,
+    )
+
+import importlib as _importlib
+
+_internal = _importlib.import_module("doeff._types_internal")
+globals().update(_internal.__dict__)

--- a/tests/core/test_import_state_mutation.py
+++ b/tests/core/test_import_state_mutation.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VM_PYTHONPATH = str(ROOT / "packages" / "doeff-vm")
+
+
+def _run_python(script: str) -> dict[str, object]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        VM_PYTHONPATH if not existing else f"{VM_PYTHONPATH}{os.pathsep}{existing}"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    return json.loads(result.stdout)
+
+
+def test_importing_doeff_does_not_rewrite_sys_path() -> None:
+    outcome = _run_python(
+        """
+import json
+import sys
+from pathlib import Path
+
+package_dir = str(Path.cwd() / "doeff")
+sys.path.insert(0, package_dir)
+before = list(sys.path)
+import doeff
+after = list(sys.path)
+print(json.dumps({"before": before, "after": after, "package_dir": package_dir}))
+"""
+    )
+    assert outcome["after"] == outcome["before"]
+    assert outcome["package_dir"] in outcome["after"]
+
+
+def test_shadowed_top_level_types_fails_instead_of_replacing_stdlib_module() -> None:
+    outcome = _run_python(
+        """
+import json
+import sys
+from pathlib import Path
+
+package_dir = str(Path.cwd() / "doeff")
+sys.path.insert(0, package_dir)
+sys.modules.pop("types", None)
+try:
+    import types
+except BaseException as exc:
+    print(json.dumps({
+        "ok": False,
+        "error_type": type(exc).__name__,
+        "message": str(exc),
+    }))
+else:
+    print(json.dumps({
+        "ok": True,
+        "module_file": getattr(types, "__file__", None),
+        "module_name": types.__name__,
+    }))
+"""
+    )
+    assert outcome["ok"] is False
+    assert outcome["error_type"] in {"ImportError", "ModuleNotFoundError", "RuntimeError"}
+    assert "types" in str(outcome["message"])
+
+
+def test_importing_doeff_types_does_not_replace_sys_modules_types() -> None:
+    outcome = _run_python(
+        """
+import json
+import sys
+
+stdlib_types = sys.modules["types"]
+import doeff.types
+current_types = sys.modules["types"]
+print(json.dumps({
+    "same_object": stdlib_types is current_types,
+    "module_name": current_types.__name__,
+}))
+"""
+    )
+    assert outcome["same_object"] is True
+    assert outcome["module_name"] == "types"


### PR DESCRIPTION
Closes #263

## Summary
- remove import-time `sys.path` rewriting from `doeff.__init__`
- remove the `doeff.types` stdlib-recovery shim that replaced `sys.modules["types"]`
- fail fast with a clear import error on invalid top-level `types` shadowing instead of mutating interpreter-global state
- add pytest coverage and a semgrep guard for import-state mutation

## Validation
- `PYTHONPATH=/Users/s22625/.codex/worktrees/issues/263-doeff/packages/doeff-vm /Users/s22625/.codex/worktrees/3e66/doeff/.venv/bin/python -m pytest tests/core/test_import_state_mutation.py tests/public_api/test_api_cleanup.py tests/core/test_vm_proto_006_effect_creation_context_removal.py -q`
- `semgrep --config .semgrep.yaml doeff/__init__.py doeff/types.py`
