### PR TITLE
Fix one-shot continuation violation in handler dispatch

### DIFF
--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -1362,6 +1362,7 @@ impl VM {
         self.dispatch_state
             .find_by_dispatch_id(dispatch_id)
             .map(|ctx| ctx.k_current.clone())
+            .filter(|k| !self.is_one_shot_consumed(k.cont_id))
     }
 
     fn active_error_dispatch_original_exception(&self) -> Option<PyException> {

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -1527,10 +1527,17 @@ pub(crate) fn classify_yielded_bound(
                 })?;
                 let cont_id = k_pyobj.borrow().cont_id;
                 let k = vm.lookup_continuation(cont_id).cloned().ok_or_else(|| {
-                    PyRuntimeError::new_err(format!(
-                        "Discontinue with unknown continuation id {}",
-                        cont_id.raw()
-                    ))
+                    if vm.is_one_shot_consumed(cont_id) {
+                        PyRuntimeError::new_err(format!(
+                            "one-shot violation: continuation {} already consumed",
+                            cont_id.raw()
+                        ))
+                    } else {
+                        PyRuntimeError::new_err(format!(
+                            "Discontinue with unknown continuation id {}",
+                            cont_id.raw()
+                        ))
+                    }
                 })?;
                 let bound_exception = d.exception.bind(py);
                 if !bound_exception.is_instance_of::<PyBaseException>() {
@@ -1622,10 +1629,17 @@ pub(crate) fn classify_yielded_bound(
                 })?;
                 let cont_id = k_pyobj.borrow().cont_id;
                 let k = vm.lookup_continuation(cont_id).cloned().ok_or_else(|| {
-                    PyRuntimeError::new_err(format!(
-                        "Resume with unknown continuation id {}",
-                        cont_id.raw()
-                    ))
+                    if vm.is_one_shot_consumed(cont_id) {
+                        PyRuntimeError::new_err(format!(
+                            "one-shot violation: continuation {} already consumed",
+                            cont_id.raw()
+                        ))
+                    } else {
+                        PyRuntimeError::new_err(format!(
+                            "Resume with unknown continuation id {}",
+                            cont_id.raw()
+                        ))
+                    }
                 })?;
                 Ok(DoCtrl::Resume {
                     continuation: k,
@@ -1641,10 +1655,17 @@ pub(crate) fn classify_yielded_bound(
                 })?;
                 let cont_id = k_pyobj.borrow().cont_id;
                 let k = vm.lookup_continuation(cont_id).cloned().ok_or_else(|| {
-                    PyRuntimeError::new_err(format!(
-                        "Transfer with unknown continuation id {}",
-                        cont_id.raw()
-                    ))
+                    if vm.is_one_shot_consumed(cont_id) {
+                        PyRuntimeError::new_err(format!(
+                            "one-shot violation: continuation {} already consumed",
+                            cont_id.raw()
+                        ))
+                    } else {
+                        PyRuntimeError::new_err(format!(
+                            "Transfer with unknown continuation id {}",
+                            cont_id.raw()
+                        ))
+                    }
                 })?;
                 Ok(DoCtrl::Transfer {
                     continuation: k,
@@ -1680,10 +1701,17 @@ pub(crate) fn classify_yielded_bound(
                 })?;
                 let cont_id = k_pyobj.borrow().cont_id;
                 let k = vm.lookup_continuation(cont_id).cloned().ok_or_else(|| {
-                    PyRuntimeError::new_err(format!(
-                        "ResumeContinuation with unknown continuation id {}",
-                        cont_id.raw()
-                    ))
+                    if vm.is_one_shot_consumed(cont_id) {
+                        PyRuntimeError::new_err(format!(
+                            "one-shot violation: continuation {} already consumed",
+                            cont_id.raw()
+                        ))
+                    } else {
+                        PyRuntimeError::new_err(format!(
+                            "ResumeContinuation with unknown continuation id {}",
+                            cont_id.raw()
+                        ))
+                    }
                 })?;
                 Ok(DoCtrl::ResumeContinuation {
                     continuation: k,
@@ -1722,10 +1750,17 @@ pub(crate) fn classify_yielded_bound(
                 })?;
                 let cont_id = k_pyobj.borrow().cont_id;
                 let k = vm.lookup_continuation(cont_id).cloned().ok_or_else(|| {
-                    PyRuntimeError::new_err(format!(
-                        "GetTraceback with unknown continuation id {}",
-                        cont_id.raw()
-                    ))
+                    if vm.is_one_shot_consumed(cont_id) {
+                        PyRuntimeError::new_err(format!(
+                            "one-shot violation: continuation {} already consumed",
+                            cont_id.raw()
+                        ))
+                    } else {
+                        PyRuntimeError::new_err(format!(
+                            "GetTraceback with unknown continuation id {}",
+                            cont_id.raw()
+                        ))
+                    }
                 })?;
                 Ok(DoCtrl::GetTraceback { continuation: k })
             }
@@ -1746,10 +1781,17 @@ pub(crate) fn classify_yielded_bound(
                 })?;
                 let cont_id = scope_obj.borrow().cont_id;
                 let scope = vm.lookup_continuation(cont_id).cloned().ok_or_else(|| {
-                    PyRuntimeError::new_err(format!(
-                        "EvalInScope with unknown continuation id {}",
-                        cont_id.raw()
-                    ))
+                    if vm.is_one_shot_consumed(cont_id) {
+                        PyRuntimeError::new_err(format!(
+                            "one-shot violation: continuation {} already consumed",
+                            cont_id.raw()
+                        ))
+                    } else {
+                        PyRuntimeError::new_err(format!(
+                            "EvalInScope with unknown continuation id {}",
+                            cont_id.raw()
+                        ))
+                    }
                 })?;
                 Ok(DoCtrl::EvalInScope {
                     expr: PyShared::new(expr),


### PR DESCRIPTION
## Summary
- Fixed `handler_stream_throw_continuation` in the Rust VM to skip already-consumed continuations, preventing spurious one-shot violations when a handler resumes a continuation then raises an exception
- Fixed all 6 continuation lookup sites in pyvm.rs to return "one-shot violation" error (instead of "unknown continuation id") when a consumed continuation is referenced
- Fixes 5 failing tests: handler resume-then-raise patterns and late-resume error messages

## Changes
- `packages/doeff-vm-core/src/vm.rs`: Added `.filter(|k| !self.is_one_shot_consumed(k.cont_id))` to `handler_stream_throw_continuation`
- `packages/doeff-vm/src/pyvm.rs`: Added `is_one_shot_consumed` check in Resume, Transfer, Discontinue, ResumeContinuation, GetTraceback, and EvalInScope lookup fallbacks

## Test evidence
```
5 previously failing tests now pass:
- test_format_default_duplicate_name_throw_marks_correct_handler
- test_runtime_handler_cleanup_after_resume_stays_tagged
- test_format_default_runtime_distinguishes_passed_and_delegated
- test_inner_handler_resumes_then_raises_in_nested_dispatch
- test_thrown_dispatch_consumes_continuation_and_rejects_late_resume

Full suite: 1117 passed, 2 deselected, 5 xfailed in 146.91s
```

## Test plan
- [x] All 5 previously failing tests pass
- [x] Full test suite passes with no regressions (1117 passed)

Ref: fix437b-zeus-claude-20260312-205605

🤖 Generated with [Claude Code](https://claude.com/claude-code)