### PR TITLE
Fix raw_run TypeError RunResult wrapping

### DIFF
--- a/packages/doeff-vm/src/pyvm.rs
+++ b/packages/doeff-vm/src/pyvm.rs
@@ -809,10 +809,10 @@ impl PyVM {
                 let exc_obj = exc.value_clone_ref(py);
                 let exc_bound = exc_obj.bind(py);
                 match gen.bind(py).call_method1("throw", (exc_bound,)) {
-                    Ok(yielded) => {
-                        let classified = self.classify_yielded(py, &yielded)?;
-                        Ok(PyCallOutcome::GenYield(classified))
-                    }
+                    Ok(yielded) => match self.classify_yielded(py, &yielded) {
+                        Ok(classified) => Ok(PyCallOutcome::GenYield(classified)),
+                        Err(e) => Ok(PyCallOutcome::GenError(pyerr_to_exception(py, e)?)),
+                    },
                     Err(e) if e.is_instance_of::<PyStopIteration>(py) => {
                         let return_value = extract_stop_iteration_value(py, &e)?;
                         Ok(PyCallOutcome::GenReturn(return_value))
@@ -869,10 +869,10 @@ impl PyVM {
         };
 
         match result {
-            Ok(yielded) => {
-                let classified = self.classify_yielded(py, &yielded)?;
-                Ok(PyCallOutcome::GenYield(classified))
-            }
+            Ok(yielded) => match self.classify_yielded(py, &yielded) {
+                Ok(classified) => Ok(PyCallOutcome::GenYield(classified)),
+                Err(e) => Ok(PyCallOutcome::GenError(pyerr_to_exception(py, e)?)),
+            },
             Err(e) if e.is_instance_of::<PyStopIteration>(py) => {
                 let return_value = extract_stop_iteration_value(py, &e)?;
                 Ok(PyCallOutcome::GenReturn(return_value))

--- a/packages/doeff-vm/tests/test_pyvm.py
+++ b/packages/doeff-vm/tests/test_pyvm.py
@@ -1278,6 +1278,23 @@ def test_module_level_run_basic():
     assert result.value == 42
 
 
+def test_module_level_run_wraps_invalid_top_level_yield_in_run_result():
+    """G11: invalid yielded values surface as Err RunResult, not raw TypeError."""
+    from doeff_vm import run
+
+    @do
+    def invalid_program() -> Program[object]:
+        yield object()
+        return "unreachable"
+
+    result = run(invalid_program())
+
+    assert result.is_err()
+    assert isinstance(result.error, TypeError)
+    assert str(result.error) == "yielded value must be EffectBase or DoExpr"
+    assert result.traceback_data is not None
+
+
 def test_module_level_run_with_env_and_store():
     """G11: run() accepts env and store dicts to seed the VM."""
     from doeff_vm import WithHandler, run, state

--- a/tests/core/test_vm_proto_004_traceback_data.py
+++ b/tests/core/test_vm_proto_004_traceback_data.py
@@ -36,3 +36,17 @@ def test_run_result_exposes_typed_traceback_data_without_exception_dunders() -> 
     assert isinstance(error, ValueError)
     assert not hasattr(error, "__doeff_traceback_data__")
     assert not hasattr(error, "__doeff_traceback__")
+
+
+def test_invalid_top_level_yield_returns_err_run_result_with_traceback_data() -> None:
+    @do
+    def body() -> Program[object]:
+        yield object()
+        return "unreachable"
+
+    result = run(body(), handlers=default_handlers())
+
+    assert result.is_err()
+    assert isinstance(result.error, TypeError)
+    assert str(result.error) == "yielded value must be EffectBase or DoExpr"
+    assert result.traceback_data is not None


### PR DESCRIPTION
## Summary
- convert generator yield-classification failures in the Rust VM into `GenError` outcomes instead of leaking raw `TypeError`
- add regression coverage for both `doeff.rust_vm.run()` and module-level `doeff_vm.run()`
- keep the fix scoped to `packages/doeff-vm/src/pyvm.rs` plus the relevant tests only

## Evidence
This issue file did not include an explicit Acceptance Criteria section, so the fix verifies the expected behavior directly:
- top-level invalid yields now return `RunResult.err` instead of raising a raw `TypeError`
- the resulting `RunResult` retains `traceback_data` for error enrichment paths

## Validation
- `cd packages/doeff-vm && uv tool run maturin develop --release`
  - built and installed editable `doeff-vm-0.1.0`
- `uv run pytest tests/core/test_vm_proto_004_traceback_data.py`
  - `3 passed`
- `uv run pytest packages/doeff-vm/tests/test_pyvm.py -k module_level_run_wraps_invalid_top_level_yield_in_run_result`
  - `1 passed`
- `uv run pytest tests/core/test_runtime_regressions_manual.py -k test_eval_expr_errors_reenter_try_except`
  - `1 passed`
- `uv run pytest tests/core/test_get_execution_context_effect.py -k "test_eval_typeerror_dispatches_get_execution_context_to_handlers or test_eval_typeerror_caught_exception_keeps_active_chain or test_eval_typeerror_keeps_context_entries_out_of_active_chain_storage"`
  - `3 passed`

Refs: gh-319
