### PR TITLE
Extract Python from VM core: introduce OpaqueRef indirection

### DIFF
--- a/packages/doeff-core-effects/src/effects/mod.rs
+++ b/packages/doeff-core-effects/src/effects/mod.rs
@@ -7,6 +7,8 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyModule, PyTuple};
 
 use doeff_vm_core::effect::{PyExecutionContext, PyGetExecutionContext};
+use doeff_vm_core::opaque_ref::OpaqueRef;
+use doeff_vm_core::py_shared::OpaqueRefPyExt;
 
 use crate::py_shared::PyShared;
 use crate::pyvm::{DoExprTag, PyEffectBase};
@@ -652,7 +654,7 @@ impl PyProgramCallFrame {
 pub struct Effect(pub PyShared);
 
 #[cfg(not(test))]
-pub type DispatchEffect = PyShared;
+pub type DispatchEffect = OpaqueRef;
 
 #[cfg(test)]
 /// An effect that can be yielded by user code.
@@ -718,18 +720,18 @@ pub fn dispatch_from_shared(obj: PyShared) -> DispatchEffect {
     }
     #[cfg(not(test))]
     {
-        obj
+        obj.into_opaque()
     }
 }
 
-pub fn dispatch_ref_as_python(effect: &DispatchEffect) -> Option<&PyShared> {
+pub fn dispatch_ref_as_python(effect: &DispatchEffect) -> Option<PyShared> {
     #[cfg(test)]
     {
-        return effect.as_python();
+        return effect.as_python().cloned();
     }
     #[cfg(not(test))]
     {
-        Some(effect)
+        PyShared::from_opaque(effect.clone())
     }
 }
 
@@ -740,7 +742,7 @@ pub fn dispatch_into_python(effect: DispatchEffect) -> Option<PyShared> {
     }
     #[cfg(not(test))]
     {
-        Some(effect)
+        PyShared::from_opaque(effect)
     }
 }
 

--- a/packages/doeff-core-effects/src/handlers/mod.rs
+++ b/packages/doeff-core-effects/src/handlers/mod.rs
@@ -28,6 +28,8 @@ use crate::segment::ScopeStore;
 use crate::step::{PyException, PythonCall};
 use crate::value::Value;
 use crate::vm::RustStore;
+use doeff_vm_core::opaque_ref::OpaqueRef;
+use doeff_vm_core::py_shared::OpaqueRefPyExt;
 use doeff_vm_core::{IRStreamFactory, IRStreamFactoryRef, IRStreamProgram, IRStreamProgramRef};
 
 enum ParsedStateEffect {
@@ -179,7 +181,7 @@ fn wrap_value_as_result_ok(value: Value) -> Result<Value, PyException> {
             },
         )
         .map_err(|e| pyerr_to_exception(py, e))?;
-        Ok(Value::Python(wrapped.into_any().unbind()))
+        Ok(Value::Opaque(OpaqueRef::new(wrapped.into_any().unbind())))
     })
 }
 
@@ -193,12 +195,12 @@ fn wrap_exception_as_result_err(error: PyException) -> Result<Value, PyException
             },
         )
         .map_err(|e| pyerr_to_exception(py, e))?;
-        Ok(Value::Python(wrapped.into_any().unbind()))
+        Ok(Value::Opaque(OpaqueRef::new(wrapped.into_any().unbind())))
     })
 }
 
 fn as_lazy_eval_expr(value: &Value) -> Option<PyShared> {
-    let Value::Python(obj) = value else {
+    let Value::Opaque(obj) = value else {
         return None;
     };
 
@@ -218,7 +220,7 @@ fn as_lazy_eval_expr(value: &Value) -> Option<PyShared> {
 }
 
 fn lazy_source_id(value: &Value) -> Option<usize> {
-    let Value::Python(obj) = value else {
+    let Value::Opaque(obj) = value else {
         return None;
     };
     Python::attach(|py| Some(obj.bind(py).as_ptr() as usize))
@@ -235,7 +237,7 @@ fn lazy_ask_create_semaphore_effect() -> Result<DispatchEffect, PyException> {
 }
 
 fn lazy_ask_acquire_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect, PyException> {
-    let Value::Python(semaphore_obj) = semaphore else {
+    let Value::Opaque(semaphore_obj) = semaphore else {
         return Err(PyException::type_error(format!(
             "CreateSemaphore returned non-semaphore value: {:?}",
             semaphore
@@ -252,7 +254,7 @@ fn lazy_ask_acquire_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect
 }
 
 fn lazy_ask_release_semaphore_effect(semaphore: &Value) -> Result<DispatchEffect, PyException> {
-    let Value::Python(semaphore_obj) = semaphore else {
+    let Value::Opaque(semaphore_obj) = semaphore else {
         return Err(PyException::type_error(format!(
             "CreateSemaphore returned non-semaphore value: {:?}",
             semaphore
@@ -327,7 +329,7 @@ impl IRStreamFactory for AwaitHandlerFactory {
         let Some(obj) = dispatch_ref_as_python(effect) else {
             return Ok(false);
         };
-        parse_await_python_effect(obj)
+        parse_await_python_effect(&obj)
             .map(|parsed| parsed.is_some())
             .map_err(|msg| {
                 VMError::internal(format!(
@@ -386,8 +388,8 @@ impl IRStreamProgram for AwaitHandlerProgram {
                     };
                     self.pending_k = Some(k);
                     IRStreamStep::NeedsPython(PythonCall::CallFunc {
-                        func: runner,
-                        args: vec![Value::Python(awaitable)],
+                        func: runner.into_opaque(),
+                        args: vec![Value::Opaque(OpaqueRef::new(awaitable))],
                         kwargs: vec![],
                     })
                 }
@@ -490,7 +492,7 @@ impl IRStreamFactory for StateHandlerFactory {
             return Ok(false);
         };
 
-        parse_state_python_effect(obj)
+        parse_state_python_effect(&obj)
             .map(|parsed| parsed.is_some())
             .map_err(|msg| {
                 VMError::internal(format!(
@@ -574,7 +576,7 @@ impl IRStreamProgram for StateHandlerProgram {
             self.pending_k = Some(k);
             self.pending_old_value = Some(old_value.clone());
             return IRStreamStep::NeedsPython(PythonCall::CallFunc {
-                func: modifier,
+                func: modifier.into_opaque(),
                 args: vec![old_value],
                 kwargs: vec![],
             });
@@ -605,7 +607,7 @@ impl IRStreamProgram for StateHandlerProgram {
                         self.pending_k = Some(k);
                         self.pending_old_value = Some(old_value.clone());
                         IRStreamStep::NeedsPython(PythonCall::CallFunc {
-                            func: modifier,
+                            func: modifier.into_opaque(),
                             args: vec![old_value],
                             kwargs: vec![],
                         })
@@ -769,7 +771,7 @@ impl IRStreamFactory for LazyAskHandlerFactory {
             return Ok(false);
         };
 
-        let is_reader = parse_reader_python_effect(obj)
+        let is_reader = parse_reader_python_effect(&obj)
             .map(|parsed| parsed.is_some())
             .map_err(|msg| {
                 VMError::internal(format!(
@@ -777,7 +779,7 @@ impl IRStreamFactory for LazyAskHandlerFactory {
                 ))
             })?;
 
-        Ok(is_reader || is_local_python_effect(obj))
+        Ok(is_reader || is_local_python_effect(&obj))
     }
 
     fn create_program(&self) -> IRStreamProgramRef {
@@ -1047,7 +1049,7 @@ impl IRStreamProgram for LazyAskHandlerProgram {
                         semaphore_snapshot,
                     };
                     return IRStreamStep::Yield(DoCtrl::EvalInScope {
-                        expr: local_effect.sub_program,
+                        expr: local_effect.sub_program.into_opaque(),
                         scope: eval_scope,
                         metadata: None,
                     });
@@ -1116,7 +1118,7 @@ impl IRStreamProgram for LazyAskHandlerProgram {
             } => {
                 let Some(semaphore) = semaphore else {
                     let semaphore = match value {
-                        Value::Python(_) => value,
+                        Value::Opaque(_) => value,
                         Value::Unit
                         | Value::Int(_)
                         | Value::String(_)
@@ -1154,7 +1156,7 @@ impl IRStreamProgram for LazyAskHandlerProgram {
                     semaphore,
                 };
                 IRStreamStep::Yield(DoCtrl::EvalInScope {
-                    expr,
+                    expr: expr.into_opaque(),
                     scope: eval_scope,
                     metadata: None,
                 })
@@ -1264,7 +1266,7 @@ impl IRStreamFactory for ReaderHandlerFactory {
             return Ok(false);
         };
 
-        parse_reader_python_effect(obj)
+        parse_reader_python_effect(&obj)
             .map(|parsed| parsed.is_some())
             .map_err(|msg| {
                 VMError::internal(format!(
@@ -1416,7 +1418,7 @@ impl IRStreamFactory for WriterHandlerFactory {
             return Ok(false);
         };
 
-        parse_writer_python_effect(obj)
+        parse_writer_python_effect(&obj)
             .map(|parsed| parsed.is_some())
             .map_err(|msg| {
                 VMError::internal(format!(
@@ -1547,7 +1549,7 @@ impl IRStreamFactory for ResultSafeHandlerFactory {
             return Ok(false);
         };
 
-        parse_result_safe_python_effect(obj)
+        parse_result_safe_python_effect(&obj)
             .map(|parsed| parsed.is_some())
             .map_err(|msg| {
                 VMError::internal(format!(
@@ -1626,7 +1628,7 @@ impl IRStreamProgram for ResultSafeHandlerProgram {
                     let eval_scope = k.clone();
                     self.phase = ResultSafePhase::AwaitEval { continuation: k };
                     IRStreamStep::Yield(DoCtrl::EvalInScope {
-                        expr: sub_program,
+                        expr: sub_program.into_opaque(),
                         scope: eval_scope,
                         metadata: None,
                     })
@@ -1779,7 +1781,7 @@ impl IRStreamProgram for DoubleCallHandlerProgram {
                     modifier: modifier.clone(),
                 };
                 IRStreamStep::NeedsPython(PythonCall::CallFunc {
-                    func: modifier,
+                    func: modifier.into_opaque(),
                     args: vec![Value::Int(10)],
                     kwargs: vec![],
                 })
@@ -1803,7 +1805,7 @@ impl IRStreamProgram for DoubleCallHandlerProgram {
                     first_result: value.clone(),
                 };
                 IRStreamStep::NeedsPython(PythonCall::CallFunc {
-                    func: modifier,
+                    func: modifier.into_opaque(),
                     args: vec![value],
                     kwargs: vec![],
                 })
@@ -2387,7 +2389,7 @@ mod tests {
             };
             match ok_step {
                 IRStreamStep::Yield(DoCtrl::Resume {
-                    value: Value::Python(obj),
+                    value: Value::Opaque(obj),
                     ..
                 }) => {
                     let bound = obj.bind(py);
@@ -2412,7 +2414,7 @@ mod tests {
 
             match err_step {
                 IRStreamStep::Yield(DoCtrl::Resume {
-                    value: Value::Python(obj),
+                    value: Value::Opaque(obj),
                     ..
                 }) => {
                     let bound = obj.bind(py);

--- a/packages/doeff-core-effects/src/scheduler/mod.rs
+++ b/packages/doeff-core-effects/src/scheduler/mod.rs
@@ -29,6 +29,7 @@ use crate::ids::{ContId, DispatchId, PromiseId, TaskId};
 use crate::ir_stream::{IRStream, IRStreamStep, StreamLocation};
 use crate::kleisli::{DgfnKleisli, KleisliRef};
 use crate::py_shared::PyShared;
+use doeff_vm_core::opaque_ref::OpaqueRef;
 use crate::pyvm::{PyResultErr, PyResultOk, PyRustHandlerSentinel};
 use crate::segment::ScopeStore;
 use crate::step::{DoCtrl, PyException, PythonCall};
@@ -916,7 +917,7 @@ fn make_python_semaphore_value(semaphore_id: u64, state_id: u64) -> Result<Value
                 ))
             })?
             .into_any();
-        Ok(Value::Python(semaphore.unbind()))
+        Ok(Value::Opaque(OpaqueRef::new(semaphore.unbind())))
     })
 }
 
@@ -941,7 +942,7 @@ fn make_async_external_wait_step() -> Result<IRStreamStep, PyException> {
             ))
         })?;
         Ok(IRStreamStep::NeedsPython(PythonCall::CallAsync {
-            func: PyShared::new(sleep.unbind()),
+            func: OpaqueRef::new(sleep.unbind()),
             args: vec![Value::Int(0)],
         }))
     })
@@ -2515,7 +2516,7 @@ impl SchedulerProgram {
                 }
             }
 
-            resume_to_continuation(k_user, Value::Python(context))
+            resume_to_continuation(k_user, Value::Opaque(OpaqueRef::new(context)))
         })
     }
 
@@ -2762,7 +2763,7 @@ impl IRStreamProgram for SchedulerProgram {
                     k_user,
                     Value::ExternalPromise(ExternalPromise {
                         id: pid,
-                        completion_queue: Some(completion_queue),
+                        completion_queue: Some(completion_queue.into_opaque()),
                     }),
                 )
             }
@@ -2852,7 +2853,7 @@ impl IRStreamProgram for SchedulerProgram {
             SchedulerPhase::SpawnAwaitTraceback { k_user, effect } => {
                 let traceback = match value {
                     Value::Traceback(hops) => hops,
-                    Value::Python(_)
+                    Value::Opaque(_)
                     | Value::Unit
                     | Value::Int(_)
                     | Value::String(_)
@@ -2942,7 +2943,7 @@ impl IRStreamProgram for SchedulerProgram {
                 };
 
                 IRStreamStep::Yield(DoCtrl::CreateContinuation {
-                    expr: PyShared::new(program),
+                    expr: OpaqueRef::new(program),
                     handlers,
                     handler_identities: vec![],
                 })
@@ -2958,7 +2959,7 @@ impl IRStreamProgram for SchedulerProgram {
             } => {
                 let handlers = match value {
                     Value::Handlers(hs) => hs,
-                    Value::Python(_)
+                    Value::Opaque(_)
                     | Value::Unit
                     | Value::Int(_)
                     | Value::String(_)
@@ -2989,7 +2990,7 @@ impl IRStreamProgram for SchedulerProgram {
                 };
 
                 IRStreamStep::Yield(DoCtrl::CreateContinuation {
-                    expr: PyShared::new(program),
+                    expr: OpaqueRef::new(program),
                     handlers,
                     handler_identities: vec![],
                 })
@@ -3005,7 +3006,7 @@ impl IRStreamProgram for SchedulerProgram {
                 // Value should be the continuation created by CreateContinuation
                 let cont = match value {
                     Value::Continuation(c) => c,
-                    Value::Python(_)
+                    Value::Opaque(_)
                     | Value::Unit
                     | Value::Int(_)
                     | Value::String(_)
@@ -3216,7 +3217,7 @@ impl IRStreamFactory for SchedulerHandler {
             return Ok(false);
         };
 
-        match parse_scheduler_python_effect(obj, None) {
+        match parse_scheduler_python_effect(&obj, None) {
             Ok(Some(_)) | Err(_) => Ok(true),
             Ok(None) => Ok(false),
         }
@@ -3441,7 +3442,7 @@ mod tests {
                 }),
                 IRStreamStep::Yield(DoCtrl::GetHandlers),
                 IRStreamStep::Yield(DoCtrl::CreateContinuation {
-                    expr: expr.clone(),
+                    expr: expr.clone().into_opaque(),
                     handlers: vec![],
                     handler_identities: vec![],
                 }),

--- a/packages/doeff-vm-core/src/capture.rs
+++ b/packages/doeff-vm-core/src/capture.rs
@@ -1,8 +1,7 @@
 //! Unified traceback capture and assembly types.
 
-use pyo3::prelude::*;
-
 use crate::ids::DispatchId;
+use crate::opaque_ref::OpaqueRef;
 
 /// Unique identifier for a program frame instance.
 pub type FrameId = u64;
@@ -123,7 +122,7 @@ pub enum ActiveChainEntry {
         result: EffectResult,
     },
     ContextEntry {
-        data: Py<PyAny>,
+        data: OpaqueRef,
     },
     ExceptionSite {
         function_name: String,

--- a/packages/doeff-vm-core/src/continuation.rs
+++ b/packages/doeff-vm-core/src/continuation.rs
@@ -9,7 +9,8 @@ use crate::frame::CallMetadata;
 use crate::frame::Frame;
 use crate::ids::{ContId, DispatchId, Marker, SegmentId};
 use crate::kleisli::KleisliRef;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::OpaqueRefPyExt;
 use crate::segment::{ScopeStore, Segment};
 use crate::step::{Mode, PendingPython, PyException};
 use crate::value::Value;
@@ -45,7 +46,7 @@ pub struct Continuation {
     /// started=false => created (unstarted) continuation
     pub started: bool,
 
-    pub program: Option<PyShared>,
+    pub program: Option<OpaqueRef>,
 
     /// Handlers to install when started=false (innermost first).
     /// Empty for captured (started=true) continuations.
@@ -53,7 +54,7 @@ pub struct Continuation {
 
     /// Optional Python identities corresponding to handlers by index.
     /// Used to preserve Rust sentinel identity across continuation round-trips.
-    pub handler_identities: Vec<Option<PyShared>>,
+    pub handler_identities: Vec<Option<OpaqueRef>>,
 
     /// Optional call metadata to attach when starting unstarted continuations.
     pub metadata: Option<CallMetadata>,
@@ -133,12 +134,12 @@ impl Continuation {
         }
     }
 
-    pub fn create_unstarted(expr: PyShared, handlers: Vec<KleisliRef>) -> Self {
+    pub fn create_unstarted(expr: OpaqueRef, handlers: Vec<KleisliRef>) -> Self {
         Self::create_unstarted_with_metadata(expr, handlers, None)
     }
 
     pub fn create_unstarted_with_metadata(
-        expr: PyShared,
+        expr: OpaqueRef,
         handlers: Vec<KleisliRef>,
         metadata: Option<CallMetadata>,
     ) -> Self {
@@ -165,9 +166,9 @@ impl Continuation {
     }
 
     pub fn create_unstarted_with_identities(
-        expr: PyShared,
+        expr: OpaqueRef,
         handlers: Vec<KleisliRef>,
-        handler_identities: Vec<Option<PyShared>>,
+        handler_identities: Vec<Option<OpaqueRef>>,
     ) -> Self {
         Self::create_unstarted_with_identities_and_metadata(
             expr,
@@ -178,9 +179,9 @@ impl Continuation {
     }
 
     pub fn create_unstarted_with_identities_and_metadata(
-        expr: PyShared,
+        expr: OpaqueRef,
         handlers: Vec<KleisliRef>,
-        handler_identities: Vec<Option<PyShared>>,
+        handler_identities: Vec<Option<OpaqueRef>>,
         metadata: Option<CallMetadata>,
     ) -> Self {
         Continuation {

--- a/packages/doeff-vm-core/src/debug_state.rs
+++ b/packages/doeff-vm-core/src/debug_state.rs
@@ -5,9 +5,10 @@ use pyo3::prelude::*;
 use crate::arena::SegmentArena;
 use crate::do_ctrl::DoCtrl;
 use crate::driver::{Mode, PyException, StepEvent};
-use crate::effect::{dispatch_ref_as_python, DispatchEffect};
+use crate::effect::{dispatch_ref_as_opaque, DispatchEffect};
 use crate::frame::{CallMetadata, Frame};
 use crate::ids::SegmentId;
+use crate::py_shared::OpaqueRefPyExt;
 use crate::python_call::{PendingPython, PythonCall};
 use crate::value::Value;
 use crate::vm::{DebugConfig, DebugLevel, ModeFormatVerbosity, TraceEvent};
@@ -73,7 +74,7 @@ impl DebugState {
     pub(crate) fn value_repr(value: &Value) -> Option<String> {
         let repr = match value {
             Value::None | Value::Unit => "None".to_string(),
-            Value::Python(obj) => Python::attach(|py| {
+            Value::Opaque(obj) => Python::attach(|py| {
                 obj.bind(py)
                     .repr()
                     .map(|v| v.to_string())
@@ -113,7 +114,7 @@ impl DebugState {
     }
 
     pub(crate) fn effect_repr(effect: &DispatchEffect) -> String {
-        let repr = if let Some(obj) = dispatch_ref_as_python(effect) {
+        let repr = if let Some(obj) = dispatch_ref_as_opaque(effect) {
             Python::attach(|py| {
                 obj.bind(py)
                     .repr()

--- a/packages/doeff-vm-core/src/dispatch.rs
+++ b/packages/doeff-vm-core/src/dispatch.rs
@@ -1,7 +1,7 @@
 //! Dispatch-facing effect aliases re-exported for compatibility.
 
 pub use crate::effect::{
-    dispatch_from_shared, dispatch_into_python, dispatch_ref_as_python, dispatch_to_pyobject,
-    make_execution_context_object, make_get_execution_context_effect, DispatchEffect, Effect,
-    PyEffectBase, PyExecutionContext, PyGetExecutionContext,
+    dispatch_from_opaque, dispatch_from_shared, dispatch_into_opaque, dispatch_ref_as_opaque,
+    dispatch_to_pyobject, make_execution_context_object, make_get_execution_context_effect,
+    DispatchEffect, Effect, PyEffectBase, PyExecutionContext, PyGetExecutionContext,
 };

--- a/packages/doeff-vm-core/src/do_ctrl.rs
+++ b/packages/doeff-vm-core/src/do_ctrl.rs
@@ -1,14 +1,12 @@
 //! DoCtrl primitives.
 
-use pyo3::prelude::*;
-
 use crate::continuation::Continuation;
 use crate::driver::PyException;
 use crate::effect::DispatchEffect;
 use crate::frame::CallMetadata;
 use crate::ir_stream::IRStreamRef;
 use crate::kleisli::KleisliRef;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
 use crate::value::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,13 +45,13 @@ pub enum DoCtrl {
         value: Value,
     },
     Map {
-        source: PyShared,
-        mapper: PyShared,
+        source: OpaqueRef,
+        mapper: OpaqueRef,
         mapper_meta: CallMetadata,
     },
     FlatMap {
-        source: PyShared,
-        binder: PyShared,
+        source: OpaqueRef,
+        binder: OpaqueRef,
         binder_meta: CallMetadata,
     },
     Perform {
@@ -78,12 +76,12 @@ pub enum DoCtrl {
     WithHandler {
         handler: KleisliRef,
         body: Box<DoCtrl>,
-        types: Option<Vec<PyShared>>,
+        types: Option<Vec<OpaqueRef>>,
     },
     WithIntercept {
         interceptor: KleisliRef,
         body: Box<DoCtrl>,
-        types: Option<Vec<PyShared>>,
+        types: Option<Vec<OpaqueRef>>,
         mode: InterceptMode,
         metadata: Option<CallMetadata>,
     },
@@ -103,16 +101,16 @@ pub enum DoCtrl {
         continuation: Continuation,
     },
     CreateContinuation {
-        expr: PyShared,
+        expr: OpaqueRef,
         handlers: Vec<KleisliRef>,
-        handler_identities: Vec<Option<PyShared>>,
+        handler_identities: Vec<Option<OpaqueRef>>,
     },
     ResumeContinuation {
         continuation: Continuation,
         value: Value,
     },
     PythonAsyncSyntaxEscape {
-        action: Py<PyAny>,
+        action: OpaqueRef,
     },
     Apply {
         f: Box<DoCtrl>,
@@ -131,174 +129,16 @@ pub enum DoCtrl {
         metadata: Option<CallMetadata>,
     },
     Eval {
-        expr: PyShared,
+        expr: OpaqueRef,
         metadata: Option<CallMetadata>,
     },
     EvalInScope {
-        expr: PyShared,
+        expr: OpaqueRef,
         scope: Continuation,
         metadata: Option<CallMetadata>,
     },
     // DEPRECATED (INTROSPECT-UNIFY-001): use GetExecutionContext for handler-aware introspection.
     GetCallStack,
-}
-
-impl DoCtrl {
-    pub fn clone_ref(&self, py: Python<'_>) -> Self {
-        match self {
-            DoCtrl::Pure { value } => DoCtrl::Pure {
-                value: value.clone(),
-            },
-            DoCtrl::Map {
-                source,
-                mapper,
-                mapper_meta,
-            } => DoCtrl::Map {
-                source: source.clone(),
-                mapper: mapper.clone(),
-                mapper_meta: mapper_meta.clone(),
-            },
-            DoCtrl::FlatMap {
-                source,
-                binder,
-                binder_meta,
-            } => DoCtrl::FlatMap {
-                source: source.clone(),
-                binder: binder.clone(),
-                binder_meta: binder_meta.clone(),
-            },
-            DoCtrl::Perform { effect } => DoCtrl::Perform {
-                effect: effect.clone(),
-            },
-            DoCtrl::Resume {
-                continuation,
-                value,
-            } => DoCtrl::Resume {
-                continuation: continuation.clone(),
-                value: value.clone(),
-            },
-            DoCtrl::Transfer {
-                continuation,
-                value,
-            } => DoCtrl::Transfer {
-                continuation: continuation.clone(),
-                value: value.clone(),
-            },
-            DoCtrl::TransferThrow {
-                continuation,
-                exception,
-            } => DoCtrl::TransferThrow {
-                continuation: continuation.clone(),
-                exception: exception.clone_ref(py),
-            },
-            DoCtrl::ResumeThrow {
-                continuation,
-                exception,
-            } => DoCtrl::ResumeThrow {
-                continuation: continuation.clone(),
-                exception: exception.clone_ref(py),
-            },
-            DoCtrl::WithHandler {
-                handler,
-                body,
-                types,
-            } => DoCtrl::WithHandler {
-                handler: handler.clone(),
-                body: body.clone(),
-                types: types.clone(),
-            },
-            DoCtrl::WithIntercept {
-                interceptor,
-                body,
-                types,
-                mode,
-                metadata,
-            } => DoCtrl::WithIntercept {
-                interceptor: interceptor.clone(),
-                body: body.clone(),
-                types: types.clone(),
-                mode: *mode,
-                metadata: metadata.clone(),
-            },
-            DoCtrl::Discontinue {
-                continuation,
-                exception,
-            } => DoCtrl::Discontinue {
-                continuation: continuation.clone(),
-                exception: exception.clone_ref(py),
-            },
-            DoCtrl::Delegate { effect } => DoCtrl::Delegate {
-                effect: effect.clone(),
-            },
-            DoCtrl::Pass { effect } => DoCtrl::Pass {
-                effect: effect.clone(),
-            },
-            DoCtrl::GetContinuation => DoCtrl::GetContinuation,
-            DoCtrl::GetHandlers => DoCtrl::GetHandlers,
-            DoCtrl::GetTraceback { continuation } => DoCtrl::GetTraceback {
-                continuation: continuation.clone(),
-            },
-            DoCtrl::CreateContinuation {
-                expr,
-                handlers,
-                handler_identities,
-            } => DoCtrl::CreateContinuation {
-                expr: PyShared::new(expr.clone_ref(py)),
-                handlers: handlers.clone(),
-                handler_identities: handler_identities.clone(),
-            },
-            DoCtrl::ResumeContinuation {
-                continuation,
-                value,
-            } => DoCtrl::ResumeContinuation {
-                continuation: continuation.clone(),
-                value: value.clone(),
-            },
-            DoCtrl::PythonAsyncSyntaxEscape { action } => DoCtrl::PythonAsyncSyntaxEscape {
-                action: action.clone_ref(py),
-            },
-            DoCtrl::Apply {
-                f,
-                args,
-                kwargs,
-                metadata,
-            } => DoCtrl::Apply {
-                f: f.clone(),
-                args: args.clone(),
-                kwargs: kwargs.clone(),
-                metadata: metadata.clone(),
-            },
-            DoCtrl::Expand {
-                factory,
-                args,
-                kwargs,
-                metadata,
-            } => DoCtrl::Expand {
-                factory: factory.clone(),
-                args: args.clone(),
-                kwargs: kwargs.clone(),
-                metadata: metadata.clone(),
-            },
-            DoCtrl::IRStream { stream, metadata } => DoCtrl::IRStream {
-                stream: stream.clone(),
-                metadata: metadata.clone(),
-            },
-            DoCtrl::Eval { expr, metadata } => DoCtrl::Eval {
-                expr: PyShared::new(expr.clone_ref(py)),
-                metadata: metadata.clone(),
-            },
-            DoCtrl::EvalInScope {
-                expr,
-                scope,
-                metadata,
-            } => DoCtrl::EvalInScope {
-                expr: PyShared::new(expr.clone_ref(py)),
-                scope: scope.clone(),
-                metadata: metadata.clone(),
-            },
-            DoCtrl::GetCallStack => DoCtrl::GetCallStack,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/packages/doeff-vm-core/src/driver.rs
+++ b/packages/doeff-vm-core/src/driver.rs
@@ -4,16 +4,17 @@ use pyo3::prelude::*;
 
 use crate::do_ctrl::DoCtrl;
 use crate::error::VMError;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::{OpaqueRefPyExt, PyShared};
 use crate::python_call::PythonCall;
 use crate::value::Value;
 
 #[derive(Debug, Clone)]
 pub enum PyException {
     Materialized {
-        exc_type: PyShared,
-        exc_value: PyShared,
-        exc_tb: Option<PyShared>,
+        exc_type: OpaqueRef,
+        exc_value: OpaqueRef,
+        exc_tb: Option<OpaqueRef>,
     },
     RuntimeError {
         message: String,
@@ -42,9 +43,9 @@ pub enum StepEvent {
 impl PyException {
     pub fn new(exc_type: Py<PyAny>, exc_value: Py<PyAny>, exc_tb: Option<Py<PyAny>>) -> Self {
         PyException::Materialized {
-            exc_type: PyShared::new(exc_type),
-            exc_value: PyShared::new(exc_value),
-            exc_tb: exc_tb.map(PyShared::new),
+            exc_type: OpaqueRef::new(exc_type),
+            exc_value: OpaqueRef::new(exc_value),
+            exc_tb: exc_tb.map(OpaqueRef::new),
         }
     }
 
@@ -82,26 +83,6 @@ impl PyException {
 
     pub fn to_pyerr(&self, py: Python<'_>) -> PyErr {
         PyErr::from_value(self.value_clone_ref(py).bind(py).clone())
-    }
-
-    pub fn clone_ref(&self, py: Python<'_>) -> Self {
-        match self {
-            PyException::Materialized {
-                exc_type,
-                exc_value,
-                exc_tb,
-            } => PyException::Materialized {
-                exc_type: PyShared::new(exc_type.clone_ref(py)),
-                exc_value: PyShared::new(exc_value.clone_ref(py)),
-                exc_tb: exc_tb.as_ref().map(|tb| PyShared::new(tb.clone_ref(py))),
-            },
-            PyException::RuntimeError { message } => PyException::RuntimeError {
-                message: message.clone(),
-            },
-            PyException::TypeError { message } => PyException::TypeError {
-                message: message.clone(),
-            },
-        }
     }
 }
 

--- a/packages/doeff-vm-core/src/effect.rs
+++ b/packages/doeff-vm-core/src/effect.rs
@@ -3,13 +3,14 @@
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::{OpaqueRefPyExt, PyShared};
 use crate::pyvm::DoExprTag;
 
 #[derive(Debug, Clone)]
-pub struct Effect(pub PyShared);
+pub struct Effect(pub OpaqueRef);
 
-pub type DispatchEffect = PyShared;
+pub type DispatchEffect = OpaqueRef;
 
 #[pyclass(subclass, frozen, name = "EffectBase")]
 pub struct PyEffectBase {
@@ -85,14 +86,18 @@ impl PyExecutionContext {
 }
 
 pub fn dispatch_from_shared(obj: PyShared) -> DispatchEffect {
+    obj.into_opaque()
+}
+
+pub fn dispatch_from_opaque(obj: OpaqueRef) -> DispatchEffect {
     obj
 }
 
-pub fn dispatch_ref_as_python(effect: &DispatchEffect) -> Option<&PyShared> {
+pub fn dispatch_ref_as_opaque(effect: &DispatchEffect) -> Option<&OpaqueRef> {
     Some(effect)
 }
 
-pub fn dispatch_into_python(effect: DispatchEffect) -> Option<PyShared> {
+pub fn dispatch_into_opaque(effect: DispatchEffect) -> Option<OpaqueRef> {
     Some(effect)
 }
 
@@ -128,20 +133,24 @@ impl Effect {
         false
     }
 
-    pub fn as_python(&self) -> Option<&PyShared> {
+    pub fn as_opaque(&self) -> Option<&OpaqueRef> {
         Some(&self.0)
     }
 
-    pub fn from_shared(obj: PyShared) -> Self {
+    pub fn from_opaque(obj: OpaqueRef) -> Self {
         Effect(obj)
     }
 
-    pub fn into_python(self) -> Option<PyShared> {
+    pub fn from_shared(obj: PyShared) -> Self {
+        Effect(obj.into_opaque())
+    }
+
+    pub fn into_opaque(self) -> Option<OpaqueRef> {
         Some(self.0)
     }
 
     pub fn type_name(&self) -> &'static str {
-        "Python"
+        "Opaque"
     }
 
     pub fn python(obj: Py<PyAny>) -> Self {
@@ -149,9 +158,9 @@ impl Effect {
     }
 
     pub fn to_pyobject<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        if let Some(obj) = self.as_python() {
+        if let Some(obj) = self.as_opaque() {
             return Ok(obj.bind(py).clone());
         }
-        unreachable!("runtime Effect is always Python")
+        unreachable!("runtime Effect is always Opaque")
     }
 }

--- a/packages/doeff-vm-core/src/frame.rs
+++ b/packages/doeff-vm-core/src/frame.rs
@@ -9,7 +9,7 @@ use crate::do_ctrl::DoCtrl;
 use crate::effect::DispatchEffect;
 use crate::ids::{DispatchId, Marker, SegmentId};
 use crate::ir_stream::IRStreamRef;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
 
 static NEXT_FRAME_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -28,7 +28,7 @@ pub struct CallMetadata {
     pub source_file: String,
     pub source_line: u32,
     pub args_repr: Option<String>,
-    pub program_call: Option<PyShared>,
+    pub program_call: Option<OpaqueRef>,
 }
 
 impl CallMetadata {
@@ -37,7 +37,7 @@ impl CallMetadata {
         source_file: String,
         source_line: u32,
         args_repr: Option<String>,
-        program_call: Option<PyShared>,
+        program_call: Option<OpaqueRef>,
     ) -> Self {
         CallMetadata {
             frame_id: fresh_frame_id(),
@@ -71,7 +71,7 @@ impl CallMetadata {
 pub struct InterceptorContinuation {
     pub marker: Marker,
     pub original_yielded: DoCtrl,
-    pub original_obj: PyShared,
+    pub original_obj: OpaqueRef,
     pub emitter_stream: IRStreamRef,
     pub emitter_metadata: Option<CallMetadata>,
     pub emitter_handler_kind: Option<HandlerKind>,
@@ -147,12 +147,12 @@ pub enum Frame {
     },
     EvalReturn(Box<EvalReturnContinuation>),
     MapReturn {
-        mapper: PyShared,
+        mapper: OpaqueRef,
         mapper_meta: CallMetadata,
     },
     FlatMapBindResult,
     FlatMapBindSource {
-        binder: PyShared,
+        binder: OpaqueRef,
         binder_meta: CallMetadata,
     },
     InterceptBodyReturn {

--- a/packages/doeff-vm-core/src/ir_stream.rs
+++ b/packages/doeff-vm-core/src/ir_stream.rs
@@ -7,7 +7,8 @@ use pyo3::prelude::*;
 
 use crate::do_ctrl::DoCtrl;
 use crate::driver::PyException;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::{OpaqueRefPyExt, PyShared};
 use crate::python_call::PythonCall;
 use crate::segment::ScopeStore;
 use crate::value::Value;
@@ -29,7 +30,7 @@ pub trait IRStream: fmt::Debug + Send {
     fn debug_location(&self) -> Option<StreamLocation> {
         None
     }
-    fn python_generator(&self) -> Option<PyShared> {
+    fn python_generator(&self) -> Option<OpaqueRef> {
         None
     }
 }
@@ -53,8 +54,8 @@ pub struct StreamLocation {
 }
 
 pub struct PythonGeneratorStream {
-    generator: PyShared,
-    get_frame: PyShared,
+    generator: OpaqueRef,
+    get_frame: OpaqueRef,
     started: bool,
 }
 
@@ -67,12 +68,17 @@ impl fmt::Debug for PythonGeneratorStream {
 }
 
 impl PythonGeneratorStream {
-    pub fn new(generator: PyShared, get_frame: PyShared) -> Self {
+    pub fn new(generator: OpaqueRef, get_frame: OpaqueRef) -> Self {
         PythonGeneratorStream {
             generator,
             get_frame,
             started: false,
         }
+    }
+
+    /// Legacy constructor from PyShared (bridge convenience).
+    pub fn from_py_shared(generator: PyShared, get_frame: PyShared) -> Self {
+        Self::new(generator.into_opaque(), get_frame.into_opaque())
     }
 
     fn resolve_location(&self, py: Python<'_>) -> Option<StreamLocation> {
@@ -128,7 +134,7 @@ impl IRStream for PythonGeneratorStream {
         Python::attach(|py| self.resolve_location(py))
     }
 
-    fn python_generator(&self) -> Option<PyShared> {
+    fn python_generator(&self) -> Option<OpaqueRef> {
         Some(self.generator.clone())
     }
 }
@@ -162,7 +168,7 @@ mod tests {
                 .unbind();
 
             let mut stream =
-                PythonGeneratorStream::new(PyShared::new(generator), PyShared::new(get_frame));
+                PythonGeneratorStream::new(OpaqueRef::new(generator), OpaqueRef::new(get_frame));
             let mut store = RustStore::new();
             let mut scope = ScopeStore::default();
 
@@ -205,7 +211,7 @@ mod tests {
                 .unbind();
 
             let mut stream =
-                PythonGeneratorStream::new(PyShared::new(generator), PyShared::new(get_frame));
+                PythonGeneratorStream::new(OpaqueRef::new(generator), OpaqueRef::new(get_frame));
             let mut store = RustStore::new();
             let mut scope = ScopeStore::default();
             let step = stream.throw(PyException::runtime_error("boom"), &mut store, &mut scope);
@@ -238,7 +244,7 @@ mod tests {
                 .expect("_get_frame missing")
                 .unbind();
             let stream =
-                PythonGeneratorStream::new(PyShared::new(generator), PyShared::new(get_frame));
+                PythonGeneratorStream::new(OpaqueRef::new(generator), OpaqueRef::new(get_frame));
 
             let location = stream
                 .debug_location()

--- a/packages/doeff-vm-core/src/kleisli.rs
+++ b/packages/doeff-vm-core/src/kleisli.rs
@@ -9,12 +9,13 @@ use pyo3::types::{PyDict, PyTuple};
 use crate::continuation::Continuation;
 use crate::do_ctrl::DoCtrl;
 use crate::doeff_generator::{DoeffGenerator, DoeffGeneratorFn};
-use crate::effect::{dispatch_from_shared, DispatchEffect};
+use crate::effect::{dispatch_from_opaque, DispatchEffect};
 use crate::error::VMError;
 use crate::frame::CallMetadata;
 use crate::handler::{IRStreamFactoryRef, IRStreamProgramRef};
 use crate::ir_stream::{IRStream, IRStreamRef, IRStreamStep, PythonGeneratorStream};
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::{OpaqueRefPyExt, PyShared};
 use crate::pyvm::PyK;
 use crate::segment::ScopeStore;
 use crate::value::Value;
@@ -60,8 +61,8 @@ pub trait Kleisli: std::fmt::Debug + Send + Sync {
         self.debug_info().name
     }
 
-    /// Optional Python identity for handler self-exclusion (OCaml semantics).
-    fn py_identity(&self) -> Option<PyShared> {
+    /// Optional identity for handler self-exclusion (OCaml semantics).
+    fn py_identity(&self) -> Option<OpaqueRef> {
         None
     }
 
@@ -87,15 +88,15 @@ pub trait Kleisli: std::fmt::Debug + Send + Sync {
 /// Shared reference to a Kleisli arrow.
 pub type KleisliRef = Arc<dyn Kleisli>;
 
-/// Kleisli wrapper that preserves a specific Python identity object.
+/// Kleisli wrapper that preserves a specific identity object.
 #[derive(Debug, Clone)]
 pub struct IdentityKleisli {
     inner: KleisliRef,
-    identity: PyShared,
+    identity: OpaqueRef,
 }
 
 impl IdentityKleisli {
-    pub fn new(inner: KleisliRef, identity: PyShared) -> Self {
+    pub fn new(inner: KleisliRef, identity: OpaqueRef) -> Self {
         Self { inner, identity }
     }
 }
@@ -118,7 +119,7 @@ impl Kleisli for IdentityKleisli {
         self.inner.debug_info()
     }
 
-    fn py_identity(&self) -> Option<PyShared> {
+    fn py_identity(&self) -> Option<OpaqueRef> {
         Some(self.identity.clone())
     }
 
@@ -346,7 +347,7 @@ impl PyKleisli {
             Value::Continuation(k) => Bound::new(py, PyK::from_cont_id(k.cont_id))
                 .map(|obj| obj.into_any())
                 .map_err(Self::map_pyerr),
-            Value::Python(_)
+            Value::Opaque(_)
             | Value::Unit
             | Value::Int(_)
             | Value::String(_)
@@ -411,7 +412,10 @@ impl Kleisli for PyKleisli {
             (produced.unbind(), Self::default_get_frame(py)?)
         };
 
-        let stream = PythonGeneratorStream::new(PyShared::new(generator), PyShared::new(get_frame));
+        let stream = PythonGeneratorStream::new(
+            OpaqueRef::new(generator),
+            OpaqueRef::new(get_frame),
+        );
         let stream_ref: IRStreamRef = Arc::new(Mutex::new(Box::new(stream)));
         let metadata = CallMetadata::new(
             self.name.clone(),
@@ -435,14 +439,14 @@ impl Kleisli for PyKleisli {
         }
     }
 
-    fn py_identity(&self) -> Option<PyShared> {
+    fn py_identity(&self) -> Option<OpaqueRef> {
         Python::attach(|py| {
             if let Ok(factory) = self.func.bind(py).getattr("_doeff_generator_factory") {
                 if let Ok(callable) = factory.getattr("callable") {
-                    return Some(PyShared::new(callable.unbind()));
+                    return Some(OpaqueRef::new(callable.unbind()));
                 }
             }
-            Some(self.func.clone())
+            Some(self.func.as_opaque().clone())
         })
     }
 }
@@ -450,7 +454,7 @@ impl Kleisli for PyKleisli {
 #[derive(Debug, Clone)]
 pub struct DgfnKleisli {
     inner: PyKleisli,
-    callable_identity: PyShared,
+    callable_identity: OpaqueRef,
 }
 
 impl DgfnKleisli {
@@ -462,7 +466,7 @@ impl DgfnKleisli {
         let inner = PyKleisli::from_handler(py, dgfn_obj)?;
         Ok(Self {
             inner,
-            callable_identity: PyShared::new(callable_identity),
+            callable_identity: OpaqueRef::new(callable_identity),
         })
     }
 }
@@ -476,7 +480,7 @@ impl Kleisli for DgfnKleisli {
         self.inner.debug_info()
     }
 
-    fn py_identity(&self) -> Option<PyShared> {
+    fn py_identity(&self) -> Option<OpaqueRef> {
         Some(self.callable_identity.clone())
     }
 }
@@ -533,7 +537,7 @@ impl Kleisli for PyCallableKleisli {
             .call1(arg_tuple)
             .map_err(PyKleisli::map_pyerr)?;
         Ok(DoCtrl::Pure {
-            value: Value::Python(produced.unbind()),
+            value: Value::Opaque(OpaqueRef::new(produced.unbind())),
         })
     }
 
@@ -545,8 +549,8 @@ impl Kleisli for PyCallableKleisli {
         }
     }
 
-    fn py_identity(&self) -> Option<PyShared> {
-        Some(self.func.clone())
+    fn py_identity(&self) -> Option<OpaqueRef> {
+        Some(self.func.as_opaque().clone())
     }
 }
 
@@ -640,10 +644,10 @@ impl Kleisli for RustKleisli {
         }
 
         let effect = match &args[0] {
-            Value::Python(obj) => dispatch_from_shared(PyShared::new(obj.clone_ref(py))),
+            Value::Opaque(obj) => dispatch_from_opaque(obj.clone()),
             other => {
                 return Err(VMError::type_error(format!(
-                    "RustKleisli arg[0] must be Python effect, got {other:?}"
+                    "RustKleisli arg[0] must be Opaque effect, got {other:?}"
                 )))
             }
         };

--- a/packages/doeff-vm-core/src/lib.rs
+++ b/packages/doeff-vm-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod ids;
 mod interceptor_state;
 pub mod ir_stream;
 pub mod kleisli;
+pub mod opaque_ref;
 pub mod py_key;
 pub mod py_shared;
 pub mod pyvm;
@@ -39,9 +40,9 @@ pub use do_ctrl::DoCtrl;
 pub use doeff_generator::{DoeffGenerator, DoeffGeneratorFn};
 pub use driver::{Mode, StepEvent};
 pub use effect::{
-    dispatch_from_shared, dispatch_into_python, dispatch_ref_as_python, dispatch_to_pyobject,
-    make_execution_context_object, make_get_execution_context_effect, DispatchEffect, Effect,
-    PyEffectBase, PyExecutionContext, PyGetExecutionContext,
+    dispatch_from_opaque, dispatch_from_shared, dispatch_into_opaque, dispatch_ref_as_opaque,
+    dispatch_to_pyobject, make_execution_context_object, make_get_execution_context_effect,
+    DispatchEffect, Effect, PyEffectBase, PyExecutionContext, PyGetExecutionContext,
 };
 pub use error::VMError;
 pub use frame::Frame;
@@ -51,6 +52,7 @@ pub use handler::{
 pub use ids::{ContId, DispatchId, Marker, PromiseId, RunnableId, SegmentId, TaskId};
 pub use ir_stream::{IRStream, IRStreamRef, IRStreamStep, PythonGeneratorStream, StreamLocation};
 pub use kleisli::{Kleisli, KleisliDebugInfo, KleisliRef, PyKleisli, RustKleisli};
+pub use opaque_ref::OpaqueRef;
 pub use py_key::HashedPyKey;
 pub use pyvm::{
     classify_yielded_for_vm, doctrl_tag, doctrl_to_pyexpr_for_vm, install_vm_hooks,

--- a/packages/doeff-vm-core/src/opaque_ref.rs
+++ b/packages/doeff-vm-core/src/opaque_ref.rs
@@ -1,0 +1,75 @@
+//! Opaque handle type for Python (or other runtime) objects.
+//!
+//! `OpaqueRef` wraps an `Arc<dyn Any + Send + Sync>` so that core VM data
+//! structures can carry runtime-specific objects without depending on PyO3
+//! or any other specific runtime crate.
+//!
+//! Bridge code (e.g. `py_shared`) provides extension traits to extract
+//! concrete types such as `Py<PyAny>`.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+/// An opaque, cheaply-clonable reference to a runtime object.
+///
+/// The VM core treats this as a black box. Only bridge code
+/// knows how to resolve the inner value.
+#[derive(Clone)]
+pub struct OpaqueRef(Arc<dyn Any + Send + Sync>);
+
+impl OpaqueRef {
+    /// Wrap any `Send + Sync + 'static` value.
+    pub fn new<T: Any + Send + Sync + 'static>(val: T) -> Self {
+        OpaqueRef(Arc::new(val))
+    }
+
+    /// Try to borrow the inner value as a concrete type.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.0.as_ref().downcast_ref::<T>()
+    }
+
+    /// Check whether the inner value is a given type.
+    pub fn is<T: Any>(&self) -> bool {
+        self.0.as_ref().is::<T>()
+    }
+
+    /// Get a raw pointer for identity comparison (not dereferenceable).
+    pub fn as_ptr(&self) -> *const () {
+        Arc::as_ptr(&self.0) as *const ()
+    }
+}
+
+impl fmt::Debug for OpaqueRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "OpaqueRef({:p})", Arc::as_ptr(&self.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_opaque_ref_roundtrip() {
+        let val = 42u64;
+        let opaque = OpaqueRef::new(val);
+        assert_eq!(opaque.downcast_ref::<u64>(), Some(&42u64));
+        assert!(opaque.is::<u64>());
+        assert!(!opaque.is::<String>());
+    }
+
+    #[test]
+    fn test_opaque_ref_clone_is_cheap() {
+        let opaque = OpaqueRef::new("hello".to_string());
+        let cloned = opaque.clone();
+        assert_eq!(opaque.as_ptr(), cloned.as_ptr());
+    }
+
+    #[test]
+    fn test_opaque_ref_debug() {
+        let opaque = OpaqueRef::new(123i32);
+        let debug = format!("{:?}", opaque);
+        assert!(debug.starts_with("OpaqueRef("));
+    }
+}

--- a/packages/doeff-vm-core/src/py_shared.rs
+++ b/packages/doeff-vm-core/src/py_shared.rs
@@ -1,19 +1,92 @@
-use std::sync::Arc;
+//! Bridge helpers for OpaqueRef ↔ PyO3 interop.
+//!
+//! `PyShared` remains as a convenience for bridge code that knows the inner
+//! value is a `Py<PyAny>`. Core data structures store `OpaqueRef` instead.
 
 use pyo3::prelude::*;
 
-/// GIL-free clonable Python object reference (`Arc<Py<PyAny>>`).
-/// `.clone()` is atomic increment — no GIL assertion on free-threaded 3.14t.
+use crate::opaque_ref::OpaqueRef;
+
+/// Extension trait: PyO3-specific methods on `OpaqueRef`.
+///
+/// Import this trait in bridge code to get `.bind(py)`, `.as_py()`, etc.
+/// Core VM code should NOT import this trait.
+pub trait OpaqueRefPyExt {
+    /// Borrow the inner `Py<PyAny>`.
+    ///
+    /// # Panics
+    /// Panics if this `OpaqueRef` does not contain a `Py<PyAny>`.
+    fn as_py(&self) -> &Py<PyAny>;
+
+    /// Bind the inner Python object to the GIL lifetime.
+    ///
+    /// # Panics
+    /// Panics if this `OpaqueRef` does not contain a `Py<PyAny>`.
+    fn bind<'py>(&self, py: Python<'py>) -> &Bound<'py, PyAny>;
+
+    /// Clone the inner Python reference (increments refcount).
+    ///
+    /// # Panics
+    /// Panics if this `OpaqueRef` does not contain a `Py<PyAny>`.
+    fn clone_ref(&self, py: Python<'_>) -> Py<PyAny>;
+
+    /// Try to borrow the inner `Py<PyAny>`, returning `None` if the
+    /// `OpaqueRef` holds a different type.
+    fn try_as_py(&self) -> Option<&Py<PyAny>>;
+}
+
+impl OpaqueRefPyExt for OpaqueRef {
+    fn as_py(&self) -> &Py<PyAny> {
+        self.downcast_ref::<Py<PyAny>>()
+            .expect("OpaqueRef does not contain Py<PyAny>")
+    }
+
+    fn bind<'py>(&self, py: Python<'py>) -> &Bound<'py, PyAny> {
+        self.as_py().bind(py)
+    }
+
+    fn clone_ref(&self, py: Python<'_>) -> Py<PyAny> {
+        self.as_py().clone_ref(py)
+    }
+
+    fn try_as_py(&self) -> Option<&Py<PyAny>> {
+        self.downcast_ref::<Py<PyAny>>()
+    }
+}
+
+/// Wrap a `Py<PyAny>` into an `OpaqueRef`.
+pub fn py_to_opaque(obj: Py<PyAny>) -> OpaqueRef {
+    OpaqueRef::new(obj)
+}
+
+/// Consume an `OpaqueRef` and extract the `Py<PyAny>`.
+///
+/// Returns `None` if the `OpaqueRef` does not hold a `Py<PyAny>`.
+///
+/// Because `OpaqueRef` uses `Arc` internally, this clones the `Py<PyAny>`
+/// when there are multiple references. In the single-owner case it moves.
+pub fn opaque_into_py(opaque: OpaqueRef) -> Option<Py<PyAny>> {
+    // OpaqueRef wraps Arc<dyn Any + Send + Sync>.
+    // We can't unwrap the Arc directly, so we clone the Py<PyAny>.
+    opaque.downcast_ref::<Py<PyAny>>().cloned()
+}
+
+// ---- Legacy PyShared compat layer ----
+
+/// GIL-free clonable Python object reference.
+///
+/// This is a thin wrapper around `OpaqueRef` for bridge code that knows
+/// the contained value is `Py<PyAny>`.
 #[derive(Debug, Clone)]
-pub struct PyShared(Arc<Py<PyAny>>);
+pub struct PyShared(pub(crate) OpaqueRef);
 
 impl PyShared {
     pub fn new(obj: Py<PyAny>) -> Self {
-        PyShared(Arc::new(obj))
+        PyShared(OpaqueRef::new(obj))
     }
 
     pub fn inner(&self) -> &Py<PyAny> {
-        &self.0
+        self.0.as_py()
     }
 
     pub fn bind<'py>(&self, py: Python<'py>) -> &Bound<'py, PyAny> {
@@ -25,14 +98,46 @@ impl PyShared {
     }
 
     pub fn into_inner(self) -> Py<PyAny> {
-        match Arc::try_unwrap(self.0) {
-            Ok(py) => py,
-            Err(arc) => {
-                // SAFETY: into_inner is only used while executing VM/Python-initiated paths where
-                // the thread is already attached to the Python runtime.
-                let py = unsafe { Python::assume_attached() };
-                arc.clone_ref(py)
-            }
+        // Clone the inner Py<PyAny> before attempting unwrap, so we have a
+        // fallback if the Arc is shared.
+        let fallback = self.inner().clone();
+        // Try to extract without GIL; fall back to the pre-cloned copy if Arc is shared.
+        opaque_into_py(self.0).unwrap_or(fallback)
+    }
+
+    /// Convert to the runtime-agnostic `OpaqueRef`.
+    pub fn into_opaque(self) -> OpaqueRef {
+        self.0
+    }
+
+    /// Borrow the underlying `OpaqueRef`.
+    pub fn as_opaque(&self) -> &OpaqueRef {
+        &self.0
+    }
+
+    /// Try to wrap an `OpaqueRef` back into a `PyShared`.
+    ///
+    /// Returns `None` if the `OpaqueRef` does not contain a `Py<PyAny>`.
+    pub fn from_opaque(opaque: OpaqueRef) -> Option<Self> {
+        if opaque.is::<Py<PyAny>>() {
+            Some(PyShared(opaque))
+        } else {
+            None
         }
+    }
+
+    /// Wrap an `OpaqueRef` into a `PyShared`, panicking if type mismatch.
+    pub fn from_opaque_unwrap(opaque: OpaqueRef) -> Self {
+        assert!(
+            opaque.is::<Py<PyAny>>(),
+            "OpaqueRef does not contain Py<PyAny>"
+        );
+        PyShared(opaque)
+    }
+}
+
+impl From<PyShared> for OpaqueRef {
+    fn from(shared: PyShared) -> Self {
+        shared.0
     }
 }

--- a/packages/doeff-vm-core/src/python_call.rs
+++ b/packages/doeff-vm-core/src/python_call.rs
@@ -7,16 +7,16 @@ use crate::driver::PyException;
 use crate::frame::CallMetadata;
 use crate::ids::Marker;
 use crate::ir_stream::IRStreamRef;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
 use crate::value::Value;
 
 #[derive(Debug, Clone)]
 pub enum PythonCall {
     EvalExpr {
-        expr: PyShared,
+        expr: OpaqueRef,
     },
     CallFunc {
-        func: PyShared,
+        func: OpaqueRef,
         args: Vec<Value>,
         kwargs: Vec<(String, Value)>,
     },
@@ -28,7 +28,7 @@ pub enum PythonCall {
         exc: PyException,
     },
     CallAsync {
-        func: PyShared,
+        func: OpaqueRef,
         args: Vec<Value>,
     },
 }

--- a/packages/doeff-vm-core/src/trace_state.rs
+++ b/packages/doeff-vm-core/src/trace_state.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use pyo3::prelude::*;
 
 use crate::arena::SegmentArena;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::OpaqueRefPyExt;
 use crate::capture::{
     ActiveChainEntry, CaptureEvent, DelegationEntry, DispatchAction, EffectCreationSite,
     EffectResult, FrameId, HandlerAction, HandlerDispatchEntry, HandlerKind, HandlerSnapshotEntry,
@@ -492,7 +494,7 @@ impl TraceState {
         original: PyException,
         context_value: Value,
     ) -> Result<PyException, PyException> {
-        let Value::Python(new_context) = context_value else {
+        let Value::Opaque(new_context) = context_value else {
             let err = PyException::type_error(
                 "GetExecutionContext handlers must Resume with ExecutionContext".to_string(),
             );
@@ -1473,7 +1475,7 @@ impl TraceState {
         let context_entries = exception.map_or_else(Vec::new, Self::context_entries_from_exception);
         let has_context_entries = !context_entries.is_empty();
         for data in context_entries {
-            active_chain.push(ActiveChainEntry::ContextEntry { data });
+            active_chain.push(ActiveChainEntry::ContextEntry { data: OpaqueRef::new(data) });
         }
 
         let Some(exception) = exception else {

--- a/packages/doeff-vm-core/src/value.rs
+++ b/packages/doeff-vm-core/src/value.rs
@@ -1,6 +1,7 @@
 //! Value types that flow through the VM.
 //!
-//! Values can be either Rust-native (for optimization) or Python objects.
+//! Values can be either Rust-native (for optimization) or opaque runtime
+//! objects wrapped in `OpaqueRef`.
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyList, PyString};
@@ -12,7 +13,8 @@ use crate::capture::{
 use crate::frame::CallMetadata;
 use crate::ids::{PromiseId, TaskId};
 use crate::kleisli::KleisliRef;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::OpaqueRefPyExt;
 use crate::pyvm::{PyTraceFrame, PyTraceHop};
 
 /// Opaque handle to a spawned task.
@@ -31,16 +33,16 @@ pub struct PromiseHandle {
 #[derive(Clone, Debug)]
 pub struct ExternalPromise {
     pub id: PromiseId,
-    pub completion_queue: Option<PyShared>,
+    pub completion_queue: Option<OpaqueRef>,
 }
 
 /// A value that can flow through the VM.
 ///
-/// Can be either a Rust-native value or a Python object.
+/// Can be either a Rust-native value or an opaque runtime object.
 /// Rust-native variants avoid Python overhead for common cases.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Value {
-    Python(Py<PyAny>),
+    Opaque(OpaqueRef),
     Unit,
     Int(i64),
     String(String),
@@ -323,7 +325,7 @@ impl Value {
             }
             ActiveChainEntry::ContextEntry { data } => {
                 dict.set_item("kind", "context_entry")?;
-                dict.set_item("data", data.clone_ref(py))?;
+                dict.set_item("data", data.bind(py))?;
             }
             ActiveChainEntry::ExceptionSite {
                 function_name,
@@ -345,7 +347,7 @@ impl Value {
 
     pub fn to_pyobject<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         match self {
-            Value::Python(obj) => Ok(obj.bind(py).clone()),
+            Value::Opaque(obj) => Ok(obj.bind(py).clone()),
             Value::Unit => Ok(py.None().into_bound(py)),
             Value::Int(i) => Ok(i.into_pyobject(py)?.into_any()),
             Value::String(s) => Ok(PyString::new(py, s).into_any()),
@@ -453,7 +455,7 @@ impl Value {
 
     /// Preserve a Python object as-is without VM-side type coercion.
     pub fn from_python_opaque(obj: &Bound<'_, PyAny>) -> Self {
-        Value::Python(obj.clone().unbind())
+        Value::Opaque(OpaqueRef::new(obj.clone().unbind()))
     }
 
     pub fn from_pyobject(obj: &Bound<'_, PyAny>) -> Self {
@@ -469,7 +471,7 @@ impl Value {
         if let Ok(s) = obj.extract::<String>() {
             return Value::String(s);
         }
-        Value::Python(obj.clone().unbind())
+        Value::Opaque(OpaqueRef::new(obj.clone().unbind()))
     }
 
     /// Create from Python object, consuming it.
@@ -482,31 +484,16 @@ impl Value {
         matches!(self, Value::None | Value::Unit)
     }
 
-    /// Check if this is a Python object.
-    pub fn is_python(&self) -> bool {
-        matches!(self, Value::Python(_))
+    /// Check if this is an opaque runtime object.
+    pub fn is_opaque(&self) -> bool {
+        matches!(self, Value::Opaque(_))
     }
 
     /// Try to get as i64.
     pub fn as_int(&self) -> Option<i64> {
         match self {
             Value::Int(i) => Some(*i),
-            Value::Python(_)
-            | Value::Unit
-            | Value::String(_)
-            | Value::Bool(_)
-            | Value::None
-            | Value::Continuation(_)
-            | Value::Handlers(_)
-            | Value::Kleisli(_)
-            | Value::Task(_)
-            | Value::Promise(_)
-            | Value::ExternalPromise(_)
-            | Value::CallStack(_)
-            | Value::Trace(_)
-            | Value::Traceback(_)
-            | Value::ActiveChain(_)
-            | Value::List(_) => None,
+            _ => None,
         }
     }
 
@@ -514,22 +501,7 @@ impl Value {
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Value::String(s) => Some(s),
-            Value::Python(_)
-            | Value::Unit
-            | Value::Int(_)
-            | Value::Bool(_)
-            | Value::None
-            | Value::Continuation(_)
-            | Value::Handlers(_)
-            | Value::Kleisli(_)
-            | Value::Task(_)
-            | Value::Promise(_)
-            | Value::ExternalPromise(_)
-            | Value::CallStack(_)
-            | Value::Trace(_)
-            | Value::Traceback(_)
-            | Value::ActiveChain(_)
-            | Value::List(_) => None,
+            _ => None,
         }
     }
 
@@ -537,22 +509,7 @@ impl Value {
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Value::Bool(b) => Some(*b),
-            Value::Python(_)
-            | Value::Unit
-            | Value::Int(_)
-            | Value::String(_)
-            | Value::None
-            | Value::Continuation(_)
-            | Value::Handlers(_)
-            | Value::Kleisli(_)
-            | Value::Task(_)
-            | Value::Promise(_)
-            | Value::ExternalPromise(_)
-            | Value::CallStack(_)
-            | Value::Trace(_)
-            | Value::Traceback(_)
-            | Value::ActiveChain(_)
-            | Value::List(_) => None,
+            _ => None,
         }
     }
 
@@ -560,22 +517,15 @@ impl Value {
     pub fn as_handlers(&self) -> Option<&[KleisliRef]> {
         match self {
             Value::Handlers(h) => Some(h),
-            Value::Python(_)
-            | Value::Unit
-            | Value::Int(_)
-            | Value::String(_)
-            | Value::Bool(_)
-            | Value::None
-            | Value::Continuation(_)
-            | Value::Kleisli(_)
-            | Value::Task(_)
-            | Value::Promise(_)
-            | Value::ExternalPromise(_)
-            | Value::CallStack(_)
-            | Value::Trace(_)
-            | Value::Traceback(_)
-            | Value::ActiveChain(_)
-            | Value::List(_) => None,
+            _ => None,
+        }
+    }
+
+    /// Try to get the inner OpaqueRef.
+    pub fn as_opaque(&self) -> Option<&OpaqueRef> {
+        match self {
+            Value::Opaque(o) => Some(o),
+            _ => None,
         }
     }
 }
@@ -587,42 +537,9 @@ impl Default for Value {
 }
 
 impl Value {
-    pub fn clone_ref(&self, py: Python<'_>) -> Self {
-        match self {
-            Value::Python(obj) => Value::Python(obj.clone_ref(py)),
-            Value::Unit => Value::Unit,
-            Value::Int(i) => Value::Int(*i),
-            Value::String(s) => Value::String(s.clone()),
-            Value::Bool(b) => Value::Bool(*b),
-            Value::None => Value::None,
-            Value::Continuation(k) => Value::Continuation(k.clone()),
-            Value::Handlers(handlers) => Value::Handlers(handlers.clone()),
-            Value::Kleisli(kleisli) => Value::Kleisli(kleisli.clone()),
-            Value::Task(h) => Value::Task(*h),
-            Value::Promise(h) => Value::Promise(*h),
-            Value::ExternalPromise(h) => Value::ExternalPromise(h.clone()),
-            Value::CallStack(stack) => Value::CallStack(stack.clone()),
-            Value::Trace(entries) => Value::Trace(entries.clone()),
-            Value::Traceback(hops) => Value::Traceback(hops.clone()),
-            Value::ActiveChain(entries) => Value::ActiveChain(entries.clone()),
-            Value::List(items) => Value::List(items.iter().map(|v| v.clone_ref(py)).collect()),
-        }
-    }
-}
-
-impl Clone for Value {
-    fn clone(&self) -> Self {
-        Python::attach(|py| self.clone_ref(py))
-    }
-}
-
-impl Value {
     pub fn from_effect(effect: &crate::effect::Effect) -> Self {
-        if let Some(py_obj) = effect.as_python() {
-            // SAFETY: from_effect only clones an existing Py<PyAny> from VM-managed effect values,
-            // and all callers execute under attached Python contexts.
-            let py = unsafe { pyo3::Python::assume_attached() };
-            return Value::Python(py_obj.clone_ref(py));
+        if let Some(opaque) = effect.as_opaque() {
+            return Value::Opaque(opaque.clone());
         }
         Value::None
     }
@@ -693,7 +610,6 @@ mod tests {
     #[test]
     fn test_value_task_and_promise() {
         use crate::ids::{PromiseId, TaskId};
-        use crate::scheduler::{ExternalPromise, PromiseHandle, TaskHandle};
 
         let task = Value::Task(TaskHandle {
             id: TaskId::from_raw(1),
@@ -710,5 +626,14 @@ mod tests {
         assert!(matches!(task, Value::Task(_)));
         assert!(matches!(promise, Value::Promise(_)));
         assert!(matches!(ext, Value::ExternalPromise(_)));
+    }
+
+    #[test]
+    fn test_value_opaque_clone() {
+        // OpaqueRef clone is cheap (Arc clone) — no GIL needed
+        let opaque = OpaqueRef::new(42u64);
+        let val = Value::Opaque(opaque);
+        let cloned = val.clone();
+        assert!(cloned.is_opaque());
     }
 }

--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -19,7 +19,7 @@ use crate::do_ctrl::{DoCtrl, InterceptMode};
 use crate::doeff_generator::DoeffGenerator;
 use crate::driver::{Mode, PyException, StepEvent};
 use crate::effect::{
-    dispatch_ref_as_python, dispatch_to_pyobject, make_get_execution_context_effect,
+    dispatch_ref_as_opaque, dispatch_to_pyobject, make_get_execution_context_effect,
     DispatchEffect, PyExecutionContext, PyGetExecutionContext,
 };
 #[cfg(test)]
@@ -30,7 +30,8 @@ use crate::ids::{ContId, DispatchId, Marker, SegmentId};
 use crate::interceptor_state::InterceptorState;
 use crate::ir_stream::{IRStream, IRStreamRef, IRStreamStep, PythonGeneratorStream};
 use crate::kleisli::{IdentityKleisli, KleisliRef};
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::{OpaqueRefPyExt, PyShared};
 use crate::python_call::{PendingPython, PyCallOutcome, PythonCall};
 use crate::pyvm::{
     classify_yielded_for_vm, doctrl_tag, doctrl_to_pyexpr_for_vm, DoExprTag, PyDoExprBase,
@@ -502,10 +503,10 @@ impl VM {
     }
 
     fn same_effect_python_type(a: &DispatchEffect, b: &DispatchEffect) -> bool {
-        let Some(a_obj) = dispatch_ref_as_python(a) else {
+        let Some(a_obj) = dispatch_ref_as_opaque(a) else {
             return false;
         };
-        let Some(b_obj) = dispatch_ref_as_python(b) else {
+        let Some(b_obj) = dispatch_ref_as_opaque(b) else {
             return false;
         };
         Python::attach(|py| {
@@ -1397,8 +1398,8 @@ impl VM {
             }
 
             let stream = Arc::new(std::sync::Mutex::new(Box::new(PythonGeneratorStream::new(
-                PyShared::new(wrapped.generator.clone_ref(py)),
-                PyShared::new(wrapped.get_frame.clone_ref(py)),
+                OpaqueRef::new(wrapped.generator.clone_ref(py)),
+                OpaqueRef::new(wrapped.get_frame.clone_ref(py)),
             )) as Box<dyn IRStream>));
             Ok((
                 stream,
@@ -1426,7 +1427,7 @@ impl VM {
 
     fn value_variant_name(value: &Value) -> &'static str {
         match value {
-            Value::Python(_) => "Python",
+            Value::Opaque(_) => "Opaque",
             Value::Unit => "Unit",
             Value::Int(_) => "Int",
             Value::String(_) => "String",
@@ -1451,7 +1452,7 @@ impl VM {
     }
 
     fn is_execution_context_effect(effect: &DispatchEffect) -> bool {
-        let Some(obj) = dispatch_ref_as_python(effect) else {
+        let Some(obj) = dispatch_ref_as_opaque(effect) else {
             return false;
         };
         Python::attach(|py| {
@@ -1522,7 +1523,7 @@ impl VM {
             }),
             args: vec![
                 DoCtrl::Pure {
-                    value: Value::Python(effect_obj),
+                    value: Value::Opaque(OpaqueRef::new(effect_obj)),
                 },
                 DoCtrl::Pure {
                     value: Value::Continuation(continuation),
@@ -1837,7 +1838,7 @@ impl VM {
             return Ok(());
         }
         let context_obj = match value {
-            Value::Python(obj) => obj,
+            Value::Opaque(obj) => obj,
             other => {
                 return Err(VMError::python_error(format!(
                     "GetExecutionContext handler must return ExecutionContext, got {}",
@@ -1877,7 +1878,7 @@ impl VM {
                     ))
                 })?;
                 active_chain.push(ActiveChainEntry::ContextEntry {
-                    data: entry.unbind(),
+                    data: OpaqueRef::new(entry.unbind()),
                 });
             }
 
@@ -2525,7 +2526,7 @@ impl VM {
 
     fn step_map_return_frame(
         &mut self,
-        mapper: PyShared,
+        mapper: OpaqueRef,
         mapper_meta: CallMetadata,
         mode: Mode,
     ) -> StepEvent {
@@ -2533,7 +2534,7 @@ impl VM {
             Mode::Deliver(value) => {
                 self.current_seg_mut().mode = Mode::HandleYield(DoCtrl::Apply {
                     f: Box::new(DoCtrl::Pure {
-                        value: Value::Python(mapper.into_inner()),
+                        value: Value::Opaque(mapper),
                     }),
                     args: vec![DoCtrl::Pure { value }],
                     kwargs: vec![],
@@ -2575,7 +2576,7 @@ impl VM {
 
     fn step_flat_map_bind_source_frame(
         &mut self,
-        binder: PyShared,
+        binder: OpaqueRef,
         binder_meta: CallMetadata,
         mode: Mode,
     ) -> StepEvent {
@@ -2589,7 +2590,7 @@ impl VM {
                 seg.push_frame(Frame::FlatMapBindResult);
                 seg.mode = Mode::HandleYield(DoCtrl::Expand {
                     factory: Box::new(DoCtrl::Pure {
-                        value: Value::Python(binder.into_inner()),
+                        value: Value::Opaque(binder),
                     }),
                     args: vec![DoCtrl::Pure { value }],
                     kwargs: vec![],
@@ -2807,7 +2808,7 @@ impl VM {
     fn classify_interceptor_result_object(
         &self,
         result_obj: Py<PyAny>,
-        original_obj: &PyShared,
+        original_obj: &OpaqueRef,
         original_yielded: DoCtrl,
     ) -> Result<DoCtrl, PyException> {
         Python::attach(|py| {
@@ -2821,14 +2822,15 @@ impl VM {
     fn classify_interceptor_eval_result(
         &self,
         value: Value,
-        original_obj: &PyShared,
+        original_obj: &OpaqueRef,
         original_yielded: DoCtrl,
     ) -> Result<DoCtrl, PyException> {
-        let Value::Python(result_obj) = value else {
+        let Value::Opaque(result_ref) = value else {
             return Err(PyException::type_error(
                 "WithIntercept effectful interceptor must resolve to DoExpr",
             ));
         };
+        let result_obj = Python::attach(|py| result_ref.clone_ref(py));
         self.classify_interceptor_result_object(result_obj, original_obj, original_yielded)
     }
 
@@ -2973,7 +2975,7 @@ impl VM {
         let continuation = InterceptorContinuation {
             marker,
             original_yielded: yielded,
-            original_obj: PyShared::new(yielded_obj_for_continuation),
+            original_obj: OpaqueRef::new(yielded_obj_for_continuation),
             emitter_stream: stream,
             emitter_metadata: metadata,
             emitter_handler_kind: handler_kind,
@@ -2998,7 +3000,7 @@ impl VM {
                 value: Value::Kleisli(interceptor_kleisli),
             }),
             args: vec![DoCtrl::Pure {
-                value: Value::Python(yielded_obj),
+                value: Value::Opaque(OpaqueRef::new(yielded_obj)),
             }],
             kwargs: vec![],
             metadata: apply_metadata,
@@ -3022,12 +3024,13 @@ impl VM {
             guard_eval_depth,
             ..
         } = continuation;
-        let Value::Python(result_obj) = value else {
+        let Value::Opaque(result_ref) = value else {
             self.pop_interceptor_skip(marker);
             return Mode::Throw(PyException::type_error(
                 "WithIntercept interceptor must return DoExpr",
             ));
         };
+        let result_obj = Python::attach(|py| result_ref.clone_ref(py));
 
         let (is_direct_expr, is_doexpr) = InterceptorState::classify_result_shape(&result_obj);
 
@@ -3076,7 +3079,7 @@ impl VM {
             })));
 
             return Mode::HandleYield(DoCtrl::Eval {
-                expr: PyShared::new(result_obj),
+                expr: OpaqueRef::new(result_obj),
                 metadata: None,
             });
         }
@@ -3229,8 +3232,8 @@ impl VM {
 
     fn handle_yield_map(
         &mut self,
-        source: PyShared,
-        mapper: PyShared,
+        source: OpaqueRef,
+        mapper: OpaqueRef,
         mapper_meta: CallMetadata,
     ) -> StepEvent {
         self.handle_map(source, mapper, mapper_meta)
@@ -3238,8 +3241,8 @@ impl VM {
 
     fn handle_yield_flat_map(
         &mut self,
-        source: PyShared,
-        binder: PyShared,
+        source: OpaqueRef,
+        binder: OpaqueRef,
         binder_meta: CallMetadata,
     ) -> StepEvent {
         self.handle_flat_map(source, binder, binder_meta)
@@ -3288,10 +3291,11 @@ impl VM {
         &mut self,
         interceptor: KleisliRef,
         body: DoCtrl,
-        types: Option<Vec<PyShared>>,
+        types: Option<Vec<OpaqueRef>>,
         mode: InterceptMode,
         metadata: Option<CallMetadata>,
     ) -> StepEvent {
+        let types = types.map(|v| v.into_iter().map(PyShared::from_opaque_unwrap).collect());
         self.handle_with_intercept(interceptor, body, types, mode, metadata)
     }
 
@@ -3317,9 +3321,9 @@ impl VM {
 
     fn handle_yield_create_continuation(
         &mut self,
-        expr: PyShared,
+        expr: OpaqueRef,
         handlers: Vec<KleisliRef>,
-        handler_identities: Vec<Option<PyShared>>,
+        handler_identities: Vec<Option<OpaqueRef>>,
     ) -> StepEvent {
         self.handle_create_continuation(expr, handlers, handler_identities)
     }
@@ -3332,10 +3336,10 @@ impl VM {
         self.handle_resume_continuation(continuation, value)
     }
 
-    fn handle_yield_python_async_syntax_escape(&mut self, action: Py<PyAny>) -> StepEvent {
+    fn handle_yield_python_async_syntax_escape(&mut self, action: OpaqueRef) -> StepEvent {
         self.current_seg_mut().pending_python = Some(PendingPython::AsyncEscape);
         StepEvent::NeedsPython(PythonCall::CallAsync {
-            func: PyShared::new(action),
+            func: action,
             args: vec![],
         })
     }
@@ -3396,7 +3400,7 @@ impl VM {
         };
 
         let func = match f_value {
-            Value::Python(func) => PyShared::new(func),
+            Value::Opaque(func) => func,
             Value::Kleisli(kleisli) => {
                 let args_values = Self::collect_value_args(args);
                 let kwargs_values = Self::collect_value_kwargs(kwargs);
@@ -3488,7 +3492,7 @@ impl VM {
         };
 
         let (func, handler_return) = match factory_value {
-            Value::Python(factory) => (PyShared::new(factory), false),
+            Value::Opaque(factory) => (factory, false),
             Value::Kleisli(kleisli) => {
                 let args_values = Self::collect_value_args(args);
                 let kwargs_values = Self::collect_value_kwargs(kwargs);
@@ -3571,7 +3575,7 @@ impl VM {
         StepEvent::Continue
     }
 
-    fn handle_yield_eval(&mut self, expr: PyShared, metadata: Option<CallMetadata>) -> StepEvent {
+    fn handle_yield_eval(&mut self, expr: OpaqueRef, metadata: Option<CallMetadata>) -> StepEvent {
         let handlers = self.current_visible_handlers();
         let cont = Continuation::create_unstarted_with_metadata(expr, handlers, metadata);
         self.handle_resume_continuation(cont, Value::None)
@@ -3579,7 +3583,7 @@ impl VM {
 
     fn handle_yield_eval_in_scope(
         &mut self,
-        expr: PyShared,
+        expr: OpaqueRef,
         scope: Continuation,
         metadata: Option<CallMetadata>,
     ) -> StepEvent {
@@ -3966,11 +3970,11 @@ impl VM {
     }
 
     fn returned_control_primitive_signature(value: &Value) -> Option<&'static str> {
-        let Value::Python(result_obj) = value else {
+        let Value::Opaque(result_ref) = value else {
             return None;
         };
 
-        Python::attach(|py| match doctrl_tag(result_obj.bind(py)) {
+        Python::attach(|py| match doctrl_tag(result_ref.bind(py)) {
             Some(DoExprTag::Pass) => Some("Pass()"),
             Some(DoExprTag::Resume) => Some("Resume(k, value)"),
             Some(DoExprTag::Delegate) => Some("Delegate()"),
@@ -4012,8 +4016,8 @@ impl VM {
 
     fn receive_expand_handler_value(&mut self, metadata: Option<CallMetadata>, value: Value) {
         match value {
-            Value::Python(handler_gen) => {
-                match Self::extract_doeff_generator(handler_gen, metadata, "ExpandReturn(handler)")
+            Value::Opaque(handler_ref) => {
+                match Self::extract_doeff_generator(Python::attach(|py| handler_ref.clone_ref(py)), metadata, "ExpandReturn(handler)")
                 {
                     Ok((stream, metadata)) => {
                         let Some(_dispatch_id) = self
@@ -4071,13 +4075,13 @@ impl VM {
         value: Value,
         context: &str,
     ) -> Result<DoCtrl, PyException> {
-        let Value::Python(result_obj) = value else {
+        let Value::Opaque(result_ref) = value else {
             return Err(PyException::type_error(format!(
                 "{context}: expected DoeffGenerator, DoExpr, or EffectBase, got {value:?}"
             )));
         };
-
         Python::attach(|py| {
+            let result_obj = result_ref.clone_ref(py);
             let bound = result_obj.bind(py);
             if bound.is_instance_of::<DoeffGenerator>() {
                 let (stream, metadata) =
@@ -4564,7 +4568,7 @@ impl VM {
         &mut self,
         marker: Marker,
         handler: KleisliRef,
-        _py_identity: Option<PyShared>,
+        _py_identity: Option<OpaqueRef>,
     ) {
         self.installed_handlers
             .retain(|entry| entry.marker != marker);
@@ -4591,7 +4595,7 @@ impl VM {
         marker: Marker,
         prompt_seg_id: SegmentId,
         handler: KleisliRef,
-        _py_identity: Option<PyShared>,
+        _py_identity: Option<OpaqueRef>,
     ) -> bool {
         let Some(seg) = self.segments.get_mut(prompt_seg_id) else {
             let prompt_seg = Segment::new_prompt(marker, None, marker, handler.clone());
@@ -4824,8 +4828,9 @@ impl VM {
         &mut self,
         handler: KleisliRef,
         program: DoCtrl,
-        types: Option<Vec<PyShared>>,
+        types: Option<Vec<OpaqueRef>>,
     ) -> StepEvent {
+        let types = types.map(|v| v.into_iter().map(PyShared::from_opaque_unwrap).collect());
         let plan = match Self::prepare_with_handler(handler, self.current_segment) {
             Ok(plan) => plan,
             Err(err) => return StepEvent::Error(err),
@@ -5122,8 +5127,8 @@ impl VM {
 
     fn handle_map(
         &mut self,
-        source: PyShared,
-        mapper: PyShared,
+        source: OpaqueRef,
+        mapper: OpaqueRef,
         mapper_meta: CallMetadata,
     ) -> StepEvent {
         let Some(seg) = self.current_segment_mut() else {
@@ -5142,8 +5147,8 @@ impl VM {
 
     fn handle_flat_map(
         &mut self,
-        source: PyShared,
-        binder: PyShared,
+        source: OpaqueRef,
+        binder: OpaqueRef,
         binder_meta: CallMetadata,
     ) -> StepEvent {
         let Some(seg) = self.current_segment_mut() else {
@@ -5205,9 +5210,9 @@ impl VM {
 
     fn handle_create_continuation(
         &mut self,
-        program: PyShared,
+        program: OpaqueRef,
         handlers: Vec<KleisliRef>,
-        handler_identities: Vec<Option<PyShared>>,
+        handler_identities: Vec<Option<OpaqueRef>>,
     ) -> StepEvent {
         let k =
             Continuation::create_unstarted_with_identities(program, handlers, handler_identities);

--- a/packages/doeff-vm/src/lib.rs
+++ b/packages/doeff-vm/src/lib.rs
@@ -47,6 +47,9 @@ pub mod ir_stream {
 pub mod kleisli {
     pub use doeff_vm_core::kleisli::*;
 }
+pub mod opaque_ref {
+    pub use doeff_vm_core::opaque_ref::*;
+}
 pub mod py_key {
     pub use doeff_vm_core::py_key::*;
 }

--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -12,8 +12,9 @@ pyo3::create_exception!(doeff_vm, Discontinued, pyo3::exceptions::PyException);
 
 use crate::do_ctrl::{DoCtrl, InterceptMode};
 use crate::doeff_generator::{DoeffGenerator, DoeffGeneratorFn};
+use crate::dispatch::{dispatch_from_opaque, dispatch_ref_as_opaque};
 use crate::effect::{
-    dispatch_from_shared, dispatch_ref_as_python, PyExecutionContext, PyGetExecutionContext,
+    PyExecutionContext, PyGetExecutionContext,
     PyProgramCallStack,
 };
 
@@ -23,7 +24,8 @@ use crate::ids::Marker;
 use crate::ir_stream::{IRStream, PythonGeneratorStream};
 use crate::kleisli::{DgfnKleisli, IdentityKleisli, KleisliRef, PyKleisli};
 use crate::py_key::HashedPyKey;
-use crate::py_shared::PyShared;
+use crate::opaque_ref::OpaqueRef;
+use crate::py_shared::OpaqueRefPyExt;
 #[allow(unused_imports)]
 use crate::segment::{Segment, SegmentKind};
 use crate::step::{Mode, PendingPython, PyCallOutcome, PyException, PythonCall, StepEvent};
@@ -313,7 +315,7 @@ fn normalize_handler_types_obj(
 fn intercept_types_from_pyobj(
     py: Python<'_>,
     types: &Option<Py<PyAny>>,
-) -> PyResult<Option<Vec<PyShared>>> {
+) -> PyResult<Option<Vec<OpaqueRef>>> {
     let Some(types_obj) = types else {
         return Ok(None);
     };
@@ -331,7 +333,7 @@ fn intercept_types_from_pyobj(
                 "WithIntercept.types must contain only Python type objects",
             ));
         }
-        normalized.push(PyShared::new(item.unbind()));
+        normalized.push(OpaqueRef::new(item.unbind()));
     }
     Ok(Some(normalized))
 }
@@ -339,7 +341,7 @@ fn intercept_types_from_pyobj(
 fn handler_types_from_pyobj(
     py: Python<'_>,
     types: &Option<Py<PyAny>>,
-) -> PyResult<Option<Vec<PyShared>>> {
+) -> PyResult<Option<Vec<OpaqueRef>>> {
     let Some(types_obj) = types else {
         return Ok(None);
     };
@@ -357,14 +359,14 @@ fn handler_types_from_pyobj(
                 "WithHandler.types must contain only Python type objects",
             ));
         }
-        normalized.push(PyShared::new(item.unbind()));
+        normalized.push(OpaqueRef::new(item.unbind()));
     }
     Ok(Some(normalized))
 }
 
 fn intercept_types_to_pyobj(
     py: Python<'_>,
-    types: &Option<Vec<PyShared>>,
+    types: &Option<Vec<OpaqueRef>>,
 ) -> PyResult<Option<Py<PyAny>>> {
     let Some(types) = types else {
         return Ok(None);
@@ -375,7 +377,7 @@ fn intercept_types_to_pyobj(
 
 fn handler_types_to_pyobj(
     py: Python<'_>,
-    types: &Option<Vec<PyShared>>,
+    types: &Option<Vec<OpaqueRef>>,
 ) -> PyResult<Option<Py<PyAny>>> {
     let Some(types) = types else {
         return Ok(None);
@@ -715,7 +717,7 @@ impl PyVM {
 
         if obj.is_instance_of::<PyRustHandlerSentinel>() {
             let sentinel: PyRef<'_, PyRustHandlerSentinel> = obj.extract()?;
-            let identity = PyShared::new(obj.clone().unbind());
+            let identity = OpaqueRef::new(obj.clone().unbind());
             return Ok(Arc::new(IdentityKleisli::new(
                 sentinel.kleisli_ref(),
                 identity,
@@ -753,7 +755,7 @@ impl PyVM {
             ));
         };
         seg.mode = Mode::HandleYield(DoCtrl::Eval {
-            expr: PyShared::new(expr),
+            expr: OpaqueRef::new(expr),
             metadata: None,
         });
         Ok(())
@@ -905,7 +907,7 @@ impl PyVM {
         match value {
             // Runtime callback arguments must receive the opaque K handle.
             Value::Continuation(k) => Ok(Bound::new(py, PyK::from_cont_id(k.cont_id))?.into_any()),
-            Value::Python(_)
+            Value::Opaque(_)
             | Value::Unit
             | Value::Int(_)
             | Value::String(_)
@@ -1010,7 +1012,7 @@ pub(crate) fn doctrl_to_pyexpr_for_vm(yielded: &DoCtrl) -> Result<Option<Py<PyAn
                 .unbind(),
             ),
             DoCtrl::Perform { effect } => {
-                dispatch_ref_as_python(effect).map(|value| value.clone_ref(py))
+                dispatch_ref_as_opaque(effect).map(|value| value.clone_ref(py))
             }
             DoCtrl::Resume {
                 continuation,
@@ -1481,8 +1483,8 @@ fn classify_doeff_generator_as_irstream(
 
     let stream: Arc<Mutex<Box<dyn IRStream>>> =
         Arc::new(Mutex::new(Box::new(PythonGeneratorStream::new(
-            PyShared::new(wrapped.generator.clone_ref(py)),
-            PyShared::new(wrapped.get_frame.clone_ref(py)),
+            OpaqueRef::new(wrapped.generator.clone_ref(py)),
+            OpaqueRef::new(wrapped.get_frame.clone_ref(py)),
         )) as Box<dyn IRStream>));
 
     Ok(DoCtrl::IRStream {
@@ -1614,23 +1616,23 @@ pub(crate) fn classify_yielded_bound(
             DoExprTag::Map => {
                 let m: PyRef<'_, PyMap> = obj.extract()?;
                 Ok(DoCtrl::Map {
-                    source: PyShared::new(m.source.clone_ref(py)),
-                    mapper: PyShared::new(m.mapper.clone_ref(py)),
+                    source: OpaqueRef::new(m.source.clone_ref(py)),
+                    mapper: OpaqueRef::new(m.mapper.clone_ref(py)),
                     mapper_meta: call_metadata_from_meta_obj(m.mapper_meta.bind(py)),
                 })
             }
             DoExprTag::FlatMap => {
                 let fm: PyRef<'_, PyFlatMap> = obj.extract()?;
                 Ok(DoCtrl::FlatMap {
-                    source: PyShared::new(fm.source.clone_ref(py)),
-                    binder: PyShared::new(fm.binder.clone_ref(py)),
+                    source: OpaqueRef::new(fm.source.clone_ref(py)),
+                    binder: OpaqueRef::new(fm.binder.clone_ref(py)),
                     binder_meta: call_metadata_from_meta_obj(fm.binder_meta.bind(py)),
                 })
             }
             DoExprTag::Perform => {
                 let pf: PyRef<'_, PyPerform> = obj.extract()?;
                 Ok(DoCtrl::Perform {
-                    effect: dispatch_from_shared(PyShared::new(pf.effect.clone_ref(py))),
+                    effect: dispatch_from_opaque(OpaqueRef::new(pf.effect.clone_ref(py))),
                 })
             }
             DoExprTag::Resume => {
@@ -1706,12 +1708,12 @@ pub(crate) fn classify_yielded_bound(
                     let kleisli = PyVM::extract_kleisli_ref(py, &item, "CreateContinuation")?;
                     let identity = kleisli
                         .py_identity()
-                        .or_else(|| Some(PyShared::new(item.clone().unbind())));
+                        .or_else(|| Some(OpaqueRef::new(item.clone().unbind())));
                     handlers.push(kleisli);
                     handler_identities.push(identity);
                 }
                 Ok(DoCtrl::CreateContinuation {
-                    expr: PyShared::new(program),
+                    expr: OpaqueRef::new(program),
                     handlers,
                     handler_identities,
                 })
@@ -1739,7 +1741,7 @@ pub(crate) fn classify_yielded_bound(
                 let eval: PyRef<'_, PyEval> = obj.extract()?;
                 let expr = eval.expr.clone_ref(py);
                 Ok(DoCtrl::Eval {
-                    expr: PyShared::new(expr),
+                    expr: OpaqueRef::new(expr),
                     metadata: None,
                 })
             }
@@ -1757,7 +1759,7 @@ pub(crate) fn classify_yielded_bound(
                     ))
                 })?;
                 Ok(DoCtrl::EvalInScope {
-                    expr: PyShared::new(expr),
+                    expr: OpaqueRef::new(expr),
                     scope,
                     metadata: None,
                 })
@@ -1765,7 +1767,7 @@ pub(crate) fn classify_yielded_bound(
             DoExprTag::AsyncEscape => {
                 let ae: PyRef<'_, PyAsyncEscape> = obj.extract()?;
                 Ok(DoCtrl::PythonAsyncSyntaxEscape {
-                    action: ae.action.clone_ref(py),
+                    action: OpaqueRef::new(ae.action.clone_ref(py)),
                 })
             }
             DoExprTag::Effect | DoExprTag::Unknown => Err(PyTypeError::new_err(
@@ -1799,7 +1801,7 @@ pub(crate) fn classify_yielded_bound(
             "<doexpr>".to_string(),
             0,
             None,
-            Some(PyShared::new(obj.clone().unbind())),
+            Some(OpaqueRef::new(obj.clone().unbind())),
         );
         return classify_doeff_generator_as_irstream(
             py,
@@ -1815,7 +1817,7 @@ pub(crate) fn classify_yielded_bound(
             return Ok(DoCtrl::GetCallStack);
         }
         return Ok(DoCtrl::Perform {
-            effect: dispatch_from_shared(PyShared::new(obj.clone().unbind())),
+            effect: dispatch_from_opaque(OpaqueRef::new(obj.clone().unbind())),
         });
     }
 
@@ -1866,7 +1868,7 @@ fn metadata_attr_as_u32(meta: &Bound<'_, PyAny>, key: &str) -> Option<u32> {
         .and_then(|v| v.extract::<u32>().ok())
 }
 
-fn metadata_attr_as_py(meta: &Bound<'_, PyAny>, key: &str) -> Option<PyShared> {
+fn metadata_attr_as_py(meta: &Bound<'_, PyAny>, key: &str) -> Option<OpaqueRef> {
     meta.cast::<PyDict>()
         .ok()
         .and_then(|dict| dict.get_item(key).ok().flatten())
@@ -1874,7 +1876,7 @@ fn metadata_attr_as_py(meta: &Bound<'_, PyAny>, key: &str) -> Option<PyShared> {
             if v.is_none() {
                 None
             } else {
-                Some(PyShared::new(v.unbind()))
+                Some(OpaqueRef::new(v.unbind()))
             }
         })
 }
@@ -3781,7 +3783,7 @@ mod tests {
             let inner_f = py.eval(c"lambda: 7", None, None).unwrap().unbind();
             let inner_apply = DoCtrl::Apply {
                 f: Box::new(DoCtrl::Pure {
-                    value: Value::Python(inner_f),
+                    value: Value::Opaque(OpaqueRef::new(inner_f)),
                 }),
                 args: vec![],
                 kwargs: vec![],
@@ -3798,10 +3800,10 @@ mod tests {
                 .expect("inner Apply conversion should produce object");
             let outer_apply = DoCtrl::Apply {
                 f: Box::new(DoCtrl::Pure {
-                    value: Value::Python(outer_f),
+                    value: Value::Opaque(OpaqueRef::new(outer_f)),
                 }),
                 args: vec![DoCtrl::Pure {
-                    value: Value::Python(inner_program.clone_ref(py)),
+                    value: Value::Opaque(OpaqueRef::new(inner_program.clone_ref(py))),
                 }],
                 kwargs: vec![],
                 metadata: CallMetadata::new(
@@ -3832,7 +3834,7 @@ mod tests {
                     assert!(matches!(args.as_slice(), [DoCtrl::Pure { .. }]));
                     match &args[0] {
                         DoCtrl::Pure {
-                            value: Value::Python(program),
+                            value: Value::Opaque(program),
                         } => {
                             assert!(program.bind(py).is_instance_of::<PyApply>());
                         }
@@ -3960,7 +3962,7 @@ mod tests {
             "PYVM-CATCHALL-001 FAIL: Value match must not use `_ =>` fallback"
         );
         let value_variants = [
-            "Value::Python",
+            "Value::Opaque",
             "Value::Unit",
             "Value::Int",
             "Value::String",


### PR DESCRIPTION
## Summary
- Introduces `OpaqueRef(Arc<dyn Any + Send + Sync>)` as the foundation type for decoupling VM core from PyO3
- Replaces `Py<PyAny>` and `PyShared` in all core data structures with `OpaqueRef`
- Bridge code resolves opaque handles via `OpaqueRefPyExt` extension trait (`.bind(py)`, `.as_py()`, `.clone_ref(py)`)

## Key changes
| Component | Before | After |
|-----------|--------|-------|
| `Value` enum | `Python(Py<PyAny>)` | `Opaque(OpaqueRef)` |
| `DoCtrl` fields | `PyShared` | `OpaqueRef` |
| `DispatchEffect` alias | `PyShared` | `OpaqueRef` |
| `PyException::Materialized` | `PyShared` | `OpaqueRef` |
| `PythonCall` fields | `PyShared` | `OpaqueRef` |
| `Continuation.program` | `Option<PyShared>` | `Option<OpaqueRef>` |
| `CallMetadata.program_call` | `Option<PyShared>` | `Option<OpaqueRef>` |
| `Kleisli::py_identity()` | `Option<PyShared>` | `Option<OpaqueRef>` |
| `Value::clone()` | Requires GIL (`Python::attach`) | Cheap Arc clone (no GIL) |

## Files changed (22)
- **New**: `packages/doeff-vm-core/src/opaque_ref.rs` — `OpaqueRef` type definition
- **Core types**: value.rs, do_ctrl.rs, driver.rs, effect.rs, frame.rs, continuation.rs, python_call.rs, capture.rs, ir_stream.rs, kleisli.rs
- **Bridge/glue**: py_shared.rs (OpaqueRefPyExt trait), pyvm.rs, dispatch.rs, lib.rs
- **Consuming code**: vm.rs, debug_state.rs, trace_state.rs
- **External crates**: doeff-core-effects (handlers, effects, scheduler), doeff-vm (lib, pyvm)

## Test evidence
- `cargo build` (doeff-vm-core + doeff-vm): **0 errors** (only pre-existing warnings)
- Pre-existing test compilation issues (PySpawn, StateHandlerFactory): unchanged
- **626 Python integration tests: all passed** (`tests/core/ tests/effects/ tests/program/ tests/error_handling/`)

## Test plan
- [x] `cargo build` succeeds for both crates
- [x] Python integration tests pass (626/626)
- [x] No new test failures introduced
- [x] `OpaqueRef` unit tests pass (roundtrip, clone, debug)

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)