### PR TITLE
Narrow cache handler responsibilities

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -75,6 +75,20 @@ rules:
     paths:
       include:
         - /doeff/run.py
+  - id: cache-handler-no-result-duck-typing
+    languages: [python]
+    severity: ERROR
+    message: >
+      Cache handlers must not duck-type result-like values or normalize them through vendor Ok/Err.
+      The cache boundary should store the original value or fail clearly if it cannot persist it.
+    pattern-either:
+      - pattern: hasattr($X, "is_ok")
+      - pattern: hasattr($X, "is_err")
+      - pattern: from doeff._vendor import Ok as $ALIAS
+      - pattern: from doeff._vendor import Err as $ALIAS
+    paths:
+      include:
+        - /doeff/handlers/cache_handlers.py
 
   - id: no-doeff-vm-import-recovery
     languages: [python]

--- a/doeff/cache.py
+++ b/doeff/cache.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
 
+import doeff_vm
+
 from doeff.cache_policy import CacheLifecycle, CachePolicy, CacheStorage
 from doeff.decorators import do_wrapper
 from doeff.do import do
@@ -17,7 +19,7 @@ from doeff.effects.execution_context import GetExecutionContext
 from doeff.effects.result import Try
 from doeff.effects.writer import slog
 from doeff.kleisli import KleisliProgram
-from doeff.types import EffectGenerator, FrozenDict, Result
+from doeff.types import EffectGenerator, Err, FrozenDict, Ok, Result
 
 
 @dataclass(frozen=True)
@@ -41,30 +43,14 @@ class CacheCallSite:
 T = TypeVar("T")
 
 
-def _result_is_ok(result: Any) -> bool:
-    probe = result.is_ok
-    return bool(probe()) if callable(probe) else bool(probe)
-
-
-def _result_is_err(result: Any) -> bool:
-    probe = result.is_err
-    return bool(probe()) if callable(probe) else bool(probe)
-
-
-def _result_value(result: Any) -> Any:
+def _normalize_cache_result(result: object) -> Result[Any]:
     if isinstance(result, Result):
-        return result.unwrap()
-    return result.value
-
-
-def _result_error(result: Any) -> BaseException:
-    if isinstance(result, Result):
-        return result.unwrap_err()
-    return result.error
-
-
-def _is_result_like(value: Any) -> bool:
-    return hasattr(value, "is_ok") and hasattr(value, "is_err")
+        return result
+    if isinstance(result, doeff_vm.Ok):
+        return Ok(result.value)
+    if isinstance(result, doeff_vm.Err):
+        return Err(result.error)
+    raise TypeError(f"cache() expected a Result value, got {type(result).__name__}")
 
 
 def _function_identifier(target: Any) -> str:
@@ -229,7 +215,9 @@ def cache(
         ... def expensive_computation(x: int) -> EffectGenerator[int]:
         ...     yield Tell(f"Computing result for {x}")
         ...     return x * 2
-        >>> await ProgramInterpreter().run(expensive_computation(5))
+        >>> result = run(expensive_computation(5), handlers=default_handlers())
+        >>> result.value
+        10
 
         The first call will compute and cache the result. Subsequent calls within the TTL return
         the cached value, and the policy hints remain available to custom cache handlers.
@@ -373,9 +361,9 @@ def cache(
             def compute_and_cache() -> EffectGenerator[T]:
                 yield slog(msg=f"Cache miss for {func_name}, computing...", level="DEBUG")
                 program_call = wrapped_func(*args, **kwargs)
-                result: Result = yield Try(program_call)
+                result = _normalize_cache_result((yield Try(program_call)))
 
-                if _result_is_ok(result):
+                if result.is_ok():
                     yield ensure_serializable(cache_key_obj)
                     yield CachePut(
                         cache_key_obj,
@@ -387,10 +375,10 @@ def cache(
                         policy=policy,
                     )
                     yield slog(msg=f"Cache: stored result for {func_name}", level="DEBUG")
-                    return _result_value(result)
+                    return result.value
 
                 yield slog(msg=f"Computation for {func_name} failed, not caching.", level="error")
-                error = _result_error(result)
+                error = result.error
                 _attach_exception_note(
                     error,
                     _cache_error_note(func_name, args, dict(kwargs), call_site),
@@ -408,10 +396,10 @@ def cache(
             else:
                 result = yield compute_and_cache()
 
-            if _is_result_like(result):
-                if _result_is_err(result):
-                    raise _result_error(result)
-                return _result_value(result)
+            if isinstance(result, Result):
+                if result.is_err():
+                    raise result.error
+                return result.value
             return result
 
         try:

--- a/doeff/handlers/cache_handlers.py
+++ b/doeff/handlers/cache_handlers.py
@@ -1,26 +1,25 @@
 """Cache effect handlers and memoization helpers."""
 
-from __future__ import annotations
-
 import dataclasses
 import hashlib
 import json
 from collections.abc import Callable, Mapping, Set
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 import doeff_vm
 
-from doeff._vendor import Err as PyErr
-from doeff._vendor import Ok as PyOk
 from doeff.do import do
 from doeff.effects.cache import CacheGet, CacheGetEffect, CachePut, CachePutEffect
 from doeff.effects.result import Try
 from doeff.storage import DurableStorage, InMemoryStorage, SQLiteStorage
 from doeff.types import Effect
 
+MemoKeyFn: TypeAlias = Callable[[object], str]
+CacheProtocolHandler: TypeAlias = Callable[..., object]
 
-def _dumps(value: Any) -> bytes:
+
+def _dumps(value: object) -> bytes:
     try:
         import cloudpickle as serializer
     except ModuleNotFoundError:  # pragma: no cover - optional dependency fallback
@@ -29,9 +28,9 @@ def _dumps(value: Any) -> bytes:
     return serializer.dumps(value)
 
 
-def _normalize_for_hash(value: Any) -> Any:
+def _normalize_for_hash(value: object) -> object:
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        normalized: Any = {
+        normalized: object = {
             "__type__": f"{type(value).__module__}.{type(value).__qualname__}",
             **{
                 field.name: _normalize_for_hash(getattr(value, field.name))
@@ -64,33 +63,28 @@ def _normalize_for_hash(value: Any) -> Any:
     return normalized
 
 
-def _storage_key(key: Any) -> str:
+def _storage_key(key: object) -> str:
     if isinstance(key, str):
         return key
     return f"sha256:{content_address(key)}"
 
 
-def _stored_value(value: Any) -> Any:
-    if (
-        hasattr(value, "is_ok")
-        and callable(value.is_ok)
-        and value.is_ok()
-        and hasattr(value, "value")
-    ):
-        return PyOk(value.value)
-
-    if (
-        hasattr(value, "is_err")
-        and callable(value.is_err)
-        and value.is_err()
-        and hasattr(value, "error")
-    ):
-        return PyErr(value.error)
-
-    return value
+def _persist_value(
+    storage: DurableStorage,
+    storage_key: str,
+    *,
+    original_key: object,
+    value: object,
+) -> None:
+    try:
+        storage.put(storage_key, value)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cache handler could not persist value for key {original_key!r}: {exc}"
+        ) from exc
 
 
-def content_address(effect: Any) -> str:
+def content_address(effect: object) -> str:
     """Return a SHA-256 content address for an effect payload."""
 
     try:
@@ -102,14 +96,14 @@ def content_address(effect: Any) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def cache_handler(storage: DurableStorage) -> Any:
+def cache_handler(storage: DurableStorage) -> CacheProtocolHandler:
     """Interpret CacheGet/CachePut against a pluggable storage backend."""
 
     @do
-    def handler(effect: CacheGetEffect | CachePutEffect, k: Any):
+    def handler(effect: CacheGetEffect | CachePutEffect, k: object):
         if not isinstance(effect, (CacheGetEffect, CachePutEffect)):
             yield doeff_vm.Pass()
-            return
+            return None
 
         key = _storage_key(effect.key)
 
@@ -119,35 +113,35 @@ def cache_handler(storage: DurableStorage) -> Any:
                 raise KeyError(effect.key)
             return (yield doeff_vm.Resume(k, value))
 
-        storage.put(key, _stored_value(effect.value))
+        _persist_value(storage, key, original_key=effect.key, value=effect.value)
         return (yield doeff_vm.Resume(k, None))
 
     return handler
 
 
-def in_memory_cache_handler() -> Any:
+def in_memory_cache_handler() -> CacheProtocolHandler:
     """Return a cache handler backed by in-memory storage."""
 
     return cache_handler(InMemoryStorage())
 
 
-def sqlite_cache_handler(db_path: str | Path) -> Any:
+def sqlite_cache_handler(db_path: str | Path) -> CacheProtocolHandler:
     """Return a cache handler backed by SQLite storage."""
 
     return cache_handler(SQLiteStorage(db_path))
 
 
 def make_memo_rewriter(
-    effect_type: type[Any],
-    key_fn: Callable[[Any], str] = content_address,
-) -> Any:
+    effect_type: type[object],
+    key_fn: MemoKeyFn = content_address,
+) -> CacheProtocolHandler:
     """Create an interceptor that memoizes handled effects through CacheGet/CachePut."""
 
     @do
-    def handler(effect: Effect, k: Any):
+    def handler(effect: Effect, k: object):
         if not isinstance(effect, effect_type):
             yield doeff_vm.Pass()
-            return
+            return None
 
         key = key_fn(effect)
 
@@ -170,9 +164,9 @@ def make_memo_rewriter(
 
 
 def memo_rewriters(
-    *effect_types: type[Any],
-    key_fn: Callable[[Any], str] = content_address,
-) -> list[Any]:
+    *effect_types: type[object],
+    key_fn: MemoKeyFn = content_address,
+) -> list[CacheProtocolHandler]:
     """Create memo rewriters for each provided effect type."""
 
     return [make_memo_rewriter(effect_type, key_fn=key_fn) for effect_type in effect_types]

--- a/tests/test_cache_handlers.py
+++ b/tests/test_cache_handlers.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 import sys
 
+import doeff_vm
+
 from doeff import (
     Ask,
     CacheGet,
@@ -36,6 +38,37 @@ def _run_with_handlers(program: object, *handlers: object):
 @dataclass(frozen=True)
 class MultiplyFx(EffectBase):
     value: int
+
+
+class _ResultLike:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def is_ok(self) -> bool:
+        return True
+
+
+class _FailingStorage:
+    def get(self, key: str) -> object | None:
+        return None
+
+    def put(self, key: str, value: object) -> None:
+        raise TypeError("backend cannot persist value")
+
+    def delete(self, key: str) -> bool:
+        return False
+
+    def exists(self, key: str) -> bool:
+        return False
+
+    def keys(self) -> list[str]:
+        return []
+
+    def items(self) -> list[tuple[str, object]]:
+        return []
+
+    def clear(self) -> None:
+        return None
 
 
 @do
@@ -75,6 +108,40 @@ def test_cache_handler_put() -> None:
     assert result.is_ok(), result.error
     assert result.value is None
     assert storage.get("answer") == 42
+
+
+def test_cache_handler_put_preserves_result_like_objects_without_reinterpretation() -> None:
+    storage = InMemoryStorage()
+    value = _ResultLike("payload")
+
+    result = _run_with_handlers(_cache_put_program("result-like", value), cache_handler(storage))
+
+    assert result.is_ok(), result.error
+    assert storage.get("result-like") is value
+
+
+def test_cache_handler_put_preserves_vm_result_values_without_vendor_coercion() -> None:
+    storage = InMemoryStorage()
+    value = doeff_vm.Ok("payload")
+
+    result = _run_with_handlers(_cache_put_program("vm-ok", value), cache_handler(storage))
+
+    assert result.is_ok(), result.error
+    stored = storage.get("vm-ok")
+    assert type(stored) is type(value)
+    assert stored.value == "payload"
+
+
+def test_cache_handler_put_raises_cache_boundary_error_when_storage_rejects_value() -> None:
+    result = _run_with_handlers(
+        _cache_put_program("bad-key", object()),
+        cache_handler(_FailingStorage()),
+    )
+
+    assert result.is_err()
+    assert isinstance(result.error, RuntimeError)
+    assert "bad-key" in str(result.error)
+    assert "persist" in str(result.error)
 
 
 def test_cache_decorator_with_handler(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #265

## Summary
- remove result duck-typing and vendor coercion from `doeff.handlers.cache_handlers`
- keep the cache handler as a storage boundary that stores values unchanged
- move explicit result normalization into the `cache()` decorator path
- add pytest coverage and a semgrep guard for cache-handler result duck-typing

## Validation
- `PYTHONPATH=/Users/s22625/.codex/worktrees/issues/265-doeff/packages/doeff-vm:/Users/s22625/.codex/worktrees/issues/265-doeff /Users/s22625/.codex/worktrees/3e66/doeff/.venv/bin/python -m pytest tests/test_cache_handlers.py -q`
- `PYTHONPATH=/Users/s22625/.codex/worktrees/issues/265-doeff/packages/doeff-vm:/Users/s22625/.codex/worktrees/issues/265-doeff /Users/s22625/.codex/worktrees/3e66/doeff/.venv/bin/python -m pytest tests/test_cache_handlers.py tests/effects/test_finally_semaphore_over_release.py -q -k 'test_cache_decorator_in_memory_high_concurrency_sync or test_cache_decorator_nested_kleisli_high_concurrency_sync or test_real_cache_handler_high_concurrency_sync or test_cache_handler'`
- `semgrep --config .semgrep.yaml doeff/handlers/cache_handlers.py doeff/cache.py`
