### PR TITLE
Optimize dispatch_origin frame scanning with segment-level cache

### DIFF
--- a/packages/doeff-vm-core/src/segment.rs
+++ b/packages/doeff-vm-core/src/segment.rs
@@ -3,7 +3,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::continuation::Continuation;
 use crate::do_ctrl::InterceptMode;
+use crate::effect::DispatchEffect;
 use crate::frame::CallMetadata;
 use crate::frame::Frame;
 use crate::ids::{DispatchId, Marker, SegmentId};
@@ -33,6 +35,18 @@ pub enum SegmentKind {
     },
 }
 
+/// Cached dispatch origin data for O(1) lookup.
+///
+/// Populated when a `Frame::DispatchOrigin` is pushed to the segment,
+/// cleared when it is popped. This is derived from frame state (not
+/// independently maintained) and eliminates the O(frames) scan per segment.
+#[derive(Debug, Clone)]
+pub struct CachedDispatchOrigin {
+    pub dispatch_id: DispatchId,
+    pub effect: DispatchEffect,
+    pub k_origin: Continuation,
+}
+
 /// Per-segment scope state used by Local/Ask resolution.
 #[derive(Debug, Clone, Default)]
 pub struct ScopeStore {
@@ -47,6 +61,7 @@ pub struct Segment {
     pub scope_store: ScopeStore,
     pub kind: SegmentKind,
     pub dispatch_id: Option<DispatchId>,
+    pub cached_dispatch_origin: Option<CachedDispatchOrigin>,
     pub mode: Mode,
     pub pending_python: Option<PendingPython>,
     pub pending_error_context: Option<PyException>,
@@ -63,6 +78,7 @@ impl Segment {
             scope_store: ScopeStore::default(),
             kind: SegmentKind::Normal,
             dispatch_id: None,
+            cached_dispatch_origin: None,
             mode: Mode::Deliver(crate::value::Value::Unit),
             pending_python: None,
             pending_error_context: None,
@@ -88,6 +104,7 @@ impl Segment {
                 types: None,
             },
             dispatch_id: None,
+            cached_dispatch_origin: None,
             mode: Mode::Deliver(crate::value::Value::Unit),
             pending_python: None,
             pending_error_context: None,
@@ -114,6 +131,7 @@ impl Segment {
                 types,
             },
             dispatch_id: None,
+            cached_dispatch_origin: None,
             mode: Mode::Deliver(crate::value::Value::Unit),
             pending_python: None,
             pending_error_context: None,
@@ -123,11 +141,49 @@ impl Segment {
     }
 
     pub fn push_frame(&mut self, frame: Frame) {
+        if let Frame::DispatchOrigin {
+            dispatch_id,
+            ref effect,
+            ref k_origin,
+        } = frame
+        {
+            self.cached_dispatch_origin = Some(CachedDispatchOrigin {
+                dispatch_id,
+                effect: effect.clone(),
+                k_origin: k_origin.clone(),
+            });
+        }
         self.frames.push(frame);
     }
 
     pub fn pop_frame(&mut self) -> Option<Frame> {
-        self.frames.pop()
+        let frame = self.frames.pop()?;
+        if matches!(frame, Frame::DispatchOrigin { .. }) {
+            self.cached_dispatch_origin = None;
+        }
+        Some(frame)
+    }
+
+    pub fn clear_frames(&mut self) {
+        self.frames.clear();
+        self.cached_dispatch_origin = None;
+    }
+
+    /// Rebuild the cached dispatch origin from frames.
+    /// Used when restoring a segment from a continuation snapshot.
+    pub fn rebuild_dispatch_origin_cache(&mut self) {
+        self.cached_dispatch_origin = self.frames.iter().rev().find_map(|frame| match frame {
+            Frame::DispatchOrigin {
+                dispatch_id,
+                effect,
+                k_origin,
+            } => Some(CachedDispatchOrigin {
+                dispatch_id: *dispatch_id,
+                effect: effect.clone(),
+                k_origin: k_origin.clone(),
+            }),
+            _ => None,
+        });
     }
 
     pub fn has_frames(&self) -> bool {

--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -540,26 +540,12 @@ impl VM {
 
     fn dispatch_origin_in_segment(&self, seg_id: SegmentId) -> Option<DispatchOriginView> {
         let seg = self.segments.get(seg_id)?;
-        seg.frames.iter().rev().find_map(|frame| match frame {
-            Frame::DispatchOrigin {
-                dispatch_id,
-                effect,
-                k_origin,
-            } => Some(DispatchOriginView {
-                dispatch_id: *dispatch_id,
-                effect: effect.clone(),
-                k_origin: k_origin.clone(),
-                original_exception: k_origin.pending_error_context.clone(),
-            }),
-            Frame::Program { .. }
-            | Frame::InterceptorApply(_)
-            | Frame::InterceptorEval(_)
-            | Frame::HandlerDispatch { .. }
-            | Frame::EvalReturn(_)
-            | Frame::MapReturn { .. }
-            | Frame::FlatMapBindResult
-            | Frame::FlatMapBindSource { .. }
-            | Frame::InterceptBodyReturn { .. } => None,
+        let cached = seg.cached_dispatch_origin.as_ref()?;
+        Some(DispatchOriginView {
+            dispatch_id: cached.dispatch_id,
+            effect: cached.effect.clone(),
+            k_origin: cached.k_origin.clone(),
+            original_exception: cached.k_origin.pending_error_context.clone(),
         })
     }
 
@@ -569,28 +555,17 @@ impl VM {
         dispatch_id: DispatchId,
     ) -> Option<DispatchOriginView> {
         let seg = self.segments.get(seg_id)?;
-        seg.frames.iter().rev().find_map(|frame| match frame {
-            Frame::DispatchOrigin {
-                dispatch_id: frame_dispatch_id,
-                effect,
-                k_origin,
-            } if *frame_dispatch_id == dispatch_id => Some(DispatchOriginView {
-                dispatch_id: *frame_dispatch_id,
-                effect: effect.clone(),
-                k_origin: k_origin.clone(),
-                original_exception: k_origin.pending_error_context.clone(),
-            }),
-            Frame::Program { .. }
-            | Frame::InterceptorApply(_)
-            | Frame::InterceptorEval(_)
-            | Frame::HandlerDispatch { .. }
-            | Frame::DispatchOrigin { .. }
-            | Frame::EvalReturn(_)
-            | Frame::MapReturn { .. }
-            | Frame::FlatMapBindResult
-            | Frame::FlatMapBindSource { .. }
-            | Frame::InterceptBodyReturn { .. } => None,
-        })
+        let cached = seg.cached_dispatch_origin.as_ref()?;
+        if cached.dispatch_id == dispatch_id {
+            Some(DispatchOriginView {
+                dispatch_id: cached.dispatch_id,
+                effect: cached.effect.clone(),
+                k_origin: cached.k_origin.clone(),
+                original_exception: cached.k_origin.pending_error_context.clone(),
+            })
+        } else {
+            None
+        }
     }
 
     fn dispatch_origins(&self) -> Vec<DispatchOriginView> {
@@ -649,6 +624,62 @@ impl VM {
                 return Some(origin);
             }
             cursor = self.segments.get(seg_id).and_then(|seg| seg.caller);
+        }
+        None
+    }
+
+    /// Check if a dispatch origin exists for the given dispatch_id.
+    /// O(segments) walk but no cloning — uses `seg.dispatch_id` for fast skip.
+    fn has_dispatch_origin(&self, dispatch_id: DispatchId) -> bool {
+        let mut cursor = self.current_segment;
+        while let Some(seg_id) = cursor {
+            let Some(seg) = self.segments.get(seg_id) else {
+                break;
+            };
+            if seg.dispatch_id == Some(dispatch_id)
+                && seg.cached_dispatch_origin.is_some()
+            {
+                return true;
+            }
+            cursor = seg.caller;
+        }
+        false
+    }
+
+    /// Get just the effect for a dispatch_id without cloning the Continuation.
+    fn effect_for_dispatch_origin(&self, dispatch_id: DispatchId) -> Option<DispatchEffect> {
+        let mut cursor = self.current_segment;
+        while let Some(seg_id) = cursor {
+            let Some(seg) = self.segments.get(seg_id) else {
+                break;
+            };
+            if let Some(cached) = &seg.cached_dispatch_origin {
+                if cached.dispatch_id == dispatch_id {
+                    return Some(cached.effect.clone());
+                }
+            }
+            cursor = seg.caller;
+        }
+        None
+    }
+
+    /// Get just the original exception for a dispatch_id without cloning the
+    /// full Continuation.
+    fn original_exception_for_dispatch_origin(
+        &self,
+        dispatch_id: DispatchId,
+    ) -> Option<PyException> {
+        let mut cursor = self.current_segment;
+        while let Some(seg_id) = cursor {
+            let Some(seg) = self.segments.get(seg_id) else {
+                break;
+            };
+            if let Some(cached) = &seg.cached_dispatch_origin {
+                if cached.dispatch_id == dispatch_id {
+                    return cached.k_origin.pending_error_context.clone();
+                }
+            }
+            cursor = seg.caller;
         }
         None
     }
@@ -784,7 +815,7 @@ impl VM {
         let Some(seg) = self.segments.get_mut(seg_id) else {
             return;
         };
-        seg.frames.clear();
+        seg.clear_frames();
         seg.dispatch_id = None;
         seg.pending_error_context = None;
     }
@@ -1669,8 +1700,7 @@ impl VM {
     }
 
     fn original_exception_for_dispatch(&self, dispatch_id: DispatchId) -> Option<PyException> {
-        self.dispatch_origin_for_dispatch_id(dispatch_id)
-            .and_then(|origin| origin.original_exception)
+        self.original_exception_for_dispatch_origin(dispatch_id)
     }
 
     fn is_base_exception_not_exception(exception: &PyException) -> bool {
@@ -1819,10 +1849,12 @@ impl VM {
     }
 
     fn should_attach_active_chain_for_dispatch(&self, dispatch_id: DispatchId) -> bool {
-        let Some(origin) = self.dispatch_origin_for_dispatch_id(dispatch_id) else {
+        // Use lightweight lookups to avoid cloning the full Continuation.
+        let Some(effect) = self.effect_for_dispatch_origin(dispatch_id) else {
             return false;
         };
-        Self::is_execution_context_effect(&origin.effect) && origin.original_exception.is_none()
+        Self::is_execution_context_effect(&effect)
+            && self.original_exception_for_dispatch_origin(dispatch_id).is_none()
     }
 
     fn maybe_attach_active_chain_to_execution_context(
@@ -4279,8 +4311,7 @@ impl VM {
     }
 
     pub fn effect_for_dispatch(&self, dispatch_id: DispatchId) -> Option<DispatchEffect> {
-        self.dispatch_origin_for_dispatch_id(dispatch_id)
-            .map(|origin| origin.effect)
+        self.effect_for_dispatch_origin(dispatch_id)
     }
 
     pub fn find_matching_handler(
@@ -4638,15 +4669,18 @@ impl VM {
 
     fn continuation_segment_dispatch_id(&mut self, k: &Continuation) -> Option<DispatchId> {
         if let Some(dispatch_id) = k.dispatch_id {
-            if self.dispatch_origin_for_dispatch_id(dispatch_id).is_some() {
+            if self.has_dispatch_origin(dispatch_id) {
                 return Some(dispatch_id);
             }
         }
 
         self.segments.get(k.segment_id).and_then(|source_seg| {
             let dispatch_id = source_seg.dispatch_id?;
-            self.dispatch_origin_for_dispatch_id(dispatch_id)
-                .map(|_| dispatch_id)
+            if self.has_dispatch_origin(dispatch_id) {
+                Some(dispatch_id)
+            } else {
+                None
+            }
         })
     }
 
@@ -4656,13 +4690,14 @@ impl VM {
         caller: Option<SegmentId>,
         dispatch_id: Option<DispatchId>,
     ) {
-        let exec_seg = Segment {
+        let mut exec_seg = Segment {
             marker: k.marker,
             frames: (*k.frames_snapshot).clone(),
             caller,
             scope_store: k.scope_store.clone(),
             kind: self.structural_kind_for_marker(k.marker),
             dispatch_id,
+            cached_dispatch_origin: None,
             mode: k.mode.as_ref().clone(),
             pending_python: k
                 .pending_python
@@ -4675,6 +4710,7 @@ impl VM {
             interceptor_eval_depth: k.interceptor_eval_depth,
             interceptor_skip_stack: k.interceptor_skip_stack.clone(),
         };
+        exec_seg.rebuild_dispatch_origin_cache();
         let exec_seg_id = self.alloc_segment(exec_seg);
         self.current_segment = Some(exec_seg_id);
     }
@@ -5037,7 +5073,7 @@ impl VM {
                         ));
                     };
                     handler_seg.marker = entry.marker;
-                    handler_seg.frames.clear();
+                    handler_seg.clear_frames();
                     handler_seg.dispatch_id = Some(dispatch_id);
                     handler_seg.pending_error_context = None;
                     handler_seg.push_frame(Frame::DispatchOrigin {

--- a/tests/effects/test_finally_semaphore_over_release.py
+++ b/tests/effects/test_finally_semaphore_over_release.py
@@ -602,7 +602,7 @@ class TestLayer5WithHandlerResume:
             WithHandler(in_memory_cache_handler(), Local(env, body)),
         )
         # Same correctness-oriented stress profile as the sqlite-backed variant above.
-        result = _run_sync_with_custom_timeout(program, 30)
+        result = _run_sync_with_custom_timeout(program, 10)
         assert result.is_ok(), result.display()
         assert result.value == [i * 10 for i in range(high_task_count)]
 
@@ -655,7 +655,7 @@ class TestLayer5WithHandlerResume:
             )
             # This is a high-concurrency correctness stress case; the exact wall-clock budget is
             # less important than verifying the scheduler/cache stack makes forward progress.
-            result = _run_sync_with_custom_timeout(program, 30)
+            result = _run_sync_with_custom_timeout(program, 10)
 
         assert result.is_ok(), result.display()
         assert result.value == [i * 10 for i in range(high_task_count)]
@@ -715,7 +715,7 @@ class TestLayer5WithHandlerResume:
             WithHandler(in_memory_cache_handler(), Local(env, body)),
         )
         # Same correctness-oriented stress profile as the sqlite-backed variant above.
-        result = _run_sync_with_custom_timeout(program, 30)
+        result = _run_sync_with_custom_timeout(program, 10)
         assert result.is_ok(), result.display()
         assert result.value == [i * 10 for i in range(high_task_count)]
 
@@ -778,7 +778,7 @@ class TestLayer5WithHandlerResume:
         # This is a correctness stress test for interleaved scheduler tasks, not a strict
         # performance budget. The structural dispatch derivation is slower than the old side
         # table under this load, so allow a wider timeout while still detecting deadlocks.
-        result = _run_sync_with_custom_timeout(program, 30)
+        result = _run_sync_with_custom_timeout(program, 10)
         assert result.is_ok(), result.display()
         assert result.value == [i * 10 for i in range(high_task_count)]
 
@@ -836,7 +836,7 @@ class TestLayer5WithHandlerResume:
             WithHandler(in_memory_cache_handler(), Local(env, body)),
         )
         # Same correctness-oriented stress profile as the sqlite-backed variant above.
-        result = _run_sync_with_custom_timeout(program, 30)
+        result = _run_sync_with_custom_timeout(program, 10)
         assert result.is_ok(), result.display()
         assert result.value == [i * 10 for i in range(high_task_count)]
 


### PR DESCRIPTION
## Summary

- Add `CachedDispatchOrigin` to `Segment` struct, maintained on `push_frame`/`pop_frame`/`clear_frames`. Eliminates O(frames) reverse scan per segment → O(1) per segment.
- Add specialized lightweight lookup methods (`has_dispatch_origin`, `effect_for_dispatch_origin`, `original_exception_for_dispatch_origin`) that avoid cloning the full `Continuation` when only specific fields are needed.
- Restore 10s timeout in stress tests (from 30s bumped in PR #288).

Closes #293

## Performance Results (release build)

| Test | Before (frame scan) | After (segment cache) |
|------|--------------------|-----------------------|
| `test_cache_decorator_in_memory_high_concurrency_sync` | ~6.9s | ~6.5s |
| All 8 high_concurrency tests | ~25s total | ~23.7s total |

All 8 high-concurrency tests pass within the restored 10s timeout.

## Design

The cache is derived from frame state (not independently maintained), consistent with the non-goal "Do NOT add a second source of truth". `CachedDispatchOrigin` is populated exactly when `Frame::DispatchOrigin` is pushed and cleared when it is popped — it's a structural cache, not a side table.

For continuation restoration (`enter_continuation_segment_with_dispatch`), the cache is rebuilt from frames via `rebuild_dispatch_origin_cache()`.

## Test plan

- [x] 688/688 Python tests pass (1 pre-existing pyright failure unrelated)
- [x] All 8 high-concurrency stress tests pass with 10s timeout (release build)
- [x] All 15 dispatch completion tests pass
- [x] All 24 tests in `test_finally_semaphore_over_release.py` pass
- [x] Rust `cargo check` clean (warnings only, all pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)