### PR TITLE
PR G1: remove orphan queue via owned fiber chains

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -3278,3 +3278,40 @@ rules:
         - "**/packages/doeff-vm-core/src/vm/dispatch.rs"
         - "**/packages/doeff-vm/src/pyvm.rs"
     pattern-regex: '\bself\.mode\b'
+
+  # ---------------------------------------------------------------------------
+  # ISSUE-VM-001 / PR G1: fiber ownership and orphan reclamation
+  # ---------------------------------------------------------------------------
+
+  - id: vm-g1-no-orphan-queue
+    languages: [generic]
+    severity: ERROR
+    message: |
+      ISSUE-VM-001 G1: orphan reclamation must be owned by Continuation's
+      detached fiber chain, not by a VM-level orphan_queue side channel.
+    paths:
+      include:
+        - "**/packages/doeff-vm-core/src/**/*.rs"
+    pattern-regex: '\b(?:orphan_queue|OrphanQueue|new_orphan_queue|drain_orphan_fibers)\b'
+
+  - id: vm-g1-no-arc-mutex-fiberid-queue
+    languages: [generic]
+    severity: ERROR
+    message: |
+      ISSUE-VM-001 G1: do not represent fiber reclamation as Arc<Mutex<Vec<FiberId>>>.
+      Detached fibers must move into Continuation ownership and drop normally.
+    paths:
+      include:
+        - "**/packages/doeff-vm-core/src/**/*.rs"
+    pattern-regex: 'Arc\s*<\s*Mutex\s*<\s*Vec\s*<\s*FiberId\s*>\s*>\s*>'
+
+  - id: vm-g1-no-queue-backed-continuation-constructor
+    languages: [generic]
+    severity: ERROR
+    message: |
+      ISSUE-VM-001 G1: Continuation constructors must not receive a VM queue.
+      Construct continuations from an owned DetachedFiberChain.
+    paths:
+      include:
+        - "**/packages/doeff-vm-core/src/**/*.rs"
+    pattern-regex: 'Continuation::(?:new|single)\([^;\n]*orphan_queue'

--- a/packages/doeff-vm-core/src/arena.rs
+++ b/packages/doeff-vm-core/src/arena.rs
@@ -1,5 +1,7 @@
 //! Fiber arena for stable fiber IDs within a run.
 
+use crate::continuation::{DetachedFiber, DetachedFiberChain};
+use crate::error::VMError;
 use crate::ids::FiberId;
 use crate::segment::Fiber;
 
@@ -33,6 +35,61 @@ impl FiberArena {
                 self.free_list.push(id.index());
             }
         }
+    }
+
+    pub fn detach_chain(
+        &mut self,
+        head: FiberId,
+        last_fiber: FiberId,
+    ) -> Result<DetachedFiberChain, VMError> {
+        let ids = self.chain_ids(head, last_fiber)?;
+        let mut detached = Vec::with_capacity(ids.len());
+
+        for id in ids {
+            let idx = id.index();
+            let slot = self.fibers.get_mut(idx).ok_or_else(|| {
+                VMError::internal(format!("detach_chain: fiber {} out of range", idx))
+            })?;
+            let fiber = slot.take().ok_or_else(|| {
+                VMError::internal(format!("detach_chain: fiber {} is not in arena", idx))
+            })?;
+            detached.push(DetachedFiber { id, fiber });
+        }
+
+        let mut chain = DetachedFiberChain::new(head, last_fiber, detached);
+        let _ = chain.set_tail_parent(None);
+        Ok(chain)
+    }
+
+    pub fn attach_chain(
+        &mut self,
+        mut chain: DetachedFiberChain,
+        tail_parent: Option<FiberId>,
+    ) -> Result<FiberId, VMError> {
+        let head = chain.head();
+        let _ = chain.set_tail_parent(tail_parent);
+
+        for DetachedFiber { id, fiber } in chain.into_fibers() {
+            let idx = id.index();
+            if self.free_list.contains(&idx) {
+                return Err(VMError::internal(format!(
+                    "attach_chain: fiber {} slot was released",
+                    idx
+                )));
+            }
+            let slot = self.fibers.get_mut(idx).ok_or_else(|| {
+                VMError::internal(format!("attach_chain: fiber {} out of range", idx))
+            })?;
+            if slot.is_some() {
+                return Err(VMError::internal(format!(
+                    "attach_chain: fiber {} slot is occupied",
+                    idx
+                )));
+            }
+            *slot = Some(fiber);
+        }
+
+        Ok(head)
     }
 
     pub fn get(&self, id: FiberId) -> Option<&Fiber> {
@@ -99,6 +156,32 @@ impl FiberArena {
     pub fn shrink_to_fit(&mut self) {
         self.fibers.shrink_to_fit();
         self.free_list.shrink_to_fit();
+    }
+
+    fn chain_ids(&self, head: FiberId, last_fiber: FiberId) -> Result<Vec<FiberId>, VMError> {
+        let mut ids = Vec::new();
+        let mut cursor = head;
+
+        loop {
+            let fiber = self.segments_get_for_chain(cursor)?;
+            ids.push(cursor);
+            if cursor == last_fiber {
+                return Ok(ids);
+            }
+            cursor = fiber.parent.ok_or_else(|| {
+                VMError::internal(format!(
+                    "detach_chain: fiber {} does not reach tail {}",
+                    head.index(),
+                    last_fiber.index()
+                ))
+            })?;
+        }
+    }
+
+    fn segments_get_for_chain(&self, id: FiberId) -> Result<&Fiber, VMError> {
+        self.get(id).ok_or_else(|| {
+            VMError::internal(format!("detach_chain: fiber {} not found", id.index()))
+        })
     }
 }
 
@@ -184,6 +267,35 @@ mod tests {
         assert_eq!(
             arena.get(unrelated).and_then(|seg| seg.parent),
             Some(caller)
+        );
+    }
+
+    #[test]
+    fn test_detach_chain_moves_fibers_without_releasing_slots() {
+        let mut arena = FiberArena::new();
+
+        let boundary = arena.alloc(Fiber::new(None));
+        let body = arena.alloc(Fiber::new(Some(boundary)));
+
+        let chain = arena.detach_chain(body, boundary).unwrap();
+        assert_eq!(chain.head(), body);
+        assert_eq!(chain.last_fiber(), boundary);
+        assert_eq!(arena.len(), 0);
+        assert_eq!(arena.slot_count(), 2);
+
+        let unrelated = arena.alloc(Fiber::new(None));
+        assert_eq!(
+            unrelated.index(),
+            2,
+            "detached fiber slots stay reserved until the chain is attached or dropped"
+        );
+
+        let head = arena.attach_chain(chain, Some(unrelated)).unwrap();
+        assert_eq!(head, body);
+        assert_eq!(arena.len(), 3);
+        assert_eq!(
+            arena.get(boundary).and_then(|fiber| fiber.parent),
+            Some(unrelated)
         );
     }
 }

--- a/packages/doeff-vm-core/src/continuation.rs
+++ b/packages/doeff-vm-core/src/continuation.rs
@@ -5,41 +5,222 @@
 //!   field[1]: last_fiber    (tail, for O(1) append in reperform)
 //!
 //! Parent pointers in the arena are the source of truth for chain structure.
-//! Continuation just holds two pointers into the arena.
+//! Continuation owns detached fibers directly while they are outside the arena.
 //! One-shot via head.take() — destructive read, like OCaml 5's atomic_swap.
-//!
-//! Orphan reclamation: when a continuation is dropped without being consumed
-//! (e.g., scheduler drops TaskCompleted's k), its fiber IDs are pushed to a
-//! thread-local queue. The VM drains this queue each step, walking and freeing
-//! the orphaned fiber chains from the arena.
-
-use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::ids::FiberId;
+use crate::ir_stream::StreamSourceLocation;
 use crate::memory_stats;
 use crate::py_shared::PyShared;
+use crate::segment::Fiber;
+use crate::value::{CallableRef, Value};
 
 // ---------------------------------------------------------------------------
-// Orphan fiber reclamation — per-VM queue
+// DetachedFiberChain — fibers owned by a continuation while detached
 // ---------------------------------------------------------------------------
 
-/// Per-VM queue for orphaned fiber heads. Each Continuation holds an Arc clone.
-/// When a Continuation is dropped without being consumed, its head FiberId is
-/// pushed to the owning VM's queue (not a global/thread-local).
-pub type OrphanQueue = Arc<Mutex<Vec<FiberId>>>;
-
-/// Create a new orphan queue. Called once per VM instance.
-pub fn new_orphan_queue() -> OrphanQueue {
-    Arc::new(Mutex::new(Vec::new()))
+/// A fiber removed from the arena while its continuation is suspended.
+#[derive(Debug)]
+pub struct DetachedFiber {
+    pub id: FiberId,
+    pub fiber: Fiber,
 }
 
-/// Drain all orphaned fiber head IDs from a queue. Called by the VM at each step.
-pub fn drain_orphan_fibers(queue: &OrphanQueue) -> Vec<FiberId> {
-    let mut v = queue.lock().unwrap();
-    std::mem::take(&mut *v)
+/// A body-through-boundary fiber chain owned by `Continuation`.
+#[derive(Debug)]
+pub struct DetachedFiberChain {
+    head: FiberId,
+    last_fiber: FiberId,
+    fibers: Vec<DetachedFiber>,
+}
+
+impl DetachedFiberChain {
+    pub fn new(head: FiberId, last_fiber: FiberId, fibers: Vec<DetachedFiber>) -> Self {
+        Self {
+            head,
+            last_fiber,
+            fibers,
+        }
+    }
+
+    pub fn head(&self) -> FiberId {
+        self.head
+    }
+
+    pub fn last_fiber(&self) -> FiberId {
+        self.last_fiber
+    }
+
+    pub fn fibers(&self) -> &[DetachedFiber] {
+        &self.fibers
+    }
+
+    pub fn into_fibers(self) -> Vec<DetachedFiber> {
+        self.fibers
+    }
+
+    pub fn set_parent(&mut self, id: FiberId, parent: Option<FiberId>) -> bool {
+        let Some(fiber) = self.fiber_mut(id) else {
+            return false;
+        };
+        fiber.parent = parent;
+        true
+    }
+
+    pub fn set_tail_parent(&mut self, parent: Option<FiberId>) -> bool {
+        self.set_parent(self.last_fiber, parent)
+    }
+
+    pub fn append(&mut self, mut other: DetachedFiberChain) {
+        let _ = self.set_tail_parent(Some(other.head));
+        self.last_fiber = other.last_fiber;
+        self.fibers.append(&mut other.fibers);
+    }
+
+    pub fn collect_traceback(&self) -> Vec<StreamSourceLocation> {
+        let mut frames = Vec::new();
+        let mut cursor = Some(self.head);
+
+        while let Some(fid) = cursor {
+            let Some(fiber) = self.fiber(fid) else { break };
+            for frame in fiber.frames.iter().rev() {
+                if let crate::frame::Frame::Program { stream, .. } = frame {
+                    if let Some(loc) = stream.source_location() {
+                        frames.push(loc);
+                    }
+                }
+            }
+            cursor = fiber.parent;
+        }
+
+        frames
+    }
+
+    pub fn handler_callables(&self) -> Vec<CallableRef> {
+        let mut handlers = Vec::new();
+        let mut cursor = Some(self.head);
+
+        while let Some(fid) = cursor {
+            let Some(fiber) = self.fiber(fid) else { break };
+            if let Some(handler) = &fiber.handler {
+                if let Some(prompt) = handler.prompt_boundary() {
+                    handlers.push(prompt.handler.clone());
+                }
+            }
+            cursor = fiber.parent;
+        }
+
+        handlers
+    }
+
+    pub fn collect_rich_context(&self) -> Vec<Value> {
+        let mut raw: Vec<(String, String, u32)> = Vec::new();
+        let mut first_boundary: Option<FiberId> = None;
+        let mut cursor = Some(self.head);
+
+        while let Some(fid) = cursor {
+            let Some(fiber) = self.fiber(fid) else { break };
+
+            if first_boundary.is_none()
+                && fiber
+                    .handler
+                    .as_ref()
+                    .and_then(|handler| handler.prompt_boundary())
+                    .is_some()
+            {
+                first_boundary = Some(fid);
+            }
+
+            for frame in fiber.frames.iter().rev() {
+                if let crate::frame::Frame::Program { stream, .. } = frame {
+                    if let Some(loc) = stream.source_location() {
+                        raw.push((loc.func_name, loc.source_file, loc.source_line));
+                    }
+                }
+            }
+
+            cursor = fiber.parent;
+        }
+
+        raw.reverse();
+
+        let mut frames = Vec::new();
+        let mut i = 0;
+        while i < raw.len() {
+            let (ref func, ref file, line) = raw[i];
+            let mut count: i64 = 1;
+            while i + (count as usize) < raw.len() {
+                let (ref nf, ref nfile, nline) = raw[i + count as usize];
+                if nf == func && nfile == file && nline == line {
+                    count += 1;
+                } else {
+                    break;
+                }
+            }
+            let mut entry = vec![
+                Value::String("frame".to_string()),
+                Value::String(func.clone()),
+                Value::String(file.clone()),
+                Value::Int(line as i64),
+            ];
+            if count > 1 {
+                entry.push(Value::Int(count));
+            }
+            frames.push(Value::List(entry));
+            i += count as usize;
+        }
+
+        if let Some(boundary_id) = first_boundary {
+            let handler_names: Vec<Value> = self
+                .handler_callables_from(boundary_id)
+                .into_iter()
+                .map(|handler| {
+                    Value::String(handler.name().unwrap_or_else(|| "<handler>".to_string()))
+                })
+                .collect();
+            if !handler_names.is_empty() {
+                frames.push(Value::List(vec![
+                    Value::String("handler".to_string()),
+                    Value::String("chain".to_string()),
+                    Value::List(handler_names),
+                ]));
+            }
+        }
+
+        frames
+    }
+
+    fn fiber(&self, id: FiberId) -> Option<&Fiber> {
+        self.fibers
+            .iter()
+            .find_map(|entry| (entry.id == id).then_some(&entry.fiber))
+    }
+
+    fn fiber_mut(&mut self, id: FiberId) -> Option<&mut Fiber> {
+        self.fibers
+            .iter_mut()
+            .find_map(|entry| (entry.id == id).then_some(&mut entry.fiber))
+    }
+
+    fn handler_callables_from(&self, start: FiberId) -> Vec<CallableRef> {
+        let mut handlers = Vec::new();
+        let mut cursor = Some(start);
+
+        while let Some(fid) = cursor {
+            let Some(fiber) = self.fiber(fid) else { break };
+            if let Some(handler) = &fiber.handler {
+                if let Some(prompt) = handler.prompt_boundary() {
+                    handlers.push(prompt.handler.clone());
+                }
+            }
+            cursor = fiber.parent;
+        }
+
+        handlers
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -53,31 +234,17 @@ pub fn drain_orphan_fibers(queue: &OrphanQueue) -> Vec<FiberId> {
 /// Extended by `reperform` (append current fiber to chain).
 #[derive(Debug)]
 pub struct Continuation {
-    /// Head of the detached fiber chain (first fiber).
+    /// The owned detached fiber chain.
     /// `take()` enforces one-shot: Some first time, None after.
-    head: Option<FiberId>,
-    /// Tail of the chain (last fiber). For O(1) append in reperform.
-    pub(crate) last_fiber: Option<FiberId>,
-    /// Per-VM orphan queue. On drop, unconsumed heads are pushed here
-    /// so the owning VM (not another VM on the same thread) reclaims them.
-    orphan_queue: Option<OrphanQueue>,
+    chain: Option<DetachedFiberChain>,
 }
 
 impl Continuation {
     /// Create a continuation from a detached fiber chain.
-    /// Called by perform after cutting the tail→handler parent pointer.
-    pub fn new(head: FiberId, last_fiber: FiberId, orphan_queue: OrphanQueue) -> Self {
+    /// Called by perform after moving fibers out of the arena.
+    pub fn from_chain(chain: DetachedFiberChain) -> Self {
         memory_stats::register_continuation();
-        Self {
-            head: Some(head),
-            last_fiber: Some(last_fiber),
-            orphan_queue: Some(orphan_queue),
-        }
-    }
-
-    /// Single-fiber continuation (head == last_fiber).
-    pub fn single(fiber_id: FiberId, orphan_queue: OrphanQueue) -> Self {
-        Self::new(fiber_id, fiber_id, orphan_queue)
+        Self { chain: Some(chain) }
     }
 
     /// Sentinel for an already-consumed continuation (head=None).
@@ -87,85 +254,69 @@ impl Continuation {
     pub fn empty() -> Self {
         // Register so Drop's unregister is balanced.
         memory_stats::register_continuation();
-        Self {
-            head: None,
-            last_fiber: None,
-            orphan_queue: None,
-        }
+        Self { chain: None }
     }
 
-    /// One-shot take: returns the head fiber and clears the continuation.
-    /// Returns None if already consumed.
-    pub fn take_head(&mut self) -> Option<FiberId> {
-        self.last_fiber = None;
-        self.head.take()
-    }
-
-    /// One-shot take: returns (head, last_fiber) and clears.
-    pub fn take(&mut self) -> Option<(FiberId, FiberId)> {
-        let head = self.head.take()?;
-        let last = self.last_fiber.take()?;
-        Some((head, last))
+    /// One-shot take: returns the detached chain and clears.
+    pub fn take(&mut self) -> Option<DetachedFiberChain> {
+        self.chain.take()
     }
 
     /// Head fiber (identity of this continuation).
     pub fn head(&self) -> Option<FiberId> {
-        self.head
+        self.chain.as_ref().map(DetachedFiberChain::head)
     }
 
     /// Last fiber in the chain.
     pub fn last_fiber(&self) -> Option<FiberId> {
-        self.last_fiber
+        self.chain.as_ref().map(DetachedFiberChain::last_fiber)
     }
 
     /// Is this continuation already consumed?
     pub fn consumed(&self) -> bool {
-        self.head.is_none()
+        self.chain.is_none()
     }
 
     /// Is this a live (unconsumed) continuation?
     pub fn is_live(&self) -> bool {
-        self.head.is_some()
+        self.chain.is_some()
     }
 
     /// Identity = head fiber. Used as dispatch identity.
     pub fn identity(&self) -> Option<FiberId> {
-        self.head
+        self.head()
     }
 
-    /// Append another continuation's chain to this one (reperform).
-    /// Sets self.last_fiber.parent = other.head in the arena,
-    /// then updates self.last_fiber = other.last_fiber.
-    ///
-    /// The caller must also set the parent pointer in the arena:
-    ///   arena[self.last_fiber].parent = Some(other.head)
-    /// This method just updates the Continuation metadata.
-    pub fn append_chain(&mut self, other: &mut Continuation) {
-        if let Some(other_last) = other.last_fiber.take() {
-            // other.head is consumed by the append — the fibers are now part of self
-            let _ = other.head.take();
-            self.last_fiber = Some(other_last);
-        }
+    pub(crate) fn append_chain(&mut self, chain: DetachedFiberChain) -> bool {
+        let Some(existing) = self.chain.as_mut() else {
+            return false;
+        };
+        existing.append(chain);
+        true
+    }
+
+    pub fn collect_traceback(&self) -> Option<Vec<StreamSourceLocation>> {
+        self.chain
+            .as_ref()
+            .map(DetachedFiberChain::collect_traceback)
+    }
+
+    pub fn handler_callables(&self) -> Option<Vec<CallableRef>> {
+        self.chain
+            .as_ref()
+            .map(DetachedFiberChain::handler_callables)
+    }
+
+    pub fn collect_rich_context(&self) -> Option<Vec<Value>> {
+        self.chain
+            .as_ref()
+            .map(DetachedFiberChain::collect_rich_context)
     }
 }
 
 impl Drop for Continuation {
     fn drop(&mut self) {
         memory_stats::unregister_continuation();
-        // If the continuation was never consumed, its fibers are orphaned
-        // in the arena. Push the head to the owning VM's orphan queue.
-        if let Some(head) = self.head.take() {
-            if let Some(ref queue) = self.orphan_queue {
-                if let Ok(mut v) = queue.lock() {
-                    v.push(head);
-                }
-                // If lock is poisoned, we silently leak the fiber.
-                // This is safe (just wastes arena slots) and avoids
-                // panicking in Drop.
-            }
-            // If orphan_queue is None (empty() sentinel), the fiber is
-            // not backed by any arena — nothing to reclaim.
-        }
     }
 }
 
@@ -184,7 +335,10 @@ pub struct PendingContinuation {
 }
 
 impl PendingContinuation {
-    pub fn create(program: PyShared, handlers: Vec<(crate::value::CallableRef, Vec<PyShared>)>) -> Self {
+    pub fn create(
+        program: PyShared,
+        handlers: Vec<(crate::value::CallableRef, Vec<PyShared>)>,
+    ) -> Self {
         memory_stats::register_continuation();
         Self {
             program,

--- a/packages/doeff-vm-core/src/do_ctrl.rs
+++ b/packages/doeff-vm-core/src/do_ctrl.rs
@@ -13,12 +13,10 @@ use crate::value::Value;
 #[derive(Debug)]
 pub enum DoCtrl {
     // --- Values ---
-
     /// Return a value. `Pure(v)` → delivers `v`.
     Pure { value: Value },
 
     // --- Evaluation ---
-
     /// Evaluate inner DoCtrl, return the resulting Value.
     Eval { expr: Box<DoCtrl> },
 
@@ -27,13 +25,11 @@ pub enum DoCtrl {
     Expand { expr: Box<DoCtrl> },
 
     // --- Function call ---
-
     /// Evaluate f and args, call f(args), return the result Value.
     /// Does NOT execute the result even if it's a Stream — use Expand for that.
     Apply { f: Box<DoCtrl>, args: Vec<DoCtrl> },
 
     // --- OCaml 5 effect handler operations ---
-
     /// Perform an effect. Walks the handler chain, detaches the fiber chain,
     /// creates a continuation, and calls the handler.
     Perform { effect: Value },
@@ -77,7 +73,6 @@ pub enum DoCtrl {
     WithObserve { observer: Value, body: Box<DoCtrl> },
 
     // --- Query ---
-
     /// Walk the fiber chain from a starting fiber, collect source locations.
     /// Returns Value::List of traceback frames.
     /// Non-consuming — does not take ownership of the continuation.
@@ -106,7 +101,6 @@ pub enum DoCtrl {
     TailEval { expr: Box<DoCtrl> },
 
     // --- Heap (OCaml ref cells) ---
-
     /// Allocate a mutable ref cell with initial value.
     AllocVar { initial: Value },
 

--- a/packages/doeff-vm-core/src/error.rs
+++ b/packages/doeff-vm-core/src/error.rs
@@ -6,48 +6,38 @@ use crate::value::Value;
 
 #[derive(Debug, Clone)]
 pub enum VMError {
-    OneShotViolation {
-        fiber_id: Option<FiberId>,
-    },
-    UnhandledEffect {
-        effect: DispatchEffect,
-    },
-    NoMatchingHandler {
-        effect: DispatchEffect,
-    },
-    DelegateNoOuterHandler {
-        effect: DispatchEffect,
-    },
-    HandlerNotFound {
-        marker: Marker,
-    },
-    InvalidSegment {
-        message: String,
-    },
-    PythonError {
-        message: String,
-    },
-    InternalError {
-        message: String,
-    },
-    TypeError {
-        message: String,
-    },
-    UncaughtException {
-        exception: Value,
-    },
+    OneShotViolation { fiber_id: Option<FiberId> },
+    UnhandledEffect { effect: DispatchEffect },
+    NoMatchingHandler { effect: DispatchEffect },
+    DelegateNoOuterHandler { effect: DispatchEffect },
+    HandlerNotFound { marker: Marker },
+    InvalidSegment { message: String },
+    PythonError { message: String },
+    InternalError { message: String },
+    TypeError { message: String },
+    UncaughtException { exception: Value },
 }
 
 impl std::fmt::Display for VMError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             VMError::OneShotViolation { fiber_id } => {
-                write!(f, "one-shot violation: continuation {:?} already consumed", fiber_id)
+                write!(
+                    f,
+                    "one-shot violation: continuation {:?} already consumed",
+                    fiber_id
+                )
             }
             VMError::UnhandledEffect { effect } => write!(f, "unhandled effect: {:?}", effect),
-            VMError::NoMatchingHandler { effect } => write!(f, "no matching handler for effect: {:?}", effect),
-            VMError::DelegateNoOuterHandler { effect } => write!(f, "delegate: no outer handler for effect: {:?}", effect),
-            VMError::HandlerNotFound { marker } => write!(f, "handler not found for marker {}", marker.raw()),
+            VMError::NoMatchingHandler { effect } => {
+                write!(f, "no matching handler for effect: {:?}", effect)
+            }
+            VMError::DelegateNoOuterHandler { effect } => {
+                write!(f, "delegate: no outer handler for effect: {:?}", effect)
+            }
+            VMError::HandlerNotFound { marker } => {
+                write!(f, "handler not found for marker {}", marker.raw())
+            }
             VMError::InvalidSegment { message } => write!(f, "invalid segment: {}", message),
             VMError::PythonError { message } => write!(f, "Python error: {}", message),
             VMError::InternalError { message } => write!(f, "internal error: {}", message),
@@ -81,19 +71,27 @@ impl VMError {
     }
 
     pub fn invalid_segment(message: impl Into<String>) -> Self {
-        VMError::InvalidSegment { message: message.into() }
+        VMError::InvalidSegment {
+            message: message.into(),
+        }
     }
 
     pub fn python_error(message: impl Into<String>) -> Self {
-        VMError::PythonError { message: message.into() }
+        VMError::PythonError {
+            message: message.into(),
+        }
     }
 
     pub fn internal(message: impl Into<String>) -> Self {
-        VMError::InternalError { message: message.into() }
+        VMError::InternalError {
+            message: message.into(),
+        }
     }
 
     pub fn type_error(message: impl Into<String>) -> Self {
-        VMError::TypeError { message: message.into() }
+        VMError::TypeError {
+            message: message.into(),
+        }
     }
 
     pub fn uncaught_exception(exception: Value) -> Self {

--- a/packages/doeff-vm-core/src/frame.rs
+++ b/packages/doeff-vm-core/src/frame.rs
@@ -210,7 +210,13 @@ impl Frame {
     }
 
     pub fn has_metadata(&self) -> bool {
-        matches!(self, Frame::Program { metadata: Some(_), .. })
+        matches!(
+            self,
+            Frame::Program {
+                metadata: Some(_),
+                ..
+            }
+        )
     }
 }
 

--- a/packages/doeff-vm-core/src/segment.rs
+++ b/packages/doeff-vm-core/src/segment.rs
@@ -20,10 +20,10 @@ pub enum InterceptMode {
 use crate::frame::CallMetadata;
 use crate::frame::Frame;
 use crate::ids::{FiberId, Marker};
-use crate::value::CallableRef;
 use crate::memory_stats;
 use crate::py_shared::PyShared;
 pub use crate::scope_store::ScopeStore;
+use crate::value::CallableRef;
 
 // ---------------------------------------------------------------------------
 // Handler — the handler delimiter at the boundary fiber
@@ -188,7 +188,10 @@ impl Fiber {
 
     /// Is this a prompt (handler) boundary?
     pub fn is_prompt_boundary(&self) -> bool {
-        self.handler.as_ref().and_then(|h| h.prompt_boundary()).is_some()
+        self.handler
+            .as_ref()
+            .and_then(|h| h.prompt_boundary())
+            .is_some()
     }
 
     /// Get the handled marker if this is a prompt boundary.
@@ -198,19 +201,24 @@ impl Fiber {
 
     /// Get the prompt boundary handler.
     pub fn prompt_handler(&self) -> Option<&CallableRef> {
-        self.handler.as_ref()
+        self.handler
+            .as_ref()
             .and_then(|h| h.prompt_boundary())
             .map(|p| &p.handler)
     }
 
     /// Is this an intercept boundary?
     pub fn is_intercept_boundary(&self) -> bool {
-        self.handler.as_ref().and_then(|h| h.intercept_boundary()).is_some()
+        self.handler
+            .as_ref()
+            .and_then(|h| h.intercept_boundary())
+            .is_some()
     }
 
     /// Get the interceptor callable.
     pub fn intercept_handler(&self) -> Option<&CallableRef> {
-        self.handler.as_ref()
+        self.handler
+            .as_ref()
             .and_then(|h| h.intercept_boundary())
             .map(|i| &i.interceptor)
     }

--- a/packages/doeff-vm-core/src/value.rs
+++ b/packages/doeff-vm-core/src/value.rs
@@ -22,7 +22,9 @@ pub trait Callable: Send + Sync + std::fmt::Debug + 'static {
     /// Call as effect handler: returns a DoCtrl to evaluate.
     /// The handler callable MUST return a DoExpr. Anything else is an error.
     fn call_handler(&self, args: Vec<Value>) -> Result<crate::do_ctrl::DoCtrl, VMError> {
-        Err(VMError::type_error("callable does not support call_handler"))
+        Err(VMError::type_error(
+            "callable does not support call_handler",
+        ))
     }
 
     /// Human-readable name for tracebacks (e.g., handler name).
@@ -79,15 +81,13 @@ impl Clone for Value {
             Value::Var(var) => Value::Var(*var),
             Value::List(list) => Value::List(list.clone()),
             Value::Opaque(obj) => Value::Opaque(obj.clone()),
-            Value::Continuation(_) => panic!(
-                "Value::Continuation must not be cloned — use move semantics (SPEC-VM-021)"
-            ),
-            Value::Callable(_) => panic!(
-                "Value::Callable must not be cloned — move or Arc::clone the CallableRef"
-            ),
-            Value::Stream(_) => panic!(
-                "Value::Stream must not be cloned — move semantics"
-            ),
+            Value::Continuation(_) => {
+                panic!("Value::Continuation must not be cloned — use move semantics (SPEC-VM-021)")
+            }
+            Value::Callable(_) => {
+                panic!("Value::Callable must not be cloned — move or Arc::clone the CallableRef")
+            }
+            Value::Stream(_) => panic!("Value::Stream must not be cloned — move semantics"),
         }
     }
 }

--- a/packages/doeff-vm-core/src/vm.rs
+++ b/packages/doeff-vm-core/src/vm.rs
@@ -1,7 +1,6 @@
 //! Core VM struct.
 
 use crate::arena::FiberArena;
-use crate::continuation::{self, OrphanQueue};
 use crate::ids::{FiberId, SegmentId};
 use crate::segment::Fiber;
 use crate::value::Value;
@@ -26,9 +25,6 @@ pub struct VM {
     pub segments: FiberArena,
     pub var_store: VarStore,
     pub current_segment: Option<SegmentId>,
-    /// Per-VM orphan queue. Continuations hold Arc clones; on drop they push
-    /// their head FiberId here. The VM drains this each step.
-    pub orphan_queue: OrphanQueue,
 }
 
 impl VM {
@@ -37,7 +33,6 @@ impl VM {
             segments: FiberArena::new(),
             var_store: VarStore::new(),
             current_segment: None,
-            orphan_queue: continuation::new_orphan_queue(),
         }
     }
 
@@ -45,9 +40,6 @@ impl VM {
         self.segments.clear();
         self.var_store.clear_run_local();
         self.current_segment = None;
-        // Replace orphan queue so stale Continuations from previous runs
-        // push to the old (now-disconnected) queue, not this new one.
-        self.orphan_queue = continuation::new_orphan_queue();
     }
 
     pub fn end_active_run_session(&mut self) {
@@ -56,23 +48,6 @@ impl VM {
         self.var_store.clear_run_local();
         self.var_store.shrink_run_local_to_fit();
         self.current_segment = None;
-    }
-
-    /// Free fibers from continuations that were dropped without being consumed.
-    ///
-    /// When a handler drops a continuation (e.g., scheduler ignoring
-    /// TaskCompleted's k), the fiber chain stays orphaned in the arena.
-    /// This walks each orphaned chain from head→last following parent
-    /// pointers, freeing every fiber.
-    pub fn reclaim_orphaned_fibers(&mut self) {
-        let orphans = continuation::drain_orphan_fibers(&self.orphan_queue);
-        for head in orphans {
-            let mut cursor = Some(head);
-            while let Some(fid) = cursor {
-                cursor = self.segments.get(fid).and_then(|s| s.parent);
-                self.segments.free(fid);
-            }
-        }
     }
 
     pub fn alloc_segment(&mut self, fiber: Fiber) -> FiberId {
@@ -87,12 +62,17 @@ impl VM {
     ///
     /// For each fiber, queries each Program frame's stream for live source location.
     /// Returns frames from innermost (current fiber, topmost frame) to outermost (root).
-    pub fn collect_traceback(&self, start: SegmentId) -> Vec<crate::ir_stream::StreamSourceLocation> {
+    pub fn collect_traceback(
+        &self,
+        start: SegmentId,
+    ) -> Vec<crate::ir_stream::StreamSourceLocation> {
         let mut frames = Vec::new();
         let mut current = Some(start);
 
         while let Some(seg_id) = current {
-            let Some(seg) = self.segments.get(seg_id) else { break };
+            let Some(seg) = self.segments.get(seg_id) else {
+                break;
+            };
 
             // Walk frames top-to-bottom (innermost first)
             for frame in seg.frames.iter().rev() {
@@ -141,10 +121,17 @@ impl VM {
         let mut cursor = Some(start);
 
         while let Some(fid) = cursor {
-            let Some(seg) = self.segments.get(fid) else { break };
+            let Some(seg) = self.segments.get(fid) else {
+                break;
+            };
 
             if first_boundary.is_none() {
-                if seg.handler.as_ref().and_then(|h| h.prompt_boundary()).is_some() {
+                if seg
+                    .handler
+                    .as_ref()
+                    .and_then(|h| h.prompt_boundary())
+                    .is_some()
+                {
                     first_boundary = Some(fid);
                 }
             }
@@ -193,9 +180,14 @@ impl VM {
             let handler_chain = self.handlers_in_caller_chain(boundary_id);
             let handler_names: Vec<Value> = handler_chain
                 .into_iter()
-                .map(|entry| Value::String(
-                    entry.handler.name().unwrap_or_else(|| "<handler>".to_string())
-                ))
+                .map(|entry| {
+                    Value::String(
+                        entry
+                            .handler
+                            .name()
+                            .unwrap_or_else(|| "<handler>".to_string()),
+                    )
+                })
                 .collect();
             if !handler_names.is_empty() {
                 frames.push(Value::List(vec![

--- a/packages/doeff-vm-core/src/vm/dispatch.rs
+++ b/packages/doeff-vm-core/src/vm/dispatch.rs
@@ -14,7 +14,7 @@ use crate::driver::{Signal, StepResult};
 use crate::effect::DispatchEffect;
 use crate::ids::FiberId;
 use crate::segment::{Fiber, Handler};
-use crate::value::Value;
+use crate::value::{CallableRef, Value};
 use crate::vm::VM;
 
 impl VM {
@@ -54,15 +54,10 @@ impl VM {
     ///   call handler.handle_effect(effect, cont)
     ///
     /// Returns (continuation, handler_fiber_id, effect) for the step machine to process.
-    pub fn perform_effect(
-        &mut self,
-        effect: &DispatchEffect,
-    ) -> Result<PerformResult, StepResult> {
-        let current = self.current_segment.ok_or_else(|| {
-            StepResult::Error {
-                error: crate::error::VMError::internal("perform: no current fiber"),
-                context: None,
-            }
+    pub fn perform_effect(&mut self, effect: &DispatchEffect) -> Result<PerformResult, StepResult> {
+        let current = self.current_segment.ok_or_else(|| StepResult::Error {
+            error: crate::error::VMError::internal("perform: no current fiber"),
+            context: None,
         })?;
 
         // Walk up parent chain to find a handler boundary.
@@ -78,17 +73,27 @@ impl VM {
                 }
             })?;
 
+        let handler_callable = self
+            .segments
+            .get(handler_fiber_id)
+            .and_then(|seg| seg.prompt_handler().cloned())
+            .ok_or_else(|| StepResult::Error {
+                error: crate::error::VMError::internal("perform: handler has no callable"),
+                context: None,
+            })?;
+
         // OCaml 5: continuation includes everything from body up to AND INCLUDING
         // the handler boundary. This way continue_k links boundary.parent = caller,
         // restoring the correct chain topology.
-        // Detach: cut boundary from its parent
         let boundary_parent = self.segments.get(handler_fiber_id).and_then(|s| s.parent);
-        if let Some(seg) = self.segments.get_mut(handler_fiber_id) {
-            seg.parent = None;
-        }
-
-        // Create continuation: head = current (body), last = boundary
-        let continuation = Continuation::new(current, handler_fiber_id, self.orphan_queue.clone());
+        let chain = self
+            .segments
+            .detach_chain(current, handler_fiber_id)
+            .map_err(|error| StepResult::Error {
+                error,
+                context: None,
+            })?;
+        let continuation = Continuation::from_chain(chain);
 
         // handler_parent is boundary's former parent
         let handler_parent = boundary_parent;
@@ -99,6 +104,7 @@ impl VM {
         Ok(PerformResult {
             continuation,
             handler_fiber_id,
+            handler_callable,
         })
     }
 
@@ -114,92 +120,39 @@ impl VM {
     ///   last.handler.parent = current_stack      // reattach
     ///   current_stack = head                     // switch
     ///   deliver v to head
-    pub fn continue_k(
-        &mut self,
-        k: &mut Continuation,
-    ) -> Result<(), crate::error::VMError> {
-        let (head, last) = k.take().ok_or_else(|| {
-            let current = self.current_segment
+    pub fn continue_k(&mut self, k: &mut Continuation) -> Result<(), crate::error::VMError> {
+        let chain = k.take().ok_or_else(|| {
+            let current = self
+                .current_segment
                 .map(|f| format!(" (current fiber={})", f.index()))
                 .unwrap_or_default();
-            crate::error::VMError::internal(
-                format!("Resume: continuation already consumed (one-shot violation){current}")
-            )
+            crate::error::VMError::internal(format!(
+                "Resume: continuation already consumed (one-shot violation){current}"
+            ))
         })?;
 
-        // Reattach: link tail to current fiber (one pointer write)
         let caller = self.current_segment;
-        if let Some(seg) = self.segments.get_mut(last) {
-            seg.parent = caller;
-        }
-
-        // Switch to the head of the resumed chain
+        let head = self.segments.attach_chain(chain, caller)?;
         self.current_segment = Some(head);
 
         Ok(())
     }
 
-    // -----------------------------------------------------------------------
-    // 4. reperform — pass/delegate effect to outer handler
-    // -----------------------------------------------------------------------
-
-    /// Reperform: the current handler doesn't handle this effect.
-    /// Append the current fiber to the continuation chain, then re-perform
-    /// at the parent handler.
-    ///
-    /// OCaml 5 equivalent:
-    ///   last_fiber.handler.parent = current_stack  // append self to chain
-    ///   last_fiber = current_stack
-    ///   parent = current_stack.handler.parent
-    ///   current_stack.handler.parent = NULL         // detach self
-    ///   current_stack = parent
-    ///   call parent.handler.handle_effect(effect, cont, last_fiber)
-    pub fn reperform(
+    pub(crate) fn continue_attached_chain(
         &mut self,
-        k: &mut Continuation,
-        effect: &DispatchEffect,
-    ) -> Result<PerformResult, StepResult> {
-        let current = self.current_segment.ok_or_else(|| {
-            StepResult::Error {
-                error: crate::error::VMError::internal("reperform: no current fiber"),
-                context: None,
-            }
-        })?;
-
-        // Append current fiber to the continuation chain
-        // Link continuation's last_fiber → current
-        if let Some(last) = k.last_fiber() {
-            if let Some(seg) = self.segments.get_mut(last) {
-                seg.parent = Some(current);
-            }
-        }
-        // Update continuation's last_fiber to current
-        // (we need the current fiber's parent as the next handler target)
-        let current_parent = self.segments.get(current).and_then(|s| s.parent);
-
-        // Detach current from its parent
-        if let Some(seg) = self.segments.get_mut(current) {
-            seg.parent = None;
-        }
-        k.last_fiber = Some(current); // update tail — direct field access since we own the mutation
-
-        // Find the next outer handler
-        let (handler_fiber_id, handler_parent) = current_parent
-            .and_then(|p| self.find_handler_for_effect(p, effect))
-            .ok_or_else(|| {
-                StepResult::Error {
-                    error: crate::error::VMError::internal("reperform: no outer handler found"),
-                    context: None,
-                }
-            })?;
-
-        // Switch to handler's parent
-        self.current_segment = handler_parent;
-
-        Ok(PerformResult {
-            continuation: Continuation::single(FiberId::from_index(0), self.orphan_queue.clone()), // placeholder — k is updated in place
-            handler_fiber_id,
-        })
+        head: FiberId,
+        last_fiber: FiberId,
+    ) -> Result<(), crate::error::VMError> {
+        let caller = self.current_segment;
+        let Some(tail) = self.segments.get_mut(last_fiber) else {
+            return Err(crate::error::VMError::internal(format!(
+                "continue_attached_chain: tail fiber {} not found",
+                last_fiber.index()
+            )));
+        };
+        tail.parent = caller;
+        self.current_segment = Some(head);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -297,11 +250,7 @@ impl VM {
 
     /// Find the fiber just before `target` in the chain starting from `start`.
     /// Returns None if start == target (single fiber).
-    pub(crate) fn find_fiber_before(
-        &self,
-        start: FiberId,
-        target: FiberId,
-    ) -> Option<FiberId> {
+    pub(crate) fn find_fiber_before(&self, start: FiberId, target: FiberId) -> Option<FiberId> {
         if start == target {
             return None;
         }
@@ -324,4 +273,5 @@ impl VM {
 pub struct PerformResult {
     pub continuation: Continuation,
     pub handler_fiber_id: FiberId,
+    pub handler_callable: CallableRef,
 }

--- a/packages/doeff-vm-core/src/vm/handler.rs
+++ b/packages/doeff-vm-core/src/vm/handler.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use crate::effect::DispatchEffect;
 use crate::error::VMError;
 use crate::ids::{FiberId, Marker, SegmentId};
-use crate::value::CallableRef;
 use crate::py_shared::PyShared;
+use crate::value::CallableRef;
 use crate::vm::VM;
 
 /// A handler entry found while walking the caller chain.

--- a/packages/doeff-vm-core/src/vm/step.rs
+++ b/packages/doeff-vm-core/src/vm/step.rs
@@ -22,9 +22,6 @@ use crate::vm::VM;
 impl VM {
     /// Execute one step.
     pub fn step(&mut self, signal: Signal) -> StepResult {
-        // Reclaim fibers from continuations dropped since the last step.
-        self.reclaim_orphaned_fibers();
-
         let Signal {
             action,
             error_context,
@@ -48,7 +45,11 @@ impl VM {
         // Fast path: fiber completed (no frames) — free it and move to parent.
         // Checked before the mutable borrow so we can call free() without
         // conflicting with the borrow used in the frame-processing match below.
-        if self.segments.get(seg_id).map_or(false, |s| s.frames.is_empty()) {
+        if self
+            .segments
+            .get(seg_id)
+            .map_or(false, |s| s.frames.is_empty())
+        {
             let parent = self.segments.get(seg_id).and_then(|s| s.parent);
             self.segments.free(seg_id);
             self.current_segment = parent;
@@ -70,19 +71,13 @@ impl VM {
                     unreachable!()
                 };
                 match stream.resume(value) {
-                    StreamStep::Instruction(doctrl) => {
-                        continue_eval(doctrl, error_context)
-                    }
+                    StreamStep::Instruction(doctrl) => continue_eval(doctrl, error_context),
                     StreamStep::Done(value) => {
                         seg.frames.pop();
                         continue_send(value, error_context)
                     }
-                    StreamStep::Error(error) => {
-                        continue_raise(error, error_context)
-                    }
-                    StreamStep::External(call) => {
-                        external_result(call, error_context)
-                    }
+                    StreamStep::Error(error) => continue_raise(error, error_context),
+                    StreamStep::External(call) => external_result(call, error_context),
                 }
             }
             Some(Frame::EvalReturn(_)) => {
@@ -96,8 +91,11 @@ impl VM {
                 // TODO: may need to pop scope on exit
                 continue_send(value, error_context)
             }
-            Some(Frame::MapReturn { .. } | Frame::FlatMapBindResult
-                | Frame::FlatMapBindSource { .. }) => {
+            Some(
+                Frame::MapReturn { .. }
+                | Frame::FlatMapBindResult
+                | Frame::FlatMapBindSource { .. },
+            ) => {
                 // Legacy frames — remove in future cleanup
                 seg.frames.pop();
                 continue_send(value, error_context)
@@ -111,15 +109,18 @@ impl VM {
 
     fn step_raise(&mut self, error: Value, error_context: Option<Vec<Value>>) -> StepResult {
         // Capture execution context on first error (before unwinding destroys it).
-        let error_context = error_context
-            .or_else(|| Some(self.collect_rich_execution_context()));
+        let error_context = error_context.or_else(|| Some(self.collect_rich_execution_context()));
 
         let Some(seg_id) = self.current_segment else {
             return error_result(VMError::uncaught_exception(error), error_context);
         };
 
         // Fast path: fiber completed (no frames) — free it and propagate to parent.
-        if self.segments.get(seg_id).map_or(false, |s| s.frames.is_empty()) {
+        if self
+            .segments
+            .get(seg_id)
+            .map_or(false, |s| s.frames.is_empty())
+        {
             let parent = self.segments.get(seg_id).and_then(|s| s.parent);
             self.segments.free(seg_id);
             self.current_segment = parent;
@@ -141,9 +142,7 @@ impl VM {
                     unreachable!()
                 };
                 match stream.throw(error) {
-                    StreamStep::Instruction(doctrl) => {
-                        continue_eval(doctrl, error_context)
-                    }
+                    StreamStep::Instruction(doctrl) => continue_eval(doctrl, error_context),
                     StreamStep::Done(value) => {
                         seg.frames.pop();
                         continue_send(value, error_context)
@@ -153,9 +152,7 @@ impl VM {
                         seg.frames.pop();
                         continue_raise(error, error_context)
                     }
-                    StreamStep::External(call) => {
-                        external_result(call, error_context)
-                    }
+                    StreamStep::External(call) => external_result(call, error_context),
                 }
             }
             _ => {
@@ -172,20 +169,14 @@ impl VM {
 
     fn step_eval(&mut self, doctrl: DoCtrl, mut error_context: Option<Vec<Value>>) -> StepResult {
         match doctrl {
-            DoCtrl::Pure { value } => {
-                continue_send(value, error_context)
-            }
+            DoCtrl::Pure { value } => continue_send(value, error_context),
 
-            DoCtrl::Eval { expr } => {
-                continue_eval(*expr, error_context)
-            }
+            DoCtrl::Eval { expr } => continue_eval(*expr, error_context),
 
             DoCtrl::Expand { expr } => {
                 // Evaluate inner, expect Value::Stream, push as frame
                 match *expr {
-                    DoCtrl::Pure { value } => {
-                        self.push_stream_value(value, error_context)
-                    }
+                    DoCtrl::Pure { value } => self.push_stream_value(value, error_context),
                     other => {
                         // Push ExpandReturn frame so we intercept the result
                         if let Some(seg_id) = self.current_segment {
@@ -200,20 +191,14 @@ impl VM {
                 }
             }
 
-            DoCtrl::Apply { f, args } => {
-                self.eval_apply(*f, args, error_context)
-            }
+            DoCtrl::Apply { f, args } => self.eval_apply(*f, args, error_context),
 
-            DoCtrl::Perform { effect } => {
-                self.eval_perform(effect, error_context)
-            }
+            DoCtrl::Perform { effect } => self.eval_perform(effect, error_context),
 
-            DoCtrl::Resume { mut k, value } => {
-                match self.continue_k(&mut k) {
-                    Ok(()) => continue_send(value, error_context),
-                    Err(error) => error_result(error, error_context),
-                }
-            }
+            DoCtrl::Resume { mut k, value } => match self.continue_k(&mut k) {
+                Ok(()) => continue_send(value, error_context),
+                Err(error) => error_result(error, error_context),
+            },
 
             DoCtrl::Transfer { mut k, value } => {
                 // Tail position — pop handler frame before resuming
@@ -228,12 +213,10 @@ impl VM {
                 }
             }
 
-            DoCtrl::ResumeThrow { mut k, exception } => {
-                match self.continue_k(&mut k) {
-                    Ok(()) => continue_raise(exception, error_context),
-                    Err(error) => error_result(error, error_context),
-                }
-            }
+            DoCtrl::ResumeThrow { mut k, exception } => match self.continue_k(&mut k) {
+                Ok(()) => continue_raise(exception, error_context),
+                Err(error) => error_result(error, error_context),
+            },
 
             DoCtrl::TransferThrow { mut k, exception } => {
                 // Tail position — pop handler frame before resuming
@@ -258,15 +241,13 @@ impl VM {
                 self.eval_pass(effect, k, error_context)
             }
 
-            DoCtrl::Delegate { .. } => {
-                error_result(
-                    VMError::type_error(
-                        "Delegate is removed. Use 'yield effect' from handler @do body to re-perform."
-                            .to_string(),
-                    ),
-                    error_context,
-                )
-            }
+            DoCtrl::Delegate { .. } => error_result(
+                VMError::type_error(
+                    "Delegate is removed. Use 'yield effect' from handler @do body to re-perform."
+                        .to_string(),
+                ),
+                error_context,
+            ),
 
             DoCtrl::WithObserve { observer, body } => {
                 self.eval_with_observe(observer, *body, error_context)
@@ -277,7 +258,10 @@ impl VM {
                     let var = self.alloc_scoped_var_in_segment(seg_id, initial);
                     continue_send(Value::Var(var), error_context)
                 } else {
-                    error_result(VMError::internal("AllocVar: no current segment"), error_context)
+                    error_result(
+                        VMError::internal("AllocVar: no current segment"),
+                        error_context,
+                    )
                 }
             }
 
@@ -291,7 +275,10 @@ impl VM {
                         ),
                     }
                 } else {
-                    error_result(VMError::internal("ReadVar: no current segment"), error_context)
+                    error_result(
+                        VMError::internal("ReadVar: no current segment"),
+                        error_context,
+                    )
                 }
             }
 
@@ -300,7 +287,10 @@ impl VM {
                     self.write_scoped_var_in_current_segment(seg_id, var, value.clone());
                     continue_send(value, error_context)
                 } else {
-                    error_result(VMError::internal("WriteVar: no current segment"), error_context)
+                    error_result(
+                        VMError::internal("WriteVar: no current segment"),
+                        error_context,
+                    )
                 }
             }
 
@@ -308,11 +298,13 @@ impl VM {
                 let locations = self.collect_traceback(from);
                 let frames: Vec<Value> = locations
                     .into_iter()
-                    .map(|loc| Value::List(vec![
-                        Value::String(loc.func_name),
-                        Value::String(loc.source_file),
-                        Value::Int(loc.source_line as i64),
-                    ]))
+                    .map(|loc| {
+                        Value::List(vec![
+                            Value::String(loc.func_name),
+                            Value::String(loc.source_file),
+                            Value::Int(loc.source_line as i64),
+                        ])
+                    })
                     .collect();
                 continue_send(Value::List(frames), error_context)
             }
@@ -320,7 +312,8 @@ impl VM {
             DoCtrl::GetExecutionContext => {
                 // Return error-site context if available (captured before unwinding),
                 // otherwise current live context.
-                let frames = error_context.take()
+                let frames = error_context
+                    .take()
                     .unwrap_or_else(|| self.collect_rich_execution_context());
                 continue_send(Value::List(frames), error_context)
             }
@@ -376,11 +369,7 @@ impl VM {
     // -------------------------------------------------------------------
 
     /// Push a Value::Stream as a new Program frame on the current fiber.
-    fn push_stream_value(
-        &mut self,
-        value: Value,
-        error_context: Option<Vec<Value>>,
-    ) -> StepResult {
+    fn push_stream_value(&mut self, value: Value, error_context: Option<Vec<Value>>) -> StepResult {
         match value {
             Value::Stream(stream) => {
                 if let Some(seg_id) = self.current_segment {
@@ -389,14 +378,15 @@ impl VM {
                         return continue_send(Value::Unit, error_context);
                     }
                 }
-                error_result(VMError::internal("push_stream: no current segment"), error_context)
-            }
-            other => {
                 error_result(
-                    VMError::type_error(format!("Expand: expected Value::Stream, got {:?}", other)),
+                    VMError::internal("push_stream: no current segment"),
                     error_context,
                 )
             }
+            other => error_result(
+                VMError::type_error(format!("Expand: expected Value::Stream, got {:?}", other)),
+                error_context,
+            ),
         }
     }
 
@@ -434,9 +424,7 @@ impl VM {
         match f_value {
             Value::Callable(callable) => {
                 match callable.call(arg_values) {
-                    Ok(result) => {
-                        continue_send(result, error_context)
-                    }
+                    Ok(result) => continue_send(result, error_context),
                     Err(VMError::UncaughtException { exception }) => {
                         // Python exception from callable — propagate through
                         // generator stack so try/except blocks can catch it.
@@ -445,9 +433,7 @@ impl VM {
                     Err(err) => error_result(err, error_context),
                 }
             }
-            _ => {
-                error_result(VMError::internal("Apply: f is not callable"), error_context)
-            }
+            _ => error_result(VMError::internal("Apply: f is not callable"), error_context),
         }
     }
 
@@ -478,25 +464,12 @@ impl VM {
             Err(step_result) => return step_result,
         };
 
-        let handler_fiber_id = result.handler_fiber_id;
         let k = result.continuation;
-
-        // 3. Get the handler callable from the handler boundary fiber
-        let handler_callable = self.segments.get(handler_fiber_id)
-            .and_then(|seg| seg.prompt_handler().cloned());
-
-        let Some(handler_callable) = handler_callable else {
-            return error_result(
-                VMError::internal("perform: handler has no callable"),
-                error_context,
-            );
-        };
+        let handler_callable = result.handler_callable;
 
         // 4. Call handler(effect, k) → must return a DoExpr.
         match handler_callable.call_handler(vec![effect, Value::Continuation(k)]) {
-            Ok(doctrl) => {
-                continue_eval(doctrl, error_context)
-            }
+            Ok(doctrl) => continue_eval(doctrl, error_context),
             Err(VMError::UncaughtException { exception }) => {
                 // Python exception from handler callable — propagate through
                 // generator stack so try/except blocks can catch it.
@@ -510,7 +483,9 @@ impl VM {
     fn call_all_observers(&self, start: FiberId, effect: &Value) {
         let mut cursor = Some(start);
         while let Some(fid) = cursor {
-            let Some(seg) = self.segments.get(fid) else { break };
+            let Some(seg) = self.segments.get(fid) else {
+                break;
+            };
             if seg.is_intercept_boundary() {
                 if let Some(observer) = seg.intercept_handler().cloned() {
                     let _ = observer.call(vec![effect.clone()]);
@@ -519,7 +494,6 @@ impl VM {
             cursor = seg.parent;
         }
     }
-
 
     /// Evaluate WithObserve: install observer boundary, create body fiber, evaluate body.
     fn eval_with_observe(
@@ -603,45 +577,21 @@ impl VM {
         };
 
         // Find handler walking up from current
-        let (handler_fiber_id, _handler_parent) = match self.find_handler_for_effect(current, &effect) {
-            Some(result) => result,
-            None => {
-                // Reconnect continuation to current chain so the full
-                // fiber walk (user code + handlers) is continuous.
-                if let (Some(last), Some(cur)) = (k.last_fiber(), self.current_segment) {
-                    if let Some(seg) = self.segments.get_mut(last) {
-                        seg.parent = Some(cur);
+        let (handler_fiber_id, _handler_parent) =
+            match self.find_handler_for_effect(current, &effect) {
+                Some(result) => result,
+                None => {
+                    let mut context = k.collect_rich_context().unwrap_or_default();
+                    if let Some(current) = self.current_segment {
+                        context.extend(self.collect_rich_context_from(current));
                     }
+                    return error_result(VMError::no_matching_handler(effect), Some(context));
                 }
-                let start = k.head().or(self.current_segment);
-                let context = start
-                    .map(|s| self.collect_rich_context_from(s))
-                    .unwrap_or_default();
-                return error_result(VMError::no_matching_handler(effect), Some(context));
-            }
-        };
+            };
 
-        // Extend k: include fibers from current up to (and including) the outer boundary
-        // Detach outer boundary from its parent
-        let boundary_parent = self.segments.get(handler_fiber_id).and_then(|s| s.parent);
-        if let Some(seg) = self.segments.get_mut(handler_fiber_id) {
-            seg.parent = None;
-        }
-
-        // Link k.last → current (extend the continuation with the intermediate chain)
-        let mut k = k;
-        if let Some(last) = k.last_fiber() {
-            if let Some(seg) = self.segments.get_mut(last) {
-                seg.parent = Some(current);
-            }
-        }
-        k.last_fiber = Some(handler_fiber_id);
-
-        // Switch to outer handler's parent
-        self.current_segment = boundary_parent;
-
-        // Get handler callable
-        let handler_callable = self.segments.get(handler_fiber_id)
+        let handler_callable = self
+            .segments
+            .get(handler_fiber_id)
             .and_then(|seg| seg.prompt_handler().cloned());
 
         let Some(handler_callable) = handler_callable else {
@@ -651,11 +601,26 @@ impl VM {
             );
         };
 
+        // Extend k: include fibers from current up to (and including) the outer boundary.
+        let boundary_parent = self.segments.get(handler_fiber_id).and_then(|s| s.parent);
+        let mut k = k;
+        let chain = match self.segments.detach_chain(current, handler_fiber_id) {
+            Ok(chain) => chain,
+            Err(error) => return error_result(error, error_context),
+        };
+        if !k.append_chain(chain) {
+            return error_result(
+                VMError::internal("Pass: continuation already consumed"),
+                error_context,
+            );
+        }
+
+        // Switch to outer handler's parent
+        self.current_segment = boundary_parent;
+
         // Call handler — must return DoExpr
         match handler_callable.call_handler(vec![effect, Value::Continuation(k)]) {
-            Ok(doctrl) => {
-                continue_eval(doctrl, error_context)
-            }
+            Ok(doctrl) => continue_eval(doctrl, error_context),
             Err(VMError::UncaughtException { exception }) => {
                 // Python exception from handler callable — propagate through
                 // generator stack so try/except blocks can catch it.
@@ -694,12 +659,7 @@ impl VM {
 
         // 1. Create boundary fiber with handler
         let marker = crate::ids::Marker::fresh();
-        let handler_obj = crate::segment::Handler::prompt(
-            marker,
-            marker,
-            handler_callable,
-            None,
-        );
+        let handler_obj = crate::segment::Handler::prompt(marker, marker, handler_callable, None);
         let boundary_fid = self.match_with(handler_obj);
 
         // 2. Create a SEPARATE body fiber whose parent is the boundary
@@ -720,32 +680,25 @@ impl VM {
     ) -> StepResult {
         match eval_return {
             EvalReturnContinuation::ResumeToContinuation { head_fiber } => {
-                let mut k = Continuation::new(head_fiber, head_fiber, self.orphan_queue.clone());
-                match self.continue_k(&mut k) {
+                match self.continue_attached_chain(head_fiber, head_fiber) {
                     Ok(()) => continue_send(value, error_context),
                     Err(error) => error_result(error, error_context),
                 }
             }
             EvalReturnContinuation::ReturnToContinuation { head_fiber } => {
-                let mut k = Continuation::new(head_fiber, head_fiber, self.orphan_queue.clone());
-                match self.continue_k(&mut k) {
+                match self.continue_attached_chain(head_fiber, head_fiber) {
                     Ok(()) => continue_send(value, error_context),
                     Err(error) => error_result(error, error_context),
                 }
             }
             EvalReturnContinuation::EvalInScopeReturn { head_fiber } => {
-                let mut k = Continuation::new(head_fiber, head_fiber, self.orphan_queue.clone());
-                match self.continue_k(&mut k) {
+                match self.continue_attached_chain(head_fiber, head_fiber) {
                     Ok(()) => continue_send(value, error_context),
                     Err(error) => error_result(error, error_context),
                 }
             }
-            EvalReturnContinuation::TailResumeReturn => {
-                continue_send(value, error_context)
-            }
-            EvalReturnContinuation::ExpandReturn => {
-                self.push_stream_value(value, error_context)
-            }
+            EvalReturnContinuation::TailResumeReturn => continue_send(value, error_context),
+            EvalReturnContinuation::ExpandReturn => self.push_stream_value(value, error_context),
             _ => {
                 // Other EvalReturn variants — TODO
                 continue_send(value, error_context)

--- a/packages/doeff-vm-core/src/vm_tests.rs
+++ b/packages/doeff-vm-core/src/vm_tests.rs
@@ -31,7 +31,11 @@ mod tests {
 
     impl ScriptStream {
         fn new(steps: Vec<DoCtrl>, final_value: Value) -> Self {
-            Self { steps, final_value, index: 0 }
+            Self {
+                steps,
+                final_value,
+                index: 0,
+            }
         }
 
         fn returning(value: Value) -> Self {
@@ -71,7 +75,9 @@ mod tests {
 
     impl HandlerStream {
         fn resume_with(doctrl: DoCtrl) -> Self {
-            Self { response: Some(doctrl) }
+            Self {
+                response: Some(doctrl),
+            }
         }
     }
 
@@ -122,7 +128,9 @@ mod tests {
     fn expand_stream(stream: impl IRStream + 'static) -> Box<DoCtrl> {
         let stream_ref = IRStreamRef::new(Box::new(stream));
         Box::new(DoCtrl::Expand {
-            expr: Box::new(DoCtrl::Pure { value: Value::Stream(stream_ref) }),
+            expr: Box::new(DoCtrl::Pure {
+                value: Value::Stream(stream_ref),
+            }),
         })
     }
 
@@ -133,7 +141,9 @@ mod tests {
     #[test]
     fn test_pure_returns_value() {
         let stream = ScriptStream::new(
-            vec![DoCtrl::Pure { value: Value::Int(42) }],
+            vec![DoCtrl::Pure {
+                value: Value::Int(42),
+            }],
             Value::Unit,
         );
         let mut vm = setup_vm_with_stream(stream);
@@ -187,7 +197,9 @@ mod tests {
                     0 => {
                         // Initial resume — alloc var
                         self.state = 1;
-                        StreamStep::Instruction(DoCtrl::AllocVar { initial: Value::Int(10) })
+                        StreamStep::Instruction(DoCtrl::AllocVar {
+                            initial: Value::Int(10),
+                        })
                     }
                     1 => {
                         // Received Var(id) — read it
@@ -228,7 +240,10 @@ mod tests {
             }
         }
 
-        let stream = VarTestStream { state: 0, var_id: None };
+        let stream = VarTestStream {
+            state: 0,
+            var_id: None,
+        };
         let mut vm = setup_vm_with_stream(stream);
 
         let result = run_to_completion(&mut vm).unwrap();
@@ -248,7 +263,9 @@ mod tests {
         struct AddOne;
 
         impl Callable for AddOne {
-            fn as_any(&self) -> &dyn std::any::Any { self }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
             fn call(&self, args: Vec<Value>) -> Result<Value, VMError> {
                 match args.first() {
                     Some(Value::Int(n)) => Ok(Value::Int(n + 1)),
@@ -262,7 +279,9 @@ mod tests {
         let stream = ScriptStream::new(
             vec![DoCtrl::Apply {
                 f: Box::new(DoCtrl::Pure { value: callable }),
-                args: vec![DoCtrl::Pure { value: Value::Int(41) }],
+                args: vec![DoCtrl::Pure {
+                    value: Value::Int(41),
+                }],
             }],
             Value::Unit, // won't reach — Apply result is delivered to stream
         );
@@ -293,8 +312,12 @@ mod tests {
         let stream = CaptureStream {
             inner: ScriptStream::new(
                 vec![DoCtrl::Apply {
-                    f: Box::new(DoCtrl::Pure { value: Value::Callable(Arc::new(AddOne) as CallableRef) }),
-                    args: vec![DoCtrl::Pure { value: Value::Int(41) }],
+                    f: Box::new(DoCtrl::Pure {
+                        value: Value::Callable(Arc::new(AddOne) as CallableRef),
+                    }),
+                    args: vec![DoCtrl::Pure {
+                        value: Value::Int(41),
+                    }],
                 }],
                 Value::Unit,
             ),
@@ -326,8 +349,8 @@ mod tests {
         body_fiber.push_frame(Frame::program(body_stream, None));
         let body_fid = vm.alloc_segment(body_fiber);
 
-        // Create a continuation pointing to the body fiber
-        let mut k = Continuation::new(body_fid, body_fid, vm.orphan_queue.clone());
+        // Create a continuation owning the detached body fiber
+        let k = Continuation::from_chain(vm.segments.detach_chain(body_fid, body_fid).unwrap());
 
         // Create a root fiber that yields Resume(k, 77)
         #[derive(Debug)]
@@ -375,7 +398,9 @@ mod tests {
     fn test_eval_pure() {
         let stream = ScriptStream::new(
             vec![DoCtrl::Eval {
-                expr: Box::new(DoCtrl::Pure { value: Value::Int(55) }),
+                expr: Box::new(DoCtrl::Pure {
+                    value: Value::Int(55),
+                }),
             }],
             Value::Unit,
         );
@@ -406,7 +431,9 @@ mod tests {
             first: true,
             inner: ScriptStream::new(
                 vec![DoCtrl::Eval {
-                    expr: Box::new(DoCtrl::Pure { value: Value::Int(55) }),
+                    expr: Box::new(DoCtrl::Pure {
+                        value: Value::Int(55),
+                    }),
                 }],
                 Value::Unit,
             ),
@@ -457,7 +484,9 @@ mod tests {
         struct TestHandler;
 
         impl Callable for TestHandler {
-            fn as_any(&self) -> &dyn std::any::Any { self }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
             fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                 Err(VMError::internal("TestHandler: use call_handler"))
             }
@@ -467,7 +496,10 @@ mod tests {
                     _ => return Err(VMError::internal("handler: expected continuation")),
                 };
                 // Return Resume DoCtrl — body gets 100, returns it
-                Ok(DoCtrl::Resume { k, value: Value::Int(100) })
+                Ok(DoCtrl::Resume {
+                    k,
+                    value: Value::Int(100),
+                })
             }
         }
 
@@ -552,7 +584,9 @@ mod tests {
         struct TransferHandler;
 
         impl Callable for TransferHandler {
-            fn as_any(&self) -> &dyn std::any::Any { self }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
             fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                 Err(VMError::internal("TransferHandler: use call_handler"))
             }
@@ -561,27 +595,43 @@ mod tests {
                     Some(Value::Continuation(k)) => k,
                     _ => return Err(VMError::internal("handler: expected continuation")),
                 };
-                Ok(DoCtrl::Transfer { k, value: Value::Int(200) })
+                Ok(DoCtrl::Transfer {
+                    k,
+                    value: Value::Int(200),
+                })
             }
         }
 
         // Body: performs, returns what it gets
         #[derive(Debug)]
-        struct BodyStream { state: u8 }
+        struct BodyStream {
+            state: u8,
+        }
 
         impl IRStream for BodyStream {
             fn resume(&mut self, value: Value) -> StreamStep {
                 match self.state {
-                    0 => { self.state = 1; StreamStep::Instruction(DoCtrl::Perform { effect: Value::String("get".into()) }) }
+                    0 => {
+                        self.state = 1;
+                        StreamStep::Instruction(DoCtrl::Perform {
+                            effect: Value::String("get".into()),
+                        })
+                    }
                     1 => StreamStep::Done(value),
                     _ => StreamStep::Error(Value::String("bad".into())),
                 }
             }
-            fn throw(&mut self, error: Value) -> StreamStep { StreamStep::Error(error) }
+            fn throw(&mut self, error: Value) -> StreamStep {
+                StreamStep::Error(error)
+            }
         }
 
         #[derive(Debug)]
-        struct Root { done: bool, handler: Option<Value>, body: Option<Box<DoCtrl>> }
+        struct Root {
+            done: bool,
+            handler: Option<Value>,
+            body: Option<Box<DoCtrl>>,
+        }
 
         impl IRStream for Root {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -595,7 +645,9 @@ mod tests {
                     StreamStep::Done(value)
                 }
             }
-            fn throw(&mut self, error: Value) -> StreamStep { StreamStep::Error(error) }
+            fn throw(&mut self, error: Value) -> StreamStep {
+                StreamStep::Error(error)
+            }
         }
 
         let mut vm = setup_vm_with_stream(Root {
@@ -625,7 +677,9 @@ mod tests {
         struct CountHandler;
 
         impl Callable for CountHandler {
-            fn as_any(&self) -> &dyn std::any::Any { self }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
             fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                 Err(VMError::internal("CountHandler: use call_handler"))
             }
@@ -635,25 +689,41 @@ mod tests {
                     _ => return Err(VMError::internal("expected k")),
                 };
 
-                static COUNTER: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(10);
+                static COUNTER: std::sync::atomic::AtomicI64 =
+                    std::sync::atomic::AtomicI64::new(10);
                 let val = COUNTER.fetch_add(10, std::sync::atomic::Ordering::Relaxed);
 
-                Ok(DoCtrl::Resume { k, value: Value::Int(val) })
+                Ok(DoCtrl::Resume {
+                    k,
+                    value: Value::Int(val),
+                })
             }
         }
 
         // Body: performs twice, adds the results
         #[derive(Debug)]
-        struct BodyStream { state: u8, first: i64 }
+        struct BodyStream {
+            state: u8,
+            first: i64,
+        }
 
         impl IRStream for BodyStream {
             fn resume(&mut self, value: Value) -> StreamStep {
                 match self.state {
-                    0 => { self.state = 1; StreamStep::Instruction(DoCtrl::Perform { effect: Value::String("a".into()) }) }
+                    0 => {
+                        self.state = 1;
+                        StreamStep::Instruction(DoCtrl::Perform {
+                            effect: Value::String("a".into()),
+                        })
+                    }
                     1 => {
-                        if let Value::Int(v) = value { self.first = v; }
+                        if let Value::Int(v) = value {
+                            self.first = v;
+                        }
                         self.state = 2;
-                        StreamStep::Instruction(DoCtrl::Perform { effect: Value::String("b".into()) })
+                        StreamStep::Instruction(DoCtrl::Perform {
+                            effect: Value::String("b".into()),
+                        })
                     }
                     2 => {
                         if let Value::Int(v) = value {
@@ -665,11 +735,17 @@ mod tests {
                     _ => StreamStep::Error(Value::String("bad".into())),
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         #[derive(Debug)]
-        struct Root { done: bool, handler: Option<Value>, body: Option<Box<DoCtrl>> }
+        struct Root {
+            done: bool,
+            handler: Option<Value>,
+            body: Option<Box<DoCtrl>>,
+        }
 
         impl IRStream for Root {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -683,7 +759,9 @@ mod tests {
                     StreamStep::Done(value)
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         // Reset counter for this test
@@ -716,10 +794,14 @@ mod tests {
         // Both handlers resume with different values
         fn make_handler(reply: i64) -> Value {
             #[derive(Debug)]
-            struct H { reply: i64 }
+            struct H {
+                reply: i64,
+            }
 
             impl Callable for H {
-                fn as_any(&self) -> &dyn std::any::Any { self }
+                fn as_any(&self) -> &dyn std::any::Any {
+                    self
+                }
 
                 fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                     Err(VMError::internal("H: use call_handler"))
@@ -729,7 +811,10 @@ mod tests {
                         Some(Value::Continuation(k)) => k,
                         _ => return Err(VMError::internal("expected k")),
                     };
-                    Ok(DoCtrl::Resume { k, value: Value::Int(self.reply) })
+                    Ok(DoCtrl::Resume {
+                        k,
+                        value: Value::Int(self.reply),
+                    })
                 }
             }
 
@@ -738,17 +823,26 @@ mod tests {
 
         // Body: performs once, returns the value
         #[derive(Debug)]
-        struct BodyStream { state: u8 }
+        struct BodyStream {
+            state: u8,
+        }
 
         impl IRStream for BodyStream {
             fn resume(&mut self, value: Value) -> StreamStep {
                 match self.state {
-                    0 => { self.state = 1; StreamStep::Instruction(DoCtrl::Perform { effect: Value::String("ask".into()) }) }
+                    0 => {
+                        self.state = 1;
+                        StreamStep::Instruction(DoCtrl::Perform {
+                            effect: Value::String("ask".into()),
+                        })
+                    }
                     1 => StreamStep::Done(value),
                     _ => StreamStep::Error(Value::String("bad".into())),
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         // Structure:
@@ -757,7 +851,11 @@ mod tests {
         // Body performs → inner handles → returns 42
 
         #[derive(Debug)]
-        struct InnerRoot { done: bool, inner_handler: Option<Value>, body: Option<Box<DoCtrl>> }
+        struct InnerRoot {
+            done: bool,
+            inner_handler: Option<Value>,
+            body: Option<Box<DoCtrl>>,
+        }
 
         impl IRStream for InnerRoot {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -771,11 +869,17 @@ mod tests {
                     StreamStep::Done(value)
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         #[derive(Debug)]
-        struct OuterRoot { done: bool, outer_handler: Option<Value>, inner: Option<Box<DoCtrl>> }
+        struct OuterRoot {
+            done: bool,
+            outer_handler: Option<Value>,
+            inner: Option<Box<DoCtrl>>,
+        }
 
         impl IRStream for OuterRoot {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -789,7 +893,9 @@ mod tests {
                     StreamStep::Done(value)
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         let inner_stream = IRStreamRef::new(Box::new(InnerRoot {
@@ -801,7 +907,11 @@ mod tests {
         let mut vm = setup_vm_with_stream(OuterRoot {
             done: false,
             outer_handler: Some(make_handler(999)),
-            inner: Some(Box::new(DoCtrl::Expand { expr: Box::new(DoCtrl::Pure { value: Value::Stream(inner_stream) }) })),
+            inner: Some(Box::new(DoCtrl::Expand {
+                expr: Box::new(DoCtrl::Pure {
+                    value: Value::Stream(inner_stream),
+                }),
+            })),
         });
 
         let result = run_to_completion(&mut vm);
@@ -825,7 +935,9 @@ mod tests {
         struct PassHandler;
 
         impl Callable for PassHandler {
-            fn as_any(&self) -> &dyn std::any::Any { self }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
             fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                 Err(VMError::internal("PassHandler: use call_handler"))
             }
@@ -842,10 +954,14 @@ mod tests {
         // Handler that resumes with a value
         fn make_resume_handler(reply: i64) -> Value {
             #[derive(Debug)]
-            struct H { reply: i64 }
+            struct H {
+                reply: i64,
+            }
 
             impl Callable for H {
-                fn as_any(&self) -> &dyn std::any::Any { self }
+                fn as_any(&self) -> &dyn std::any::Any {
+                    self
+                }
 
                 fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                     Err(VMError::internal("H: use call_handler"))
@@ -855,7 +971,10 @@ mod tests {
                         Some(Value::Continuation(k)) => k,
                         _ => return Err(VMError::internal("expected k")),
                     };
-                    Ok(DoCtrl::Resume { k, value: Value::Int(self.reply) })
+                    Ok(DoCtrl::Resume {
+                        k,
+                        value: Value::Int(self.reply),
+                    })
                 }
             }
 
@@ -864,24 +983,37 @@ mod tests {
 
         // Body: performs once, returns the value
         #[derive(Debug)]
-        struct BodyStream { state: u8 }
+        struct BodyStream {
+            state: u8,
+        }
 
         impl IRStream for BodyStream {
             fn resume(&mut self, value: Value) -> StreamStep {
                 match self.state {
-                    0 => { self.state = 1; StreamStep::Instruction(DoCtrl::Perform { effect: Value::String("ask".into()) }) }
+                    0 => {
+                        self.state = 1;
+                        StreamStep::Instruction(DoCtrl::Perform {
+                            effect: Value::String("ask".into()),
+                        })
+                    }
                     1 => StreamStep::Done(value),
                     _ => StreamStep::Error(Value::String("bad".into())),
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         // WithHandler(outer=777, WithHandler(inner=Pass, body))
         // Body performs → inner passes → outer handles → 777
 
         #[derive(Debug)]
-        struct WrapStream { done: bool, h: Option<Value>, b: Option<Box<DoCtrl>> }
+        struct WrapStream {
+            done: bool,
+            h: Option<Value>,
+            b: Option<Box<DoCtrl>>,
+        }
 
         impl IRStream for WrapStream {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -891,9 +1023,13 @@ mod tests {
                         handler: self.h.take().unwrap(),
                         body: self.b.take().unwrap(),
                     })
-                } else { StreamStep::Done(value) }
+                } else {
+                    StreamStep::Done(value)
+                }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         let inner_stream = IRStreamRef::new(Box::new(WrapStream {
@@ -905,7 +1041,11 @@ mod tests {
         let mut vm = setup_vm_with_stream(WrapStream {
             done: false,
             h: Some(make_resume_handler(777)),
-            b: Some(Box::new(DoCtrl::Expand { expr: Box::new(DoCtrl::Pure { value: Value::Stream(inner_stream) }) })),
+            b: Some(Box::new(DoCtrl::Expand {
+                expr: Box::new(DoCtrl::Pure {
+                    value: Value::Stream(inner_stream),
+                }),
+            })),
         });
 
         let result = run_to_completion(&mut vm);
@@ -929,7 +1069,9 @@ mod tests {
         struct InnerHandler;
 
         impl Callable for InnerHandler {
-            fn as_any(&self) -> &dyn std::any::Any { self }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
             fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                 Err(VMError::internal("InnerHandler: use call_handler"))
             }
@@ -940,7 +1082,10 @@ mod tests {
                     _ => return Err(VMError::internal("expected k")),
                 };
                 if matches!(&effect, Value::String(s) if s == "ask") {
-                    Ok(DoCtrl::Resume { k, value: Value::Int(999) })
+                    Ok(DoCtrl::Resume {
+                        k,
+                        value: Value::Int(999),
+                    })
                 } else {
                     Ok(DoCtrl::Pass { effect, k })
                 }
@@ -953,7 +1098,9 @@ mod tests {
             struct H;
 
             impl Callable for H {
-                fn as_any(&self) -> &dyn std::any::Any { self }
+                fn as_any(&self) -> &dyn std::any::Any {
+                    self
+                }
 
                 fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
                     Err(VMError::internal("H: use call_handler"))
@@ -963,7 +1110,10 @@ mod tests {
                         Some(Value::Continuation(k)) => k,
                         _ => return Err(VMError::internal("expected k")),
                     };
-                    Ok(DoCtrl::Resume { k, value: Value::Int(0) })
+                    Ok(DoCtrl::Resume {
+                        k,
+                        value: Value::Int(0),
+                    })
                 }
             }
 
@@ -974,7 +1124,9 @@ mod tests {
         //       then performs "ask" (inner handles with 999),
         //       returns the ask result
         #[derive(Debug)]
-        struct BodyStream { state: u8 }
+        struct BodyStream {
+            state: u8,
+        }
 
         impl IRStream for BodyStream {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -999,12 +1151,18 @@ mod tests {
                     _ => StreamStep::Error(Value::String("bad state".into())),
                 }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         // WithHandler(outer, WithHandler(inner, body))
         #[derive(Debug)]
-        struct WrapStream { done: bool, h: Option<Value>, b: Option<Box<DoCtrl>> }
+        struct WrapStream {
+            done: bool,
+            h: Option<Value>,
+            b: Option<Box<DoCtrl>>,
+        }
 
         impl IRStream for WrapStream {
             fn resume(&mut self, value: Value) -> StreamStep {
@@ -1014,9 +1172,13 @@ mod tests {
                         handler: self.h.take().unwrap(),
                         body: self.b.take().unwrap(),
                     })
-                } else { StreamStep::Done(value) }
+                } else {
+                    StreamStep::Done(value)
+                }
             }
-            fn throw(&mut self, e: Value) -> StreamStep { StreamStep::Error(e) }
+            fn throw(&mut self, e: Value) -> StreamStep {
+                StreamStep::Error(e)
+            }
         }
 
         let inner_stream = IRStreamRef::new(Box::new(WrapStream {
@@ -1029,7 +1191,9 @@ mod tests {
             done: false,
             h: Some(make_outer_handler()),
             b: Some(Box::new(DoCtrl::Expand {
-                expr: Box::new(DoCtrl::Pure { value: Value::Stream(inner_stream) }),
+                expr: Box::new(DoCtrl::Pure {
+                    value: Value::Stream(inner_stream),
+                }),
             })),
         });
 

--- a/packages/doeff-vm/src/python_generator_stream.rs
+++ b/packages/doeff-vm/src/python_generator_stream.rs
@@ -378,17 +378,56 @@ fn take_continuation(
     }
 }
 
-/// Peek at head FiberId from a Py<PyK> without consuming.
-fn peek_head(
+fn continuation_traceback_value(
     py: Python<'_>,
     k: &Py<doeff_vm_core::continuation::PyK>,
     label: &str,
-) -> Result<doeff_vm_core::FiberId, String> {
+) -> Result<Value, String> {
     let k_ref = k.bind(py);
     let k_borrowed = k_ref.borrow();
-    k_borrowed
-        .peek_head()
-        .ok_or_else(|| format!("{}: continuation has no head fiber", label))
+    let Some(doeff_vm_core::OwnedControlContinuation::Started(k)) = k_borrowed.continuation_ref()
+    else {
+        return Err(format!(
+            "{}: continuation has no detached fiber chain",
+            label
+        ));
+    };
+    let frames = k
+        .collect_traceback()
+        .ok_or_else(|| format!("{}: continuation has no detached fiber chain", label))?
+        .into_iter()
+        .map(|loc| {
+            Value::List(vec![
+                Value::String(loc.func_name),
+                Value::String(loc.source_file),
+                Value::Int(loc.source_line as i64),
+            ])
+        })
+        .collect();
+    Ok(Value::List(frames))
+}
+
+fn continuation_handlers_value(
+    py: Python<'_>,
+    k: &Py<doeff_vm_core::continuation::PyK>,
+    label: &str,
+) -> Result<Value, String> {
+    let k_ref = k.bind(py);
+    let k_borrowed = k_ref.borrow();
+    let Some(doeff_vm_core::OwnedControlContinuation::Started(k)) = k_borrowed.continuation_ref()
+    else {
+        return Err(format!(
+            "{}: continuation has no detached fiber chain",
+            label
+        ));
+    };
+    let handlers = k
+        .handler_callables()
+        .ok_or_else(|| format!("{}: continuation has no detached fiber chain", label))?
+        .into_iter()
+        .map(Value::Callable)
+        .collect();
+    Ok(Value::List(handlers))
 }
 
 /// Wrap a handler callable as Value::Callable.
@@ -493,15 +532,15 @@ pub fn classify_python_object(py: Python<'_>, obj: &Bound<'_, PyAny>) -> Result<
         });
     }
     if let Ok(gt) = obj.downcast::<PyGetTraceback>() {
-        let head = peek_head(py, &gt.get().continuation, "GetTraceback")?;
-        return Ok(DoCtrl::GetTraceback { from: head });
+        let value = continuation_traceback_value(py, &gt.get().continuation, "GetTraceback")?;
+        return Ok(DoCtrl::Pure { value });
     }
     if obj.downcast::<PyGetExecutionContext>().is_ok() {
         return Ok(DoCtrl::GetExecutionContext);
     }
     if let Ok(gh) = obj.downcast::<PyGetHandlers>() {
-        let head = peek_head(py, &gh.get().continuation, "GetHandlers")?;
-        return Ok(DoCtrl::GetHandlers { from: head });
+        let value = continuation_handlers_value(py, &gh.get().continuation, "GetHandlers")?;
+        return Ok(DoCtrl::Pure { value });
     }
     if obj.downcast::<crate::do_expr::PyGetOuterHandlers>().is_ok() {
         return Ok(DoCtrl::GetOuterHandlers);
@@ -629,14 +668,35 @@ fn classify_tagged_to_doctrl(
             let k_obj = obj
                 .getattr("continuation")
                 .map_err(|_| "GetTraceback: missing 'continuation' attribute".to_string())?;
-            let k_ref = k_obj
+            let k = k_obj
                 .downcast::<doeff_vm_core::continuation::PyK>()
                 .map_err(|_| "GetTraceback: continuation must be K".to_string())?;
-            let k_borrowed = k_ref.borrow();
-            let head = k_borrowed
-                .peek_head()
-                .ok_or_else(|| "GetTraceback: continuation has no head fiber".to_string())?;
-            Ok(DoCtrl::GetTraceback { from: head })
+            let value = {
+                let k_borrowed = k.borrow();
+                let Some(doeff_vm_core::OwnedControlContinuation::Started(k)) =
+                    k_borrowed.continuation_ref()
+                else {
+                    return Err(
+                        "GetTraceback: continuation has no detached fiber chain".to_string()
+                    );
+                };
+                let frames = k
+                    .collect_traceback()
+                    .ok_or_else(|| {
+                        "GetTraceback: continuation has no detached fiber chain".to_string()
+                    })?
+                    .into_iter()
+                    .map(|loc| {
+                        Value::List(vec![
+                            Value::String(loc.func_name),
+                            Value::String(loc.source_file),
+                            Value::Int(loc.source_line as i64),
+                        ])
+                    })
+                    .collect();
+                Value::List(frames)
+            };
+            Ok(DoCtrl::Pure { value })
         }
         24 => {
             let observer_obj = obj
@@ -658,14 +718,27 @@ fn classify_tagged_to_doctrl(
             let k_obj = obj
                 .getattr("continuation")
                 .map_err(|_| "GetHandlers: missing 'continuation' attribute".to_string())?;
-            let k_ref = k_obj
+            let k = k_obj
                 .downcast::<doeff_vm_core::continuation::PyK>()
                 .map_err(|_| "GetHandlers: continuation must be K".to_string())?;
-            let k_borrowed = k_ref.borrow();
-            let head = k_borrowed
-                .peek_head()
-                .ok_or_else(|| "GetHandlers: continuation has no head fiber".to_string())?;
-            Ok(DoCtrl::GetHandlers { from: head })
+            let value = {
+                let k_borrowed = k.borrow();
+                let Some(doeff_vm_core::OwnedControlContinuation::Started(k)) =
+                    k_borrowed.continuation_ref()
+                else {
+                    return Err("GetHandlers: continuation has no detached fiber chain".to_string());
+                };
+                let handlers = k
+                    .handler_callables()
+                    .ok_or_else(|| {
+                        "GetHandlers: continuation has no detached fiber chain".to_string()
+                    })?
+                    .into_iter()
+                    .map(Value::Callable)
+                    .collect();
+                Value::List(handlers)
+            };
+            Ok(DoCtrl::Pure { value })
         }
         27 => Ok(DoCtrl::GetOuterHandlers),
         _ => Err(format!("unknown DoExpr tag: {}", tag)),

--- a/specs/vm/ISSUE-VM-001-mutable-state-audit.md
+++ b/specs/vm/ISSUE-VM-001-mutable-state-audit.md
@@ -137,6 +137,13 @@ Prerequisite for SPEC-VM-022 (Pass with reason trail):
 The V1/V3 cleanup makes SPEC-VM-022 much smaller: no new register to add,
 no old register to coexist with.
 
+## Progress
+
+- **PR G0** merged as #394. `VM.last_error_context` and `VM.mode` are removed;
+  step input/output now carries `Signal` and error context explicitly.
+- **PR G1** is now scoped by
+  `specs/vm/SPEC-VM-023-fiber-ownership.md`.
+
 ## Reliable-Checkpoint Requirement
 
 Before starting PR G0 work, the existing test suite must be green. Stale

--- a/specs/vm/SPEC-VM-023-fiber-ownership.md
+++ b/specs/vm/SPEC-VM-023-fiber-ownership.md
@@ -1,0 +1,233 @@
+# SPEC-VM-023: Fiber Ownership and Orphan Reclamation
+
+**Status:** Draft
+**Created:** 2026-04-25
+**Depends on:** ISSUE-VM-001, SPEC-VM-020, SPEC-VM-021, PR #394
+**Scope:** PR G1
+
+## Problem
+
+PR G0 removed the VM's `mode` and `last_error_context` registers. The remaining
+mutable-state violation from ISSUE-VM-001 is orphan reclamation:
+
+```rust
+VM.orphan_queue: Arc<Mutex<Vec<FiberId>>>
+Continuation.orphan_queue: Option<OrphanQueue>
+```
+
+Today a dropped, unconsumed `Continuation` pushes its detached fiber head into
+the queue from `Drop`. `VM::step` drains that queue and frees the fiber chain
+from the arena.
+
+This works mechanically, but it violates the VM invariant:
+
+1. `Continuation::drop` mutates VM-owned state through a shared pointer.
+2. The queue is a hidden VM register, even though it is presented as a GC
+   mechanism.
+3. Reclamation timing depends on an out-of-band side channel instead of fiber
+   ownership.
+
+G1 must remove the queue without weakening one-shot continuation semantics.
+
+## Current Ownership Model
+
+The current code has these owners:
+
+| Object | Owner |
+| --- | --- |
+| Live executing fibers | `VM.segments: FiberArena` |
+| Detached continuation head/tail | `Continuation { head, last_fiber }` |
+| Python-visible continuation | `PyK { continuation: Option<OwnedControlContinuation> }` |
+| Orphan notification | `Arc<Mutex<Vec<FiberId>>>` shared by VM and continuations |
+
+`Continuation` does not own the detached fibers themselves. It owns only two
+arena IDs. Therefore, if a `Continuation` is dropped without being consumed,
+the arena still owns the detached fibers but no semantic root can reach them.
+The orphan queue exists to tell the arena what to free later.
+
+## Required Invariants
+
+After G1:
+
+1. `VM` has no `orphan_queue` field.
+2. `Continuation` has no queue, VM pointer, arena pointer, `Arc<Mutex<_>>`, or
+   other shared mutable reclamation channel.
+3. Dropping an unconsumed continuation does not mutate VM state.
+4. A live `PyK` remains first-class. It may be held by Python code and resumed
+   later, so reclamation must not assume that only the active VM fiber chain is
+   live.
+5. Fibers reachable from a live continuation must not be freed or reused.
+6. Fibers reachable from no VM root and no continuation root must eventually
+   release Python payload references.
+
+## Design Options
+
+### Option A: Keep Arena Ownership, Replace Queue with Mark-Sweep
+
+The VM would periodically walk roots, mark reachable arena fibers, and free
+unmarked fibers.
+
+Roots are:
+
+- `VM.current_segment`
+- all live `Continuation` heads
+
+This removes the queue only if live continuations can be enumerated without a
+new mutable registry. The current bridge cannot do that: `PyK` is a Python
+object and can be held in generator locals or user data outside the VM's arena
+walk. A sweep rooted only at `current_segment` would free a still-live
+continuation.
+
+Adding a live-`PyK` registry would replace `orphan_queue` with another VM-level
+mutable side table. That does not satisfy ISSUE-VM-001.
+
+**Decision:** reject for G1 unless a future design makes continuation roots
+structurally enumerable without a registry.
+
+### Option B: Continuation Owns Detached Fibers
+
+On perform, the VM removes the detached chain from arena ownership and moves
+the fiber values into the `Continuation`. On resume/pass, the VM reattaches the
+owned chain to the arena. If the continuation is dropped, Rust drops the owned
+fiber values directly; no VM callback or queue is needed.
+
+This is the clean ownership model:
+
+```rust
+pub struct Continuation {
+    chain: Option<DetachedFiberChain>,
+}
+
+pub struct DetachedFiberChain {
+    head: FiberId,
+    last_fiber: FiberId,
+    fibers: Vec<DetachedFiber>,
+}
+
+pub struct DetachedFiber {
+    old_id: FiberId,
+    fiber: Fiber,
+}
+```
+
+The exact storage shape may change during implementation, but ownership must
+not: while detached, the continuation owns the fiber values.
+
+**Decision:** G1 should implement this direction.
+
+### Option C: Cosmetic Queue Replacement
+
+Replacing `Arc<Mutex<Vec<FiberId>>>` with `Rc<RefCell<Vec<FiberId>>>`, a
+thread-local, an atomic flag, or a weak registry keeps the same hidden mutable
+channel.
+
+**Decision:** reject.
+
+## Target Semantics
+
+### Perform
+
+1. Find the matching handler boundary.
+2. Detach the body-through-boundary chain from the active arena chain.
+3. Move the detached fiber values into `Continuation`.
+4. Switch `current_segment` to the handler parent.
+5. Pass `Value::Continuation(k)` to the handler.
+
+The VM keeps no copy of `k`.
+
+### Resume / Transfer
+
+1. Destructively take the chain from `Continuation`.
+2. Reattach the chain to the arena with the current fiber as the parent of the
+   chain tail.
+3. Switch `current_segment` to the reattached head.
+4. Deliver the value or exception.
+
+A second resume still fails through `Option::take()`.
+
+### Pass / Reperform
+
+1. Destructively take or mutably own the existing detached chain.
+2. Append the current handler chain to it.
+3. Search for the next outer handler.
+4. Pass the extended continuation to that handler.
+
+No placeholder continuation may be created solely to satisfy type shape.
+
+### Drop
+
+Dropping an unconsumed `Continuation` drops its owned detached fiber chain.
+This releases frames, streams, and Python payload references immediately from
+normal Rust ownership. It does not call into `VM`.
+
+## Arena API Requirements
+
+G1 will need arena operations that make ownership explicit:
+
+```rust
+impl FiberArena {
+    fn detach_chain(&mut self, head: FiberId, last: FiberId) -> Result<DetachedFiberChain, VMError>;
+    fn attach_chain(
+        &mut self,
+        chain: DetachedFiberChain,
+        tail_parent: Option<FiberId>,
+    ) -> Result<FiberId, VMError>;
+}
+```
+
+Implementation details to settle in code:
+
+- Whether detached chains re-use their original `FiberId`s or receive fresh IDs
+  on reattach.
+- How `GetTraceback(k)` and `GetHandlers(k)` inspect a detached chain while it
+  is not in the arena.
+- Whether the arena needs a reserved-slot state during detachment. A reserved
+  slot is acceptable only if it stores no `Fiber` and therefore cannot retain
+  Python payloads.
+
+## TDD and Guard Plan
+
+Before implementation, add failing tests and guards:
+
+1. Runtime regression:
+   - un-xfail or clone the existing bounded-memory tests in
+     `tests/test_vm_memory_leak.py`.
+   - Add a focused Rust test that drops an unconsumed `Continuation` and
+     verifies the detached fiber payloads are released without calling
+     `VM::step`.
+2. Architecture tests:
+   - `VM` must not contain `orphan_queue`.
+   - `Continuation` must not contain `orphan_queue`, `OrphanQueue`, `Arc`,
+     `Mutex`, or an arena/VM pointer.
+   - `Continuation::drop` must not enqueue or lock.
+3. Semgrep guards:
+   - ban `orphan_queue` in `packages/doeff-vm-core/src`.
+   - ban `Arc<Mutex<Vec<FiberId>>>` in VM core.
+   - ban `Continuation::new(..., vm.orphan_queue.clone())`-style constructors.
+
+The tests should fail on the current code before implementation.
+
+## Acceptance Criteria
+
+G1 is complete when:
+
+1. `rg "orphan_queue|OrphanQueue" packages/doeff-vm-core/src` returns no
+   production-code hits.
+2. `Continuation` owns detached fiber values or an equivalent move-only
+   detached-chain object.
+3. Dropping a live, unconsumed `PyK` does not require the VM to take another
+   step to release detached fiber payloads.
+4. Existing continuation behavior remains intact:
+   - resume is one-shot
+   - pass/reperform preserves handler ordering
+   - traceback and handler introspection still work for continuation roots
+5. Root pytest does not regress from the post-G0 baseline.
+6. `make lint` is no worse than the known pre-existing pyright/import failures.
+
+## Non-Goals
+
+- G1 does not implement SPEC-VM-022 pass reason trails.
+- G1 does not redesign Python generator state retention except where retained
+  payloads are caused by detached fiber ownership.
+- G1 does not reintroduce continuation cloning, `ContId`, or shared consumed
+  flags.

--- a/tests/core/test_vm_fiber_ownership_g1.py
+++ b/tests/core/test_vm_fiber_ownership_g1.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VM_CORE = ROOT / "packages" / "doeff-vm-core" / "src"
+VM_RS = VM_CORE / "vm.rs"
+CONTINUATION_RS = VM_CORE / "continuation.rs"
+DISPATCH_RS = VM_CORE / "vm" / "dispatch.rs"
+STEP_RS = VM_CORE / "vm" / "step.rs"
+ARENA_RS = VM_CORE / "arena.rs"
+
+
+def _runtime_source(path: Path) -> str:
+    source = path.read_text(encoding="utf-8")
+    runtime_source, _, _ = source.rpartition("\n#[cfg(test)]")
+    return runtime_source if runtime_source else source
+
+
+def _struct_body(source: str, name: str) -> str:
+    match = re.search(rf"pub struct {name}\s*\{{(?P<body>.*?)\n\}}", source, re.DOTALL)
+    assert match is not None, f"missing pub struct {name}"
+    return match.group("body")
+
+
+def test_g1_vm_has_no_orphan_queue_register() -> None:
+    body = _struct_body(_runtime_source(VM_RS), "VM")
+
+    assert "orphan_queue" not in body
+    assert "OrphanQueue" not in body
+
+
+def test_g1_continuation_owns_detached_fiber_chain_without_queue() -> None:
+    source = _runtime_source(CONTINUATION_RS)
+    body = _struct_body(source, "Continuation")
+
+    assert "DetachedFiberChain" in body
+    assert "orphan_queue" not in body
+    assert "OrphanQueue" not in source
+    assert "Arc<Mutex" not in source
+    assert ".lock()" not in source
+    assert ".push(head)" not in source
+
+
+def test_g1_arena_exposes_explicit_detach_attach_operations() -> None:
+    source = _runtime_source(ARENA_RS)
+
+    assert "detach_chain" in source
+    assert "attach_chain" in source
+    assert "DetachedFiberChain" in source
+
+
+def test_g1_dispatch_and_step_do_not_construct_queue_backed_continuations() -> None:
+    source = "\n".join(
+        [
+            _runtime_source(DISPATCH_RS),
+            _runtime_source(STEP_RS),
+        ]
+    )
+
+    assert "orphan_queue" not in source
+    assert "Continuation::single" not in source
+    assert not re.search(r"Continuation::new\([^;\n]*orphan_queue", source)


### PR DESCRIPTION
## Summary
- Add `SPEC-VM-023-fiber-ownership.md` for PR G1 and record G0 completion in ISSUE-VM-001.
- Add G1 source/semgrep guards banning `orphan_queue`, `OrphanQueue`, `Arc<Mutex<Vec<FiberId>>>`, and queue-backed continuation constructors.
- Move detached fiber chains into `Continuation` ownership via `DetachedFiberChain` / `DetachedFiber`.
- Add explicit `FiberArena::detach_chain` / `attach_chain` operations that reserve detached slots until reattach/drop.
- Remove `VM.orphan_queue`, `Continuation.orphan_queue`, and per-step queue draining.
- Keep `GetTraceback(k)` / `GetHandlers(k)` working by reading from the detached chain owned by `PyK` without consuming it.

## Validation
- `make sync`
- `uv run --active pytest` -> 782 passed, 84 skipped, 4 xfailed
- `uv run --active pytest tests/core/test_vm_fiber_ownership_g1.py tests/core/test_vm_mutable_state_audit_g0.py tests/test_get_handlers_defk.py tests/effects/test_unhandled_effect_chain.py tests/test_handler_exception_catchable.py` -> 21 passed
- `PYO3_PYTHON=/Users/s22625/repos/doeff/.venv/bin/python3 cargo test --features python_bridge --lib` in `packages/doeff-vm-core` -> 27 passed, 1 ignored
- `cargo check -p doeff-vm`
- `uv run --active semgrep --config .semgrep.yaml packages/doeff-vm-core/src/vm.rs packages/doeff-vm-core/src/continuation.rs packages/doeff-vm-core/src/vm/dispatch.rs packages/doeff-vm-core/src/vm/step.rs` -> 0 findings
- `git diff --check HEAD~2..HEAD`

## Known Notes
- `make lint` still fails at pyright on pre-existing import/type issues (`GetOuterHandlers`, missing `doeff_core_effects`/`doeff_indexer`, `Expand` type args), same class as before G1.
- The two VM memory leak tests remain xfailed; G1 removes queue-backed detached-chain reclamation but does not solve resumed Python handler generator payload retention.