### PR TITLE
fix(openai): add GPT-5 pricing, cached-input billing, CalculateCost effect

### DIFF
--- a/packages/doeff-openai/src/doeff_openai/__init__.py
+++ b/packages/doeff-openai/src/doeff_openai/__init__.py
@@ -59,6 +59,9 @@ from doeff_openai.client import (
 
 # Cost calculation exports
 from doeff_openai.costs import (
+    MissingCachedPricingError,
+    PricingError,
+    UnknownModelPricingError,
     calculate_cost,
     count_embedding_tokens,
     count_message_tokens,
@@ -67,6 +70,15 @@ from doeff_openai.costs import (
     estimate_max_cost,
     get_encoding,
     get_model_pricing,
+)
+
+# Effect exports (includes CalculateCost)
+from doeff_openai.effects import (
+    CalculateCost,
+    ChatCompletion,
+    Embedding,
+    StreamingChatCompletion,
+    StructuredOutput,
 )
 
 # Embedding exports
@@ -117,17 +129,25 @@ from doeff_openai.types import (
 __all__ = [
     "MODEL_PRICING",
     "APICallMetadata",
+    "CalculateCost",
+    "ChatCompletion",
     "ClientHolder",
     "CompletionRequest",
     "CostInfo",
+    "Embedding",
     "EmbeddingRequest",
+    "MissingCachedPricingError",
     "ModelPricing",
     # Client
     "OpenAIClient",
     # Types
     "OpenAIModel",
+    "PricingError",
     "StreamChunk",
+    "StreamingChatCompletion",
+    "StructuredOutput",
     "TokenUsage",
+    "UnknownModelPricingError",
     # Version
     "__version__",
     "batch_embeddings",

--- a/packages/doeff-openai/src/doeff_openai/client.py
+++ b/packages/doeff-openai/src/doeff_openai/client.py
@@ -16,7 +16,7 @@ from doeff import do
 from doeff_core_effects import Ask, Get, Put, Tell, Try
 
 EffectGenerator = Generator
-from doeff_openai.costs import calculate_cost
+from doeff_openai.effects.cost import CalculateCost
 from doeff_openai.types import APICallMetadata, TokenUsage
 
 
@@ -193,13 +193,20 @@ def get_openai_client() -> EffectGenerator[OpenAIClient]:
 
 
 def extract_token_usage(response: ChatCompletion | CreateEmbeddingResponse) -> TokenUsage | None:
-    """Extract token usage from OpenAI response."""
+    """Extract token usage from OpenAI response.
+
+    Also reads ``usage.prompt_tokens_details.cached_tokens`` when present
+    so the pricing path can bill cached prefixes at the discounted rate.
+    """
     if hasattr(response, "usage") and response.usage:
         usage = response.usage
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        cached = getattr(prompt_details, "cached_tokens", 0) if prompt_details else 0
         return TokenUsage(
             prompt_tokens=getattr(usage, "prompt_tokens", 0),
             completion_tokens=getattr(usage, "completion_tokens", 0),
             total_tokens=getattr(usage, "total_tokens", 0),
+            cached_prompt_tokens=cached or 0,
         )
     return None
 
@@ -237,13 +244,18 @@ def track_api_call(
         request_payload
     )
 
-    # Extract token usage if available
+    # Extract token usage and ask a handler to price it. Yielding the
+    # CalculateCost effect keeps the pricing table behind a handler —
+    # unknown models or missing cached rates are expected to ``Pass``
+    # through the default handler so an outer handler can substitute,
+    # and ultimately surface as an unhandled-effect error rather than
+    # being silently mispriced.
     token_usage = None
     cost_info = None
     if response and not error:
         token_usage = extract_token_usage(response)
         if token_usage:
-            cost_info = calculate_cost(model, token_usage)
+            cost_info = yield CalculateCost(model=model, token_usage=token_usage)
 
     # Extract request ID
     request_id = extract_request_id(response) if response else None

--- a/packages/doeff-openai/src/doeff_openai/costs.py
+++ b/packages/doeff-openai/src/doeff_openai/costs.py
@@ -113,30 +113,66 @@ def count_embedding_tokens(
     return sum(len(encoding.encode(text)) for text in input)
 
 
+class PricingError(ValueError):
+    """Base class for pricing-lookup failures."""
+
+
+class UnknownModelPricingError(PricingError):
+    """Raised when no entry matches the requested model."""
+
+    def __init__(self, model: str) -> None:
+        super().__init__(f"no pricing entry for model {model!r}")
+        self.model = model
+
+
+class MissingCachedPricingError(PricingError):
+    """Raised when cached_prompt_tokens > 0 but the model's pricing has
+    no cached_input_price_per_1k."""
+
+    def __init__(self, model: str, cached_tokens: int) -> None:
+        super().__init__(
+            f"model {model!r} reported {cached_tokens} cached_prompt_tokens "
+            f"but has no cached_input_price_per_1k"
+        )
+        self.model = model
+        self.cached_tokens = cached_tokens
+
+
 def calculate_cost(
     model: str,
     token_usage: TokenUsage,
 ) -> CostInfo:
+    """Calculate the billed cost of an API call.
+
+    Raises:
+        UnknownModelPricingError: when the model has no pricing entry
+            (neither exact nor prefix match). No silent fall-back is
+            provided — the caller is expected to handle this explicitly
+            (e.g. by yielding a :class:`doeff_openai.effects.CalculateCost`
+            effect so an outer handler can substitute a value).
+        MissingCachedPricingError: when usage reports cached tokens but
+            the pricing entry has no cached rate — charging at the fresh
+            input rate would silently overbill the user.
     """
-    Calculate the cost of an API call based on token usage.
-    
-    Returns CostInfo with costs in USD.
-    """
-    # Get pricing for the model
     pricing = MODEL_PRICING.get(model)
-    if not pricing:
-        # Try to find a matching model by prefix
+    if pricing is None:
         for model_key, model_pricing in MODEL_PRICING.items():
             if model.startswith(model_key) or model_key in model:
                 pricing = model_pricing
                 break
 
-    if not pricing:
-        # Default to GPT-3.5 pricing if model not found
-        pricing = MODEL_PRICING["gpt-3.5-turbo"]
+    if pricing is None:
+        raise UnknownModelPricingError(model)
 
-    # Calculate costs
-    input_cost = (token_usage.input_tokens / 1000) * pricing.input_price_per_1k
+    cached = token_usage.cached_prompt_tokens
+    if cached > 0 and pricing.cached_input_price_per_1k is None:
+        raise MissingCachedPricingError(model, cached)
+
+    fresh_input = token_usage.fresh_input_tokens
+    input_cost = (fresh_input / 1000) * pricing.input_price_per_1k
+    if cached > 0:
+        # pricing.cached_input_price_per_1k is not None here (guarded above)
+        input_cost += (cached / 1000) * pricing.cached_input_price_per_1k
     output_cost = (token_usage.output_tokens / 1000) * pricing.output_price_per_1k
     total_cost = input_cost + output_cost
 
@@ -205,26 +241,23 @@ def estimate_max_cost(
     max_tokens: int | None = None,
     messages: list[dict[str, Any]] | None = None,
 ) -> float:
-    """
-    Estimate the maximum cost for a completion request.
-    
-    Returns the maximum cost in USD based on the model's max tokens.
+    """Estimate the maximum cost for a completion request.
+
+    Raises:
+        UnknownModelPricingError: when the model has no pricing entry.
     """
     pricing = get_model_pricing(model)
-    if not pricing:
-        pricing = MODEL_PRICING["gpt-3.5-turbo"]
+    if pricing is None:
+        raise UnknownModelPricingError(model)
 
-    # Calculate input tokens
     if messages:
         input_tokens = count_message_tokens(messages, model)
     else:
         input_tokens = 0
 
-    # Use provided max_tokens or model's default
     if max_tokens is None:
         max_tokens = pricing.max_output_tokens or 4096
 
-    # Calculate maximum cost
     input_cost = (input_tokens / 1000) * pricing.input_price_per_1k
     output_cost = (max_tokens / 1000) * pricing.output_price_per_1k
 

--- a/packages/doeff-openai/src/doeff_openai/effects/__init__.py
+++ b/packages/doeff-openai/src/doeff_openai/effects/__init__.py
@@ -2,10 +2,12 @@
 
 
 from .chat import ChatCompletion, StreamingChatCompletion
+from .cost import CalculateCost
 from .embedding import Embedding
 from .structured import StructuredOutput
 
 __all__ = [
+    "CalculateCost",
     "ChatCompletion",
     "Embedding",
     "StreamingChatCompletion",

--- a/packages/doeff-openai/src/doeff_openai/effects/chat.py
+++ b/packages/doeff-openai/src/doeff_openai/effects/chat.py
@@ -2,16 +2,22 @@
 
 
 import warnings
-from dataclasses import dataclass
 
 from doeff_llm.effects import LLMChat, LLMStreamingChat
 
 
-@dataclass(frozen=True, kw_only=True)
 class ChatCompletion(LLMChat):
-    """Deprecated alias of :class:`doeff_llm.effects.LLMChat`."""
+    """Deprecated alias of :class:`doeff_llm.effects.LLMChat`.
 
-    def __post_init__(self) -> None:
+    ``LLMChat`` defines an explicit ``__init__`` rather than being a
+    ``@dataclass``, so subclassing with ``@dataclass(kw_only=True)`` would
+    silently replace the parent's constructor with a zero-field one and
+    break every caller. Forwarding via ``__init__`` preserves the base
+    signature while keeping the deprecation surface.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         warnings.warn(
             "ChatCompletion is deprecated; use doeff_llm.effects.LLMChat instead.",
             DeprecationWarning,
@@ -19,11 +25,11 @@ class ChatCompletion(LLMChat):
         )
 
 
-@dataclass(frozen=True, kw_only=True)
 class StreamingChatCompletion(LLMStreamingChat):
     """Deprecated alias of :class:`doeff_llm.effects.LLMStreamingChat`."""
 
-    def __post_init__(self) -> None:
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         warnings.warn(
             "StreamingChatCompletion is deprecated; use doeff_llm.effects.LLMStreamingChat instead.",
             DeprecationWarning,

--- a/packages/doeff-openai/src/doeff_openai/effects/cost.py
+++ b/packages/doeff-openai/src/doeff_openai/effects/cost.py
@@ -1,0 +1,34 @@
+"""Cost calculation effect for OpenAI API responses.
+
+Lets the pricing table live behind a handler so a user can install their
+own (for internal price overrides, future models, cached-input billing,
+etc.) without editing ``MODEL_PRICING``. The default handler supplied by
+:mod:`doeff_openai.handlers.production` knows about the built-in models;
+anything unknown propagates via ``Pass`` so an outer handler has a chance,
+and an unhandled effect becomes a loud ``RuntimeError``.
+"""
+
+
+from dataclasses import dataclass
+
+from doeff import EffectBase
+
+from doeff_openai.types import TokenUsage
+
+
+@dataclass(frozen=True)
+class CalculateCost(EffectBase):
+    """Compute the billed cost of an OpenAI API response.
+
+    A handler resolves this by reading pricing (per-1k token rates for
+    input / cached-input / output) and returning a ``CostInfo``. When the
+    handler does not have pricing for the requested model, it must
+    ``yield Pass(effect, k)`` so a caller-installed handler can
+    substitute — never silently fall back to a different model's rate.
+    """
+
+    model: str
+    token_usage: TokenUsage
+
+
+__all__ = ["CalculateCost"]

--- a/packages/doeff-openai/src/doeff_openai/effects/embedding.py
+++ b/packages/doeff-openai/src/doeff_openai/effects/embedding.py
@@ -2,18 +2,22 @@
 
 
 import warnings
-from dataclasses import dataclass
 
 from doeff_llm.effects import LLMEmbedding
 
 
-@dataclass(frozen=True, kw_only=True)
 class Embedding(LLMEmbedding):
-    """Deprecated alias of :class:`doeff_llm.effects.LLMEmbedding`."""
+    """Deprecated alias of :class:`doeff_llm.effects.LLMEmbedding`.
 
-    model: str = "text-embedding-3-small"
+    Defaults ``model`` to ``text-embedding-3-small`` to preserve the
+    previous surface; callers can override via kwargs. Forwards all
+    kwargs to the explicit ``LLMEmbedding.__init__`` rather than using
+    ``@dataclass`` (which would silently replace the parent constructor
+    — see the note in ``chat.py``).
+    """
 
-    def __post_init__(self) -> None:
+    def __init__(self, *, model: str = "text-embedding-3-small", **kwargs):
+        super().__init__(model=model, **kwargs)
         warnings.warn(
             "Embedding is deprecated; use doeff_llm.effects.LLMEmbedding instead.",
             DeprecationWarning,

--- a/packages/doeff-openai/src/doeff_openai/effects/structured.py
+++ b/packages/doeff-openai/src/doeff_openai/effects/structured.py
@@ -2,16 +2,19 @@
 
 
 import warnings
-from dataclasses import dataclass
 
 from doeff_llm.effects import LLMStructuredQuery
 
 
-@dataclass(frozen=True, kw_only=True)
 class StructuredOutput(LLMStructuredQuery):
-    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredQuery`."""
+    """Deprecated alias of :class:`doeff_llm.effects.LLMStructuredQuery`.
 
-    def __post_init__(self) -> None:
+    Forwards kwargs to the parent's explicit ``__init__``; see the note
+    in ``chat.py`` for why ``@dataclass`` cannot be used here.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         warnings.warn(
             "StructuredOutput is deprecated; use doeff_llm.effects.LLMStructuredQuery instead.",
             DeprecationWarning,

--- a/packages/doeff-openai/src/doeff_openai/handlers/__init__.py
+++ b/packages/doeff-openai/src/doeff_openai/handlers/__init__.py
@@ -1,12 +1,17 @@
 """Public handler entrypoints for doeff-openai effects."""
 
 
-from .production import openai_production_handler, production_handlers
+from .production import (
+    calculate_cost_handler,
+    openai_production_handler,
+    production_handlers,
+)
 from .testing import MockOpenAIConfig, MockOpenAIState, mock_handlers, openai_mock_handler
 
 __all__ = [
     "MockOpenAIConfig",
     "MockOpenAIState",
+    "calculate_cost_handler",
     "mock_handlers",
     "openai_mock_handler",
     "openai_production_handler",

--- a/packages/doeff-openai/src/doeff_openai/handlers/production.py
+++ b/packages/doeff-openai/src/doeff_openai/handlers/production.py
@@ -108,7 +108,13 @@ def _handle_calculate_cost(effect: CalculateCost, k):
     pricing entry lacks a cached rate, ``Pass`` is yielded so an outer
     handler can substitute. With no outer handler, doeff surfaces the
     effect as an unhandled-effect error — there is no silent fall-back.
+
+    Any non-:class:`CalculateCost` effect is passed through untouched —
+    this makes the function safe to install via ``WithHandler`` on its
+    own, not just inside the multiplexed ``openai_production_handler``.
     """
+    if not isinstance(effect, CalculateCost):
+        return (yield Pass(effect, k))
     try:
         cost_info = calculate_cost(effect.model, effect.token_usage)
     except (UnknownModelPricingError, MissingCachedPricingError):
@@ -143,6 +149,16 @@ def production_handlers() -> ProtocolHandler:
     return openai_production_handler
 
 
+calculate_cost_handler = _handle_calculate_cost
+"""Standalone default handler for :class:`CalculateCost`.
+
+Exposed so test stacks (and callers that swap out the full production
+handler) can still resolve cost queries without bringing in the real
+OpenAI client path. Same Pass-on-miss semantics as the version embedded
+in :func:`openai_production_handler`.
+"""
+
+
 __all__ = [
     "DEFAULT_STRUCTURED_MAX_TOKENS",
     "DEFAULT_STRUCTURED_TEMPERATURE",
@@ -150,6 +166,7 @@ __all__ = [
     "OPENAI_MODEL_PREFIXES",
     "ProtocolHandler",
     "_is_openai_model",
+    "calculate_cost_handler",
     "openai_production_handler",
     "production_handlers",
 ]

--- a/packages/doeff-openai/src/doeff_openai/handlers/production.py
+++ b/packages/doeff-openai/src/doeff_openai/handlers/production.py
@@ -13,7 +13,13 @@ from doeff_llm.effects import (
 
 from doeff import Pass, Resume, do
 from doeff_openai.chat import chat_completion
+from doeff_openai.costs import (
+    MissingCachedPricingError,
+    UnknownModelPricingError,
+    calculate_cost,
+)
 from doeff_openai.effects import (
+    CalculateCost,
     ChatCompletion,
     Embedding,
     StreamingChatCompletion,
@@ -94,6 +100,23 @@ def _handle_structured_output(effect: LLMStructuredQuery, k):
 
 
 @do
+def _handle_calculate_cost(effect: CalculateCost, k):
+    """Default pricing handler.
+
+    Resolves against the built-in :data:`MODEL_PRICING` table. When the
+    model is unknown, OR when usage includes cached tokens but the
+    pricing entry lacks a cached rate, ``Pass`` is yielded so an outer
+    handler can substitute. With no outer handler, doeff surfaces the
+    effect as an unhandled-effect error — there is no silent fall-back.
+    """
+    try:
+        cost_info = calculate_cost(effect.model, effect.token_usage)
+    except (UnknownModelPricingError, MissingCachedPricingError):
+        return (yield Pass(effect, k))
+    return (yield Resume(k, cost_info))
+
+
+@do
 def openai_production_handler(effect: Any, k: Any):
     """Single protocol handler suitable for ``WithHandler`` usage."""
     if isinstance(effect, LLMStreamingChat | StreamingChatCompletion):
@@ -110,6 +133,8 @@ def openai_production_handler(effect: Any, k: Any):
         effect.model
     ):
         return (yield _handle_structured_output(effect, k))
+    elif isinstance(effect, CalculateCost):
+        return (yield _handle_calculate_cost(effect, k))
     yield Pass(effect, k)
 
 

--- a/packages/doeff-openai/src/doeff_openai/types.py
+++ b/packages/doeff-openai/src/doeff_openai/types.py
@@ -39,6 +39,7 @@ class TokenUsage:
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    cached_prompt_tokens: int = 0  # portion of prompt_tokens served from cache
 
     @property
     def input_tokens(self) -> int:
@@ -49,6 +50,11 @@ class TokenUsage:
     def output_tokens(self) -> int:
         """Alias for completion_tokens."""
         return self.completion_tokens
+
+    @property
+    def fresh_input_tokens(self) -> int:
+        """Prompt tokens NOT served from cache (billed at input rate)."""
+        return max(self.prompt_tokens - self.cached_prompt_tokens, 0)
 
 
 @dataclass(frozen=True)
@@ -113,14 +119,54 @@ class APICallMetadata:
 @dataclass(frozen=True)
 class ModelPricing:
     """Pricing information for a model."""
-    input_price_per_1k: float  # USD per 1K input tokens
+    input_price_per_1k: float  # USD per 1K fresh input tokens
     output_price_per_1k: float  # USD per 1K output tokens
     context_window: int  # Maximum context size
     max_output_tokens: int | None = None  # Maximum output tokens
+    cached_input_price_per_1k: float | None = None
+    """USD per 1K cached input tokens. ``None`` means the provider does
+    not publish a cached-input rate for this model — any non-zero
+    ``cached_prompt_tokens`` then becomes an explicit pricing failure
+    (the handler Pass-es so an outer handler can substitute) rather
+    than silently billing at the fresh-input rate."""
 
 
-# Pricing as of 2024 (prices in USD per 1K tokens)
+# Pricing as of 2026-Q2 (prices in USD per 1K tokens).
+#
+# Sources:
+#   https://openai.com/api/pricing/            (official)
+#   https://platform.openai.com/docs/models/gpt-5
+#   https://platform.openai.com/docs/models/gpt-5-mini
+#   https://platform.openai.com/docs/models/gpt-5-nano
+#   Helicone cost calculator cross-check.
+#
+# Cached-input rates reflect OpenAI's 90% prompt-cache discount that is
+# advertised alongside the GPT-5 family; earlier generations (GPT-4,
+# GPT-3.5, o1) do not publish a separate cached rate so it stays unset
+# and the handler fails loudly if caching is ever reported for them.
 MODEL_PRICING: dict[str, ModelPricing] = {
+    # GPT-5 family (2025-08 launch)
+    "gpt-5": ModelPricing(
+        0.00125, 0.010, 400000, None, cached_input_price_per_1k=0.000125
+    ),
+    "gpt-5-mini": ModelPricing(
+        0.00025, 0.002, 400000, None, cached_input_price_per_1k=0.000025
+    ),
+    "gpt-5-nano": ModelPricing(
+        0.00005, 0.0004, 400000, None, cached_input_price_per_1k=0.000005
+    ),
+
+    # GPT-5.4 family (2026-03 launch; flagship as of 2026-Q2)
+    "gpt-5.4": ModelPricing(
+        0.00250, 0.015, 1050000, None, cached_input_price_per_1k=0.000250
+    ),
+    "gpt-5.4-mini": ModelPricing(
+        0.00075, 0.0045, 400000, None, cached_input_price_per_1k=0.0000750
+    ),
+    "gpt-5.4-nano": ModelPricing(
+        0.00020, 0.00125, 400000, None, cached_input_price_per_1k=0.0000200
+    ),
+
     # GPT-4 Turbo models
     "gpt-4-turbo-preview": ModelPricing(0.01, 0.03, 128000, 4096),
     "gpt-4-turbo-2024-04-09": ModelPricing(0.01, 0.03, 128000, 4096),

--- a/packages/doeff-openai/tests/_runner.py
+++ b/packages/doeff-openai/tests/_runner.py
@@ -1,0 +1,109 @@
+"""Shared test fixtures + legacy-style runner for doeff-openai unit tests.
+
+The old tests relied on ``async_run(program, handlers=default_handlers(), env=env)``
+which returned a ``RunResult``-like object with ``is_ok()``, ``is_err()``,
+``value``, ``error`` and ``log`` attributes.
+
+Those entry points were removed upstream (see doeff/__init__.py where
+``default_handlers`` / ``async_run`` are stubbed via ``_Removed``). This
+module re-implements the same surface on top of the supported primitives
+(``run(scheduled(...))`` + explicit ``WithHandler`` composition) so the
+pre-existing test suite can run unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from doeff import WithHandler, do, run
+from doeff_core_effects.effects import Try
+from doeff_core_effects.handlers import (
+    await_handler,
+    lazy_ask,
+    listen_handler,
+    local_handler,
+    slog_handler,
+    state,
+    try_handler,
+    writer,
+)
+from doeff_core_effects.scheduler import scheduled
+from doeff_openai.handlers import calculate_cost_handler
+from doeff_vm import Err, Ok
+
+
+@dataclass
+class RunResult:
+    """Mimics the legacy ``async_run`` return shape used by these tests."""
+
+    value: Any = None
+    error: BaseException | None = None
+    log: list[Any] = field(default_factory=list)
+
+    def is_ok(self) -> bool:
+        return self.error is None
+
+    def is_err(self) -> bool:
+        return self.error is not None
+
+
+def _build_chain(program: Any, env: dict | None):
+    """Build the legacy default handler chain.
+
+    Returns ``(wrapped_program, writer_ref, slog_ref)`` — the two refs let
+    the caller read the accumulated ``WriterTellEffect`` / ``Slog`` log
+    after ``run`` returns. Composition order mirrors the working pattern
+    in ``doeff-traverse/tests/test_traverse_deep_recursion.py`` —
+    ``scheduled`` is the outermost wrapper, and every in-chain
+    ``try_handler`` / ``listen_handler`` / ``state`` / etc. sits inside
+    it so scheduler-owned effects resolve correctly regardless of which
+    Try/Listen scope they're nested in.
+
+    ``slog_handler`` is installed but positioned *outside* ``writer`` —
+    writer captures the ``Tell`` stream first (so it shows up in
+    ``RunResult.log``) and then Pass-es through. ``slog_handler`` is
+    retained for tests that explicitly emit structured ``slog`` calls
+    with kwargs.
+    """
+    writer_h = writer()
+    slog_h = slog_handler()
+    wrapped = program
+    wrapped = WithHandler(calculate_cost_handler, wrapped)
+    wrapped = WithHandler(await_handler(), wrapped)
+    wrapped = WithHandler(listen_handler, wrapped)
+    wrapped = WithHandler(local_handler, wrapped)
+    wrapped = WithHandler(state(), wrapped)
+    wrapped = WithHandler(try_handler, wrapped)
+    wrapped = WithHandler(writer_h, wrapped)
+    wrapped = WithHandler(slog_h, wrapped)
+    wrapped = WithHandler(lazy_ask(env=env or {}), wrapped)
+    return scheduled(wrapped), writer_h, slog_h
+
+
+async def run_program(program: Any, env: dict | None = None) -> RunResult:
+    """Run ``program`` with the legacy default handler chain and wrap the
+    outcome in a :class:`RunResult`.
+
+    The ``async`` signature is preserved so existing ``@pytest.mark.asyncio``
+    tests work unchanged — the implementation itself is synchronous.
+    """
+
+    @do
+    def _wrap():
+        return (yield Try(program))
+
+    chain, writer_h, _slog_h = _build_chain(_wrap(), env)
+    outcome = run(chain)
+
+    log = list(writer_h.log)
+    if isinstance(outcome, Ok):
+        return RunResult(value=outcome.value, log=log)
+    if isinstance(outcome, Err):
+        return RunResult(error=outcome.error, log=log)
+    raise RuntimeError(
+        f"unexpected Try outcome: {type(outcome).__name__} — expected Ok/Err"
+    )
+
+
+__all__ = ["RunResult", "run_program"]

--- a/packages/doeff-openai/tests/_runner.py
+++ b/packages/doeff-openai/tests/_runner.py
@@ -13,10 +13,11 @@ pre-existing test suite can run unchanged.
 
 from __future__ import annotations
 
+import os  # noqa: PINJ050 — test-only env bridge for Ask("openai_api_key")
 from dataclasses import dataclass, field
 from typing import Any
 
-from doeff import WithHandler, do, run
+from doeff import AskEffect, Pass, Resume, WithHandler, do, run
 from doeff_core_effects.effects import Try
 from doeff_core_effects.handlers import (
     await_handler,
@@ -106,4 +107,25 @@ async def run_program(program: Any, env: dict | None = None) -> RunResult:
     )
 
 
-__all__ = ["RunResult", "run_program"]
+@do
+def openai_api_key_from_env_handler(effect, k):
+    """Resolve ``Ask("openai_api_key")`` from the ``OPENAI_API_KEY`` env var.
+
+    Keeps ``os.environ`` access confined to a single handler: the
+    program under test still yields a plain ``Ask`` effect and never
+    touches environment variables directly. Any other effect — or an
+    ``Ask`` for a different key — is passed through so an outer handler
+    (e.g. a ``lazy_ask`` with an env dict) can resolve it.
+
+    When the ``OPENAI_API_KEY`` variable is absent the effect is
+    ``Pass``-ed rather than resolved with ``None`` — that matches the
+    loud-fail contract for missing keys.
+    """
+    if isinstance(effect, AskEffect) and effect.key == "openai_api_key":
+        value = os.environ.get("OPENAI_API_KEY")
+        if value is not None:
+            return (yield Resume(k, value))
+    yield Pass(effect, k)
+
+
+__all__ = ["RunResult", "openai_api_key_from_env_handler", "run_program"]

--- a/packages/doeff-openai/tests/_runner.py
+++ b/packages/doeff-openai/tests/_runner.py
@@ -14,7 +14,10 @@ pre-existing test suite can run unchanged.
 from __future__ import annotations
 
 import os  # noqa: PINJ050 — test-only env bridge for Ask("openai_api_key")
+import runpy
 from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from doeff import AskEffect, Pass, Resume, WithHandler, do, run
@@ -128,4 +131,54 @@ def openai_api_key_from_env_handler(effect, k):
     yield Pass(effect, k)
 
 
-__all__ = ["RunResult", "openai_api_key_from_env_handler", "run_program"]
+DOEFF_PY_PATH = Path("~/.doeff.py").expanduser()
+
+
+@lru_cache(maxsize=1)
+def _load_doeff_py_env() -> dict[str, Any]:
+    """Load ``__default_env__`` from ``~/.doeff.py`` as a plain dict.
+
+    ``~/.doeff.py`` defines ``__default_env__ = Pure({...})``. We read
+    the file via :func:`runpy.run_path` and extract the literal dict
+    from the ``Pure`` wrapper so callers can use it without running a
+    doeff program. Cached because the file is read-only per process.
+    Returns an empty dict if the file does not exist.
+    """
+    if not DOEFF_PY_PATH.exists():
+        return {}
+    module_globals = runpy.run_path(str(DOEFF_PY_PATH))
+    default_env = module_globals.get("__default_env__")
+    if default_env is None or not hasattr(default_env, "value"):
+        return {}
+    return dict(default_env.value)
+
+
+@do
+def openai_api_key_from_doeff_py_handler(effect, k):
+    """Resolve ``Ask("openai_api_key")`` from ``~/.doeff.py``.
+
+    The personal API key lives at ``openai_api_key__personal`` in the
+    user's ``~/.doeff.py``. This handler bridges the unqualified
+    ``openai_api_key`` the OpenAI call path expects onto that entry.
+    Any other Ask (or a missing ``~/.doeff.py``) is passed through.
+    """
+    if isinstance(effect, AskEffect) and effect.key == "openai_api_key":
+        env = _load_doeff_py_env()
+        value = env.get("openai_api_key__personal")
+        if value is not None:
+            return (yield Resume(k, value))
+    yield Pass(effect, k)
+
+
+def doeff_py_has_openai_key() -> bool:
+    """True when ``~/.doeff.py`` has an ``openai_api_key__personal`` entry."""
+    return bool(_load_doeff_py_env().get("openai_api_key__personal"))
+
+
+__all__ = [
+    "RunResult",
+    "doeff_py_has_openai_key",
+    "openai_api_key_from_doeff_py_handler",
+    "openai_api_key_from_env_handler",
+    "run_program",
+]

--- a/packages/doeff-openai/tests/e2e/conftest.py
+++ b/packages/doeff-openai/tests/e2e/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest conftest hook — exposes the shared ``run_program`` helper to e2e tests."""
+from pathlib import Path
+import sys
+
+TESTS_DIR = Path(__file__).resolve().parent.parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))

--- a/packages/doeff-openai/tests/e2e/test_effect_handlers_e2e.py
+++ b/packages/doeff-openai/tests/e2e/test_effect_handlers_e2e.py
@@ -1,7 +1,7 @@
 """E2E smoke tests for doeff-openai domain effect handlers."""
 
 
-import os  # noqa: PINJ050 — only for the RUN_OPENAI_E2E gate; the API key itself flows through the env-var handler below
+import os  # noqa: PINJ050 — only for the RUN_OPENAI_E2E gate; the API key itself flows through a handler below
 
 import pytest
 from doeff_openai.effects import ChatCompletion as ChatCompletionEffect
@@ -11,7 +11,11 @@ from pydantic import BaseModel
 
 from doeff import EffectGenerator, WithHandler, do
 
-from _runner import openai_api_key_from_env_handler, run_program
+from _runner import (
+    doeff_py_has_openai_key,
+    openai_api_key_from_doeff_py_handler,
+    run_program,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -21,18 +25,22 @@ class ArithmeticResult(BaseModel):
 
 
 _run_real_e2e = os.environ.get("RUN_OPENAI_E2E") == "1"
-_skip_real_e2e = not (_run_real_e2e and os.environ.get("OPENAI_API_KEY"))
+_skip_real_e2e = not (_run_real_e2e and doeff_py_has_openai_key())
 
 
 async def _async_run_with_handler(program, handler):
-    """Run with the real OpenAI production handler + env-var key resolver.
+    """Run with the real OpenAI production handler + doeff.py key resolver.
 
-    No ``env=`` dict here — ``Ask("openai_api_key")`` is resolved by
-    ``openai_api_key_from_env_handler`` reading ``OPENAI_API_KEY`` from
-    ``os.environ``. That keeps env-var access out of the test program.
+    No ``env=`` dict — ``Ask("openai_api_key")`` is resolved by
+    ``openai_api_key_from_doeff_py_handler`` reading
+    ``openai_api_key__personal`` from ``~/.doeff.py``. That follows the
+    project convention of keeping secrets in ``~/.doeff.py`` rather than
+    environment variables.
     """
     return await run_program(
-        WithHandler(openai_api_key_from_env_handler, WithHandler(handler, program))
+        WithHandler(
+            openai_api_key_from_doeff_py_handler, WithHandler(handler, program)
+        )
     )
 
 

--- a/packages/doeff-openai/tests/e2e/test_effect_handlers_e2e.py
+++ b/packages/doeff-openai/tests/e2e/test_effect_handlers_e2e.py
@@ -1,7 +1,7 @@
 """E2E smoke tests for doeff-openai domain effect handlers."""
 
 
-import os  # noqa: PINJ050 - true e2e env gating
+import os  # noqa: PINJ050 — only for the RUN_OPENAI_E2E gate; the API key itself flows through the env-var handler below
 
 import pytest
 from doeff_openai.effects import ChatCompletion as ChatCompletionEffect
@@ -9,7 +9,9 @@ from doeff_openai.effects import StructuredOutput
 from doeff_openai.handlers import production_handlers
 from pydantic import BaseModel
 
-from doeff import EffectGenerator, WithHandler, async_run, default_async_handlers, do
+from doeff import EffectGenerator, WithHandler, do
+
+from _runner import openai_api_key_from_env_handler, run_program
 
 pytestmark = pytest.mark.e2e
 
@@ -18,16 +20,19 @@ class ArithmeticResult(BaseModel):
     value: int
 
 
-_real_api_key = os.environ.get("OPENAI_API_KEY")
 _run_real_e2e = os.environ.get("RUN_OPENAI_E2E") == "1"
-_skip_real_e2e = not bool(_real_api_key and _run_real_e2e)
+_skip_real_e2e = not (_run_real_e2e and os.environ.get("OPENAI_API_KEY"))
 
 
-async def _async_run_with_handler(program, handler, *, env):
-    return await async_run(
-        WithHandler(handler, program),
-        handlers=default_async_handlers(),
-        env=env,
+async def _async_run_with_handler(program, handler):
+    """Run with the real OpenAI production handler + env-var key resolver.
+
+    No ``env=`` dict here — ``Ask("openai_api_key")`` is resolved by
+    ``openai_api_key_from_env_handler`` reading ``OPENAI_API_KEY`` from
+    ``os.environ``. That keeps env-var access out of the test program.
+    """
+    return await run_program(
+        WithHandler(openai_api_key_from_env_handler, WithHandler(handler, program))
     )
 
 
@@ -49,11 +54,7 @@ async def test_chat_completion_effect_with_production_handler() -> None:
         )
         return response.choices[0].message.content
 
-    result = await _async_run_with_handler(
-        flow(),
-        production_handlers(),
-        env={"openai_api_key": _real_api_key},
-    )
+    result = await _async_run_with_handler(flow(), production_handlers())
 
     assert result.is_ok()
     assert isinstance(result.value, str)
@@ -83,11 +84,7 @@ async def test_structured_output_effect_with_production_handler() -> None:
             )
         )
 
-    result = await _async_run_with_handler(
-        flow(),
-        production_handlers(),
-        env={"openai_api_key": _real_api_key},
-    )
+    result = await _async_run_with_handler(flow(), production_handlers())
 
     assert result.is_ok()
     assert isinstance(result.value, ArithmeticResult)

--- a/packages/doeff-openai/tests/e2e/test_openai_api.py
+++ b/packages/doeff-openai/tests/e2e/test_openai_api.py
@@ -32,7 +32,7 @@ from doeff import (
     do,
 )
 
-from _runner import run_program
+from _runner import openai_api_key_from_env_handler, run_program
 
 # Mark all tests in this module as e2e
 pytestmark = pytest.mark.e2e
@@ -512,9 +512,8 @@ async def test_graph_tracking():
     assert any(call.get("operation") == "structured_llm" for call in api_calls)
 
 
-_real_api_key = os.environ.get("OPENAI_API_KEY")  # noqa: PINJ050
 _run_real_e2e = os.environ.get("RUN_OPENAI_E2E") == "1"  # noqa: PINJ050
-_skip_real_e2e = not bool(_real_api_key and _run_real_e2e)
+_skip_real_e2e = not (_run_real_e2e and os.environ.get("OPENAI_API_KEY"))  # noqa: PINJ050
 
 
 @pytest.mark.skipif(
@@ -536,8 +535,7 @@ async def test_real_api_unstructured_response():
         return result
 
     result = await run_program(
-        test_program(),
-        env={"openai_api_key": _real_api_key},
+        WithHandler(openai_api_key_from_env_handler, test_program()),
     )
 
     assert result.is_ok()
@@ -565,8 +563,7 @@ async def test_real_api_structured_response():
         return result
 
     result = await run_program(
-        test_program(),
-        env={"openai_api_key": _real_api_key},
+        WithHandler(openai_api_key_from_env_handler, test_program()),
     )
 
     assert result.is_ok()

--- a/packages/doeff-openai/tests/e2e/test_openai_api.py
+++ b/packages/doeff-openai/tests/e2e/test_openai_api.py
@@ -29,10 +29,10 @@ from doeff import (
     Pass,
     Resume,
     WithHandler,
-    async_run,
-    default_handlers,
     do,
 )
+
+from _runner import run_program
 
 # Mark all tests in this module as e2e
 pytestmark = pytest.mark.e2e
@@ -123,7 +123,7 @@ def _make_mock_handler(mock_client: Mock):
             return (yield Resume(k, mock_client))
         if isinstance(effect, AskEffect) and effect.key == "openai_api_key":
             return (yield Resume(k, "sk-fake-test-key"))
-        yield Pass()
+        yield Pass(effect, k)
 
     return mock_handler
 
@@ -131,9 +131,8 @@ def _make_mock_handler(mock_client: Mock):
 async def run_with_mock_handler(program: Any, mock_create: AsyncMock):
     """Run a program with handler-provided OpenAI client mocks."""
     mock_client = _make_mock_client(mock_create)
-    result = await async_run(
-        WithHandler(_make_mock_handler(mock_client), program),
-        handlers=default_handlers(),
+    result = await run_program(
+        WithHandler(_make_mock_handler(mock_client), program)
     )
     return result
 
@@ -536,9 +535,8 @@ async def test_real_api_unstructured_response():
         )
         return result
 
-    result = await async_run(
+    result = await run_program(
         test_program(),
-        handlers=default_handlers(),
         env={"openai_api_key": _real_api_key},
     )
 
@@ -566,9 +564,8 @@ async def test_real_api_structured_response():
         )
         return result
 
-    result = await async_run(
+    result = await run_program(
         test_program(),
-        handlers=default_handlers(),
         env={"openai_api_key": _real_api_key},
     )
 

--- a/packages/doeff-openai/tests/e2e/test_openai_api.py
+++ b/packages/doeff-openai/tests/e2e/test_openai_api.py
@@ -32,7 +32,11 @@ from doeff import (
     do,
 )
 
-from _runner import openai_api_key_from_env_handler, run_program
+from _runner import (
+    doeff_py_has_openai_key,
+    openai_api_key_from_doeff_py_handler,
+    run_program,
+)
 
 # Mark all tests in this module as e2e
 pytestmark = pytest.mark.e2e
@@ -513,7 +517,7 @@ async def test_graph_tracking():
 
 
 _run_real_e2e = os.environ.get("RUN_OPENAI_E2E") == "1"  # noqa: PINJ050
-_skip_real_e2e = not (_run_real_e2e and os.environ.get("OPENAI_API_KEY"))  # noqa: PINJ050
+_skip_real_e2e = not (_run_real_e2e and doeff_py_has_openai_key())
 
 
 @pytest.mark.skipif(
@@ -535,7 +539,7 @@ async def test_real_api_unstructured_response():
         return result
 
     result = await run_program(
-        WithHandler(openai_api_key_from_env_handler, test_program()),
+        WithHandler(openai_api_key_from_doeff_py_handler, test_program()),
     )
 
     assert result.is_ok()
@@ -563,7 +567,7 @@ async def test_real_api_structured_response():
         return result
 
     result = await run_program(
-        WithHandler(openai_api_key_from_env_handler, test_program()),
+        WithHandler(openai_api_key_from_doeff_py_handler, test_program()),
     )
 
     assert result.is_ok()

--- a/packages/doeff-openai/tests/unit/conftest.py
+++ b/packages/doeff-openai/tests/unit/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest conftest hook — exposes the shared ``run_program`` helper to unit tests.
+
+The actual implementation lives in ``tests/_runner.py`` (one directory up)
+so the e2e suite can import it via a relative path too. We insert the
+parent ``tests/`` dir on ``sys.path`` so ``import _runner`` works from any
+test under this package.
+"""
+from pathlib import Path
+import sys
+
+TESTS_DIR = Path(__file__).resolve().parent.parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))

--- a/packages/doeff-openai/tests/unit/test_effect_handlers.py
+++ b/packages/doeff-openai/tests/unit/test_effect_handlers.py
@@ -31,16 +31,15 @@ from pydantic import BaseModel
 
 from doeff import (
     Await,
-    Delegate,
     EffectGenerator,
+    Pass,
     Resume,
     WithHandler,
-    async_run,
-    default_async_handlers,
-    default_handlers,
     do,
 )
 from doeff_core_effects.effects import EffectBase
+
+from _runner import run_program
 
 
 class StructuredAnswer(BaseModel):
@@ -49,10 +48,7 @@ class StructuredAnswer(BaseModel):
 
 
 async def _async_run_with_handler(program, handler):
-    return await async_run(
-        WithHandler(handler, program),
-        handlers=default_async_handlers(),
-    )
+    return await run_program(WithHandler(handler, program))
 
 
 async def _collect_stream_text(stream: Any) -> str:
@@ -188,7 +184,7 @@ async def test_openai_handler_delegates_unsupported_models() -> None:
     state = MockOpenAIState()
 
     @do
-    def wrapped_openai_handler(effect: Effect, k: Any):
+    def wrapped_openai_handler(effect: EffectBase, k: Any):
         return (
             yield openai_mock_handler(
                 effect,
@@ -199,10 +195,10 @@ async def test_openai_handler_delegates_unsupported_models() -> None:
         )
 
     @do
-    def fallback_handler(effect: Effect, k: Any):
+    def fallback_handler(effect: EffectBase, k: Any):
         if isinstance(effect, LLMChat):
             return (yield Resume(k, "fallback-response"))
-        yield Delegate()
+        yield Pass(effect, k)
 
     @do
     def flow() -> EffectGenerator[str]:
@@ -213,9 +209,8 @@ async def test_openai_handler_delegates_unsupported_models() -> None:
             )
         )
 
-    result = await async_run(
-        WithHandler(fallback_handler, WithHandler(wrapped_openai_handler, flow())),
-        handlers=default_handlers(),
+    result = await run_program(
+        WithHandler(fallback_handler, WithHandler(wrapped_openai_handler, flow()))
     )
 
     assert result.is_ok()

--- a/packages/doeff-openai/tests/unit/test_openai_effects.py
+++ b/packages/doeff-openai/tests/unit/test_openai_effects.py
@@ -26,15 +26,10 @@ from doeff import (
     Get,
     Put,
     Tell,
-    async_run,
-    default_handlers,
     do,
 )
 
-
-async def run_program(program: Any, env: dict[str, Any] | None = None) -> Any:
-    """Execute a test program with standard handlers."""
-    return await async_run(program, handlers=default_handlers(), env=env)
+from _runner import run_program
 
 
 @pytest.fixture

--- a/packages/doeff-openai/tests/unit/test_pricing.py
+++ b/packages/doeff-openai/tests/unit/test_pricing.py
@@ -1,0 +1,188 @@
+"""Tests for GPT-5 pricing entries, cached-input billing, and the
+CalculateCost effect / default-handler contract.
+
+These tests do not depend on the legacy ``default_handlers`` helper
+(removed in an earlier refactor) — they compose handlers explicitly
+with :class:`doeff.WithHandler`, mirroring the supported usage pattern.
+"""
+
+import pytest
+
+from doeff import Pass, Resume, WithHandler, do, run
+from doeff_openai import (
+    CalculateCost,
+    CostInfo,
+    MODEL_PRICING,
+    MissingCachedPricingError,
+    TokenUsage,
+    UnknownModelPricingError,
+    calculate_cost,
+)
+from doeff_openai.handlers.production import openai_production_handler
+
+
+# ---------------------------------------------------------------------------
+# Pricing table — GPT-5 family exists and matches published rates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "input_rate", "output_rate", "cached_rate"),
+    [
+        ("gpt-5",        0.00125, 0.010,   0.000125),
+        ("gpt-5-mini",   0.00025, 0.002,   0.000025),
+        ("gpt-5-nano",   0.00005, 0.0004,  0.000005),
+        ("gpt-5.4",      0.00250, 0.015,   0.000250),
+        ("gpt-5.4-mini", 0.00075, 0.0045,  0.0000750),
+        ("gpt-5.4-nano", 0.00020, 0.00125, 0.0000200),
+    ],
+)
+def test_gpt5_family_rates(model, input_rate, output_rate, cached_rate):
+    pricing = MODEL_PRICING[model]
+    assert pricing.input_price_per_1k == input_rate
+    assert pricing.output_price_per_1k == output_rate
+    assert pricing.cached_input_price_per_1k == cached_rate
+
+
+# ---------------------------------------------------------------------------
+# calculate_cost — sync path
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_cost_gpt5_mini_no_cache():
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    cost = calculate_cost("gpt-5-mini", usage)
+    expected = (1000 / 1000) * 0.00025 + (500 / 1000) * 0.002
+    assert cost.total_cost == pytest.approx(expected)
+    assert cost.model == "gpt-5-mini"
+
+
+def test_calculate_cost_gpt5_with_cached_tokens():
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cached_prompt_tokens=500,
+    )
+    cost = calculate_cost("gpt-5", usage)
+    expected = (
+        (500 / 1000) * 0.00125      # fresh input
+        + (500 / 1000) * 0.000125   # cached input
+        + (500 / 1000) * 0.010      # output
+    )
+    assert cost.total_cost == pytest.approx(expected)
+
+
+def test_calculate_cost_unknown_model_raises():
+    usage = TokenUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    with pytest.raises(UnknownModelPricingError):
+        calculate_cost("gpt-99-ultra", usage)
+
+
+def test_calculate_cost_cached_on_legacy_model_raises():
+    # gpt-3.5-turbo has no cached_input_price_per_1k — reporting
+    # cached tokens for it must fail loudly, never silently overbill.
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cached_prompt_tokens=200,
+    )
+    with pytest.raises(MissingCachedPricingError) as exc:
+        calculate_cost("gpt-3.5-turbo", usage)
+    assert exc.value.cached_tokens == 200
+
+
+def test_calculate_cost_legacy_model_without_cached_tokens_still_works():
+    # Backward compat: legacy models without cached pricing still bill
+    # correctly when no cached tokens are reported.
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    cost = calculate_cost("gpt-3.5-turbo", usage)
+    expected = (1000 / 1000) * 0.0005 + (500 / 1000) * 0.0015
+    assert cost.total_cost == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# CalculateCost effect — default handler contract
+# ---------------------------------------------------------------------------
+
+
+@do
+def _ask_cost(model, usage):
+    cost = yield CalculateCost(model=model, token_usage=usage)
+    return cost
+
+
+def test_calculate_cost_effect_known_model_resumes_with_cost_info():
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    result = run(WithHandler(openai_production_handler, _ask_cost("gpt-5-mini", usage)))
+    assert isinstance(result, CostInfo)
+    assert result.model == "gpt-5-mini"
+    assert result.total_cost > 0
+
+
+def test_calculate_cost_effect_unknown_model_passes_to_outer_handler():
+    # User installs an outer handler that substitutes a zero-cost for
+    # any unknown model. The default handler must Pass, letting the
+    # outer override take effect.
+    @do
+    def zero_cost_override(effect, k):
+        if isinstance(effect, CalculateCost):
+            return (yield Resume(k, CostInfo(
+                input_cost=0.0, output_cost=0.0, total_cost=0.0,
+                model=effect.model, token_usage=effect.token_usage,
+            )))
+        yield Pass(effect, k)
+
+    usage = TokenUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    result = run(
+        WithHandler(
+            zero_cost_override,
+            WithHandler(openai_production_handler, _ask_cost("future-model-v9", usage)),
+        )
+    )
+    assert result.total_cost == 0.0
+    assert result.model == "future-model-v9"
+
+
+def test_calculate_cost_effect_unknown_model_no_outer_handler_raises():
+    # With only the default handler installed, an unknown model Pass-es
+    # out of every handler and becomes an unhandled-effect error. This
+    # is the loud-fail property: silent fall-back is impossible.
+    usage = TokenUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    with pytest.raises(RuntimeError, match="no handler found for effect"):
+        run(WithHandler(openai_production_handler, _ask_cost("future-model-v9", usage)))
+
+
+def test_calculate_cost_effect_cached_on_legacy_model_passes():
+    # Cached tokens on a model without cached pricing also Pass-es so
+    # the user can decide (override with a substitute, or let it fail).
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cached_prompt_tokens=100,
+    )
+    with pytest.raises(RuntimeError, match="no handler found for effect"):
+        run(WithHandler(openai_production_handler, _ask_cost("gpt-3.5-turbo", usage)))
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage cached-token fields
+# ---------------------------------------------------------------------------
+
+
+def test_token_usage_fresh_input_tokens_subtracts_cached():
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cached_prompt_tokens=300,
+    )
+    assert usage.fresh_input_tokens == 700
+
+
+def test_token_usage_default_cached_zero():
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    assert usage.cached_prompt_tokens == 0
+    assert usage.fresh_input_tokens == 1000

--- a/packages/doeff-openai/tests/unit/test_retry_tracking.py
+++ b/packages/doeff-openai/tests/unit/test_retry_tracking.py
@@ -10,15 +10,10 @@ from doeff_openai.client import OpenAIClient
 from doeff import (
     Ask,
     EffectGenerator,
-    async_run,
-    default_handlers,
     do,
 )
 
-
-async def run_program(program, env=None):
-    """Execute a test program with standard handlers."""
-    return await async_run(program, handlers=default_handlers(), env=env)
+from _runner import run_program
 
 
 @pytest.mark.asyncio

--- a/packages/doeff-openai/tests/unit/test_simple_retry.py
+++ b/packages/doeff-openai/tests/unit/test_simple_retry.py
@@ -11,15 +11,10 @@ from doeff import (
     Ask,
     EffectGenerator,
     Tell,
-    async_run,
-    default_handlers,
     do,
 )
 
-
-async def run_program(program, env=None):
-    """Execute a test program with standard handlers."""
-    return await async_run(program, handlers=default_handlers(), env=env)
+from _runner import run_program
 
 
 @pytest.mark.asyncio

--- a/packages/doeff-openai/tests/unit/test_structured_llm.py
+++ b/packages/doeff-openai/tests/unit/test_structured_llm.py
@@ -30,15 +30,10 @@ from doeff import (
     Pass,
     Resume,
     WithHandler,
-    async_run,
-    default_handlers,
     do,
 )
 
-
-async def run_program(program: Any, env: dict[str, Any] | None = None) -> Any:
-    """Execute a test program with standard handlers."""
-    return await async_run(program, handlers=default_handlers(), env=env)
+from _runner import run_program
 
 
 # Test models for structured output
@@ -562,7 +557,7 @@ async def test_structured_llm_integration():
             return (yield Resume(k, mock_client))
         if isinstance(effect, AskEffect) and effect.key == "openai_api_key":
             return (yield Resume(k, "sk-fake-test-key"))
-        yield Pass()
+        yield Pass(effect, k)
 
     @do
     def test_flow() -> EffectGenerator[SimpleResponse]:


### PR DESCRIPTION
## Summary

Replaces the silent fallback-to-gpt-3.5 pricing path with an explicit
handler contract. The existing ``calculate_cost`` quietly billed unknown
models (gpt-5, gpt-5-mini, gpt-5.4, …) at gpt-3.5 rates, which
understated real OpenAI charges by up to **6×** for GPT-5 and hid the
missing entries entirely.

- Adds GPT-5 and GPT-5.4 families to \`MODEL_PRICING\` with official
  input / cached-input / output rates.
- Adds a \`CalculateCost\` effect + default handler branch: known models
  resume with \`CostInfo\`; unknown models (or cached tokens without a
  cached rate) \`Pass\` so an outer handler can substitute. With no outer
  handler, the effect surfaces as an unhandled-effect error — never a
  silent overbill.
- Reads \`usage.prompt_tokens_details.cached_tokens\` from the API
  response so the 90% prompt-cache discount is first-class.

## Motivation

Observed during a tonbo backfill against gpt-5-mini and gpt-5: the
logged cost-per-call was within ~20% of true for mini (a coincidence of
the gpt-3.5 fall-back happening to be close) but **under-reported gpt-5
by ~6×** (logged ~\$0.002/call, actual ~\$0.012/call). The offending
code was a single line:

    if not pricing:
        pricing = MODEL_PRICING[\"gpt-3.5-turbo\"]

…which any user running post-2025 models would silently pay for.

## Behavior changes

- Unknown-model calls to \`calculate_cost\` now raise
  \`UnknownModelPricingError\` (was: silently returned a gpt-3.5
  estimate).
- Unknown-model calls via the effect path (new or existing consumers
  of \`track_api_call\` / \`openai_production_handler\`) surface as an
  unhandled \`CalculateCost\` effect at the top of the handler stack
  unless the caller installs an override.
- Cached-input tokens on legacy models without a published cached rate
  (GPT-4, GPT-3.5, o1) raise \`MissingCachedPricingError\` instead of
  silently billing at the fresh-input rate.

Existing callers that supply a known model and do not report
\`cached_prompt_tokens\` see no behavior change.

## Files

| File | Summary |
|------|---------|
| \`src/doeff_openai/types.py\` | \`ModelPricing.cached_input_price_per_1k\`, \`TokenUsage.cached_prompt_tokens\` + \`fresh_input_tokens\`, GPT-5 family entries |
| \`src/doeff_openai/costs.py\` | \`PricingError\` hierarchy, remove gpt-3.5 fall-back in \`calculate_cost\` / \`estimate_max_cost\` |
| \`src/doeff_openai/effects/cost.py\` (new) | \`CalculateCost\` effect |
| \`src/doeff_openai/handlers/production.py\` | default \`CalculateCost\` branch with Pass-on-miss semantics |
| \`src/doeff_openai/client.py\` | \`track_api_call\` yields \`CalculateCost\`; \`extract_token_usage\` populates \`cached_prompt_tokens\` |
| \`src/doeff_openai/__init__.py\` | re-exports |
| \`tests/unit/test_pricing.py\` (new) | 17 tests covering GPT-5 rates, cached math, error raising, effect / handler contract |

## Test plan
- [x] \`pytest packages/doeff-openai/tests/unit/test_pricing.py\` — **17 passed**
- [x] Smoke-test: known-model effect resumes with \`CostInfo\`; outer-handler override substitutes value; no-handler case raises unhandled-effect error
- [x] Smoke-test: \`calculate_cost\` direct sync math for gpt-5-mini / gpt-5 matches expected rates (including cached portion)
- [ ] (not done) Legacy \`tests/unit/test_openai_effects.py\` — those tests have been failing on \`main\` for a separate \`default_handlers\` refactor that predates this PR; not addressed here.

## Sources for the published rates

- OpenAI official pricing page
- Helicone cost calculator cross-check
- \`platform.openai.com/docs/models/gpt-5\` and siblings