### PR TITLE
Fix VM xfail regressions

### DIFF
--- a/doeff/do.py
+++ b/doeff/do.py
@@ -11,33 +11,247 @@ The @do decorator — converts a generator function into a program factory.
 """
 from __future__ import annotations
 
+import ast
 import inspect
-from collections.abc import Generator
+import warnings
+from collections.abc import Callable, Generator
 from functools import wraps
-from typing import Any, Callable, ParamSpec, TypeVar
+from textwrap import dedent
+from typing import Any, ParamSpec, overload
 
-from doeff.program import Expand, Apply, Pure
+from doeff.program import Apply, Expand, Pure
 
 P = ParamSpec("P")
-T = TypeVar("T")
 
 
-def do(fn: Callable[P, Generator[Any, Any, T]]) -> Callable[P, Expand[T]]:
+class _ResumeYieldAnalysis(ast.NodeVisitor):
+    def __init__(self, source_start_line: int) -> None:
+        self.source_start_line = source_start_line
+        self.function_depth = 0
+        self.protected_depth = 0
+        self.tail_resume_lines: set[int] = set()
+        self.non_tail_resume_lines: set[int] = set()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self.function_depth > 0:
+            return
+        self.function_depth += 1
+        self._visit_statement_block(node.body)
+        self.function_depth -= 1
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if self.function_depth > 0:
+            return
+        self.function_depth += 1
+        self._visit_statement_block(node.body)
+        self.function_depth -= 1
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if (
+            self.protected_depth == 0
+            and isinstance(node.value, ast.Yield)
+            and _is_resume_call(node.value.value)
+        ):
+            self.tail_resume_lines.update(self._absolute_lines(node.value))
+            return
+        self.generic_visit(node)
+
+    def visit_Yield(self, node: ast.Yield) -> None:
+        if _is_resume_call(node.value):
+            self.non_tail_resume_lines.add(self._absolute_line(node))
+        self.generic_visit(node)
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        self._visit_statement_block(node.body)
+        self._visit_statement_block(node.orelse)
+
+    def visit_For(self, node: ast.For) -> None:
+        self.visit(node.target)
+        self.visit(node.iter)
+        self._visit_statement_block(node.body)
+        self._visit_statement_block(node.orelse)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.visit(node.target)
+        self.visit(node.iter)
+        self._visit_statement_block(node.body)
+        self._visit_statement_block(node.orelse)
+
+    def visit_While(self, node: ast.While) -> None:
+        self.visit(node.test)
+        self._visit_statement_block(node.body)
+        self._visit_statement_block(node.orelse)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self.protected_depth += 1
+        self.generic_visit(node)
+        self.protected_depth -= 1
+
+    def visit_With(self, node: ast.With) -> None:
+        self.protected_depth += 1
+        self.generic_visit(node)
+        self.protected_depth -= 1
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self.protected_depth += 1
+        self.generic_visit(node)
+        self.protected_depth -= 1
+
+    def _absolute_line(self, node: ast.AST) -> int:
+        lineno = int(getattr(node, "lineno", 0))
+        return self.source_start_line + lineno - 1
+
+    def _absolute_lines(self, node: ast.AST) -> range:
+        lineno = int(getattr(node, "lineno", 0))
+        end_lineno = int(getattr(node, "end_lineno", lineno))
+        start = self._absolute_line(node)
+        end = self.source_start_line + end_lineno - 1
+        return range(start, end + 1)
+
+    def _visit_statement_block(self, statements: list[ast.stmt]) -> None:
+        index = 0
+        while index < len(statements):
+            if index + 1 < len(statements):
+                yield_node = self._tail_assignment_resume_yield(
+                    statements[index],
+                    statements[index + 1],
+                )
+                if yield_node is not None:
+                    self.tail_resume_lines.update(self._absolute_lines(yield_node))
+                    index += 2
+                    continue
+            self.visit(statements[index])
+            index += 1
+
+    def _tail_assignment_resume_yield(
+        self,
+        first: ast.stmt,
+        second: ast.stmt,
+    ) -> ast.Yield | None:
+        if self.protected_depth != 0:
+            return None
+        if not isinstance(second, ast.Return) or not isinstance(second.value, ast.Name):
+            return None
+
+        assigned_name: str | None = None
+        assigned_value: ast.expr | None = None
+        if isinstance(first, ast.Assign) and len(first.targets) == 1:
+            target = first.targets[0]
+            if isinstance(target, ast.Name):
+                assigned_name = target.id
+                assigned_value = first.value
+        elif isinstance(first, ast.AnnAssign) and isinstance(first.target, ast.Name):
+            assigned_name = first.target.id
+            assigned_value = first.value
+
+        if assigned_name != second.value.id or not isinstance(assigned_value, ast.Yield):
+            return None
+        if not _is_resume_call(assigned_value.value):
+            return None
+        return assigned_value
+
+
+def _is_resume_call(node: ast.AST | None) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    return _call_leaf_name(node.func) in {"Resume", "ResumeThrow"}
+
+
+def _call_leaf_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _analyze_resume_yields(fn: Callable[..., Any], *, non_tail: bool) -> tuple[int, ...]:
+    try:
+        source_lines, start_line = inspect.getsourcelines(fn)
+    except (OSError, TypeError):
+        return ()
+
+    try:
+        module = ast.parse(dedent("".join(source_lines)))
+    except SyntaxError:
+        return ()
+
+    function_node = next(
+        (
+            node
+            for node in ast.walk(module)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == fn.__name__
+        ),
+        None,
+    )
+    if function_node is None:
+        return ()
+
+    visitor = _ResumeYieldAnalysis(start_line)
+    visitor.visit(function_node)
+    if visitor.non_tail_resume_lines and not non_tail:
+        sorted_lines = sorted(visitor.non_tail_resume_lines)
+        lines = ", ".join(str(line) for line in sorted_lines)
+        warnings.warn_explicit(
+            "non-tail Resume/ResumeThrow in @do handler keeps the handler generator "
+            "frame and its locals live until the resumed continuation returns; use "
+            "@do(non_tail=True) to acknowledge this, or Transfer/TransferThrow when "
+            f"the handler is done after resuming (line(s): {lines})",
+            RuntimeWarning,
+            fn.__code__.co_filename,
+            sorted_lines[0],
+        )
+
+    return tuple(sorted(visitor.tail_resume_lines))
+
+
+@overload
+def do(fn: Callable[P, Generator[Any, Any, Any]], /) -> Callable[P, Expand]: ...
+
+
+@overload
+def do(
+    *,
+    non_tail: bool = False,
+) -> Callable[[Callable[P, Generator[Any, Any, Any]]], Callable[P, Expand]]: ...
+
+
+def do(
+    fn: Callable[P, Generator[Any, Any, Any]] | None = None,
+    /,
+    *,
+    non_tail: bool = False,
+) -> Callable[P, Expand] | Callable[[Callable[P, Generator[Any, Any, Any]]], Callable[P, Expand]]:
     """Wrap a generator function so calling it returns a DoExpr tree."""
-    from doeff_vm import Callable as VMCallable, IRStream
 
-    def _make_stream(result):
-        if inspect.isgenerator(result):
-            return IRStream(result)
-        def value_gen():
-            if False:
-                yield
-            return result
-        return IRStream(value_gen())
+    def decorate(fn: Callable[P, Generator[Any, Any, Any]]) -> Callable[P, Expand]:
+        tail_resume_lines = _analyze_resume_yields(fn, non_tail=non_tail)
 
-    @wraps(fn)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Expand[T]:
-        def thunk():
-            return _make_stream(fn(*args, **kwargs))
-        return Expand(Apply(Pure(VMCallable(thunk)), []))
-    return wrapper
+        from doeff_vm import Callable as VMCallable
+        from doeff_vm import IRStream
+
+        def _make_stream(result):
+            if inspect.isgenerator(result):
+                return IRStream(result, tail_resume_lines)
+
+            def value_gen():
+                if False:
+                    yield
+                return result
+
+            return IRStream(value_gen())
+
+        @wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Expand:
+            def thunk():
+                return _make_stream(fn(*args, **kwargs))
+
+            return Expand(Apply(Pure(VMCallable(thunk)), []))
+
+        return wrapper
+
+    if fn is None:
+        return decorate
+
+    return decorate(fn)

--- a/packages/doeff-vm/doeff_vm/__init__.pyi
+++ b/packages/doeff-vm/doeff_vm/__init__.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, SupportsIndex, TypeVar
 
 _T = TypeVar("_T")
 
@@ -18,16 +18,16 @@ class K:
 # --- Callable / Stream ---
 
 class Callable:
-    def __init__(self, callable: Any) -> None: ...
+    def __init__(self, callable_: Any) -> None: ...
 
 class IRStream:
-    def __init__(self, generator: Any) -> None: ...
+    def __init__(self, generator: Any, tail_resume_lines: Any | None = None) -> None: ...
 
 # --- EffectBase ---
 
 class EffectBase:
     def __init__(self, *_args: Any, **_kwargs: Any) -> None: ...
-    def __reduce_ex__(self, protocol: int) -> tuple[Any, ...]: ...
+    def __reduce_ex__(self, protocol: SupportsIndex) -> tuple[Any, ...]: ...
 
 # --- Result types ---
 

--- a/packages/doeff-vm/src/python_generator_stream.rs
+++ b/packages/doeff-vm/src/python_generator_stream.rs
@@ -144,13 +144,18 @@ impl doeff_vm_core::value::Callable for PythonCallable {
 #[derive(Debug)]
 pub struct PyIRStream {
     pub generator: Py<PyAny>,
+    pub tail_resume_lines: Vec<u32>,
 }
 
 #[pymethods]
 impl PyIRStream {
     #[new]
-    pub fn new(generator: Py<PyAny>) -> Self {
-        Self { generator }
+    #[pyo3(signature = (generator, tail_resume_lines=None))]
+    pub fn new(generator: Py<PyAny>, tail_resume_lines: Option<Vec<u32>>) -> Self {
+        Self {
+            generator,
+            tail_resume_lines: tail_resume_lines.unwrap_or_default(),
+        }
     }
 }
 
@@ -161,15 +166,17 @@ impl PyIRStream {
 #[derive(Debug)]
 pub struct PythonGeneratorStream {
     generator: PyShared,
+    tail_resume_lines: Vec<u32>,
     exhausted: bool,
     /// Last known source location, preserved after generator exhaustion.
     last_location: Option<doeff_vm_core::ir_stream::StreamSourceLocation>,
 }
 
 impl PythonGeneratorStream {
-    pub fn new(generator: PyShared) -> Self {
+    pub fn new(generator: PyShared, tail_resume_lines: Vec<u32>) -> Self {
         Self {
             generator,
+            tail_resume_lines,
             exhausted: false,
             last_location: None,
         }
@@ -270,6 +277,17 @@ impl PythonGeneratorStream {
     /// classify_python_object handles all cases:
     /// DoExpr (has tag), EffectBase (implicit Perform), or error.
     fn classify_yielded(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> StreamStep {
+        if is_tail_resume_candidate(obj) {
+            if let Some(line) = generator_current_line(py, &self.generator) {
+                if self.tail_resume_lines.contains(&line) {
+                    match classify_tail_resume(py, obj) {
+                        Ok(Some(doctrl)) => return StreamStep::Instruction(doctrl),
+                        Ok(None) => {}
+                        Err(msg) => return StreamStep::Error(Value::String(msg)),
+                    }
+                }
+            }
+        }
         match classify_python_object(py, obj) {
             Ok(doctrl) => StreamStep::Instruction(doctrl),
             Err(msg) => StreamStep::Error(Value::String(msg)),
@@ -357,6 +375,44 @@ impl IRStream for PythonGeneratorStream {
 // ---------------------------------------------------------------------------
 // classify_python_object — top-level classification for run()
 // ---------------------------------------------------------------------------
+
+fn is_tail_resume_candidate(obj: &Bound<'_, PyAny>) -> bool {
+    use crate::do_expr::{PyResume, PyResumeThrow};
+
+    obj.downcast::<PyResume>().is_ok() || obj.downcast::<PyResumeThrow>().is_ok()
+}
+
+fn generator_current_line(py: Python<'_>, generator: &PyShared) -> Option<u32> {
+    let gen = generator.bind(py);
+    let frame = gen.getattr("gi_frame").ok()?;
+    if frame.is_none() {
+        return None;
+    }
+    frame
+        .getattr("f_lineno")
+        .ok()
+        .and_then(|line| line.extract::<u32>().ok())
+}
+
+fn classify_tail_resume(py: Python<'_>, obj: &Bound<'_, PyAny>) -> Result<Option<DoCtrl>, String> {
+    use crate::do_expr::{PyResume, PyResumeThrow};
+
+    if let Ok(r) = obj.downcast::<PyResume>() {
+        let r = r.get();
+        let k = take_continuation(py, &r.continuation, "Transfer")?;
+        let value = python_to_value(py, &r.value.bind(py));
+        return Ok(Some(DoCtrl::Transfer { k, value }));
+    }
+
+    if let Ok(rt) = obj.downcast::<PyResumeThrow>() {
+        let rt = rt.get();
+        let k = take_continuation(py, &rt.continuation, "TransferThrow")?;
+        let exception = Value::Opaque(PyShared::new(rt.exception.clone_ref(py)));
+        return Ok(Some(DoCtrl::TransferThrow { k, exception }));
+    }
+
+    Ok(None)
+}
 
 /// Extract continuation from PyK. No one-shot enforcement here — that's the VM core's job
 /// (continue_k in dispatch.rs, where self.current_segment is available for diagnostics).
@@ -850,8 +906,14 @@ pub fn python_to_value(_py: Python<'_>, obj: &Bound<'_, PyAny>) -> Value {
     }
     // PyIRStream → Value::Stream
     if let Ok(s) = obj.downcast::<PyIRStream>() {
-        let gen = s.borrow().generator.clone_ref(_py);
-        let stream = PythonGeneratorStream::new(PyShared::new(gen));
+        let (gen, tail_resume_lines) = {
+            let stream = s.borrow();
+            (
+                stream.generator.clone_ref(_py),
+                stream.tail_resume_lines.clone(),
+            )
+        };
+        let stream = PythonGeneratorStream::new(PyShared::new(gen), tail_resume_lines);
         let stream_ref = doeff_vm_core::ir_stream::IRStreamRef::new(Box::new(stream));
         return Value::Stream(stream_ref);
     }

--- a/tests/effects/test_finally_semaphore_over_release.py
+++ b/tests/effects/test_finally_semaphore_over_release.py
@@ -2,7 +2,7 @@
 
 The basic pattern (Finally + Semaphore + Spawn/Gather) works in isolation.
 The bug manifests in proboscis-ema's pipeline which has a richer handler stack:
-  WithIntercept(loguru_interceptor, ...)
+  WithObserve(loguru_observer, ...)
     WithHandler(cache_handler, ...)
       WithHandler(sync_await_handler, ...)
         spawn_intercept_handler
@@ -18,28 +18,18 @@ import asyncio
 import signal
 from typing import Any
 
-import pytest
-
 from doeff import (
     AcquireSemaphore,
+    Await,
     CreateSemaphore,
-    Effect,
     EffectBase,
     Gather,
-    Pass,
     ReleaseSemaphore,
-    Resume,
     Spawn,
     Tell,
-    WithHandler,
-    WithIntercept,
-    async_run,
-    default_async_handlers,
+    WithObserve,
     do,
-    run,)
-from doeff import Await
-# REMOVED: from doeff.effects._program_types import ProgramLike
-from doeff import EffectGenerator
+)
 from tests._run_helpers import run_with_defaults
 
 
@@ -108,7 +98,7 @@ def _worker_with_tell(n: int):
     return result
 
 
-def _wrap_with_semaphore_cleanup(program: ProgramLike, sem):
+def _wrap_with_semaphore_cleanup(program: Any, sem):
     @do
     def _impl():
         yield AcquireSemaphore(sem)
@@ -121,7 +111,7 @@ def _wrap_with_semaphore_cleanup(program: ProgramLike, sem):
     return _impl()
 
 
-def _wrap_with_semaphore_cleanup_and_tell(program: ProgramLike, sem):
+def _wrap_with_semaphore_cleanup_and_tell(program: Any, sem):
     @do
     def _impl():
         yield Tell("acquiring semaphore")
@@ -141,7 +131,7 @@ def _spawn_gather(programs: list):
     def _impl():
         tasks = []
         for p in programs:
-            task = yield Spawn(p, daemon=False)
+            task = yield Spawn(p)
             tasks.append(task)
         return list((yield Gather(*tasks)))
 
@@ -177,29 +167,17 @@ class TestLayer1WithIntercept:
 
 
 class TestLayer2WithTell:
-    @pytest.mark.xfail(
-        reason="move semantics: handler resume concurrency regression",
-        strict=False,
-    )
     def test_tell_workers_sync(self) -> None:
         programs = [_worker_with_tell(i) for i in range(TASK_COUNT)]
         result = _run_sync_with_timeout(_throttled(programs, CONCURRENCY, with_tell=True))
-        assert result.is_ok(), result.display()
+        assert result.is_ok(), result.error
         assert result.value == [i * 10 for i in range(TASK_COUNT)]
 
-    @pytest.mark.xfail(
-        reason="move semantics: handler resume concurrency regression",
-        strict=False,
-    )
-    def test_tell_workers_with_intercept_sync(self) -> None:
-        @do
-        def _interceptor(expr: ProgramLike):
-            return expr
-
+    def test_tell_workers_with_observe_sync(self) -> None:
         programs = [_worker_with_tell(i) for i in range(TASK_COUNT)]
-        program = WithIntercept(_interceptor, _throttled(programs, CONCURRENCY, with_tell=True))
+        program = WithObserve(lambda _effect: None, _throttled(programs, CONCURRENCY, with_tell=True))
         result = _run_sync_with_timeout(program)
-        assert result.is_ok(), result.display()
+        assert result.is_ok(), result.error
         assert result.value == [i * 10 for i in range(TASK_COUNT)]
 
 

--- a/tests/test_do_tail_resume_ast.py
+++ b/tests/test_do_tail_resume_ast.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from doeff import Resume, do
+
+
+def _non_tail_resume_warnings(caught: list[warnings.WarningMessage]) -> list[warnings.WarningMessage]:
+    return [warning for warning in caught if "non-tail Resume/ResumeThrow" in str(warning.message)]
+
+
+def test_tail_resume_shape_does_not_warn() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @do
+        def handler(_effect: object, k: object):
+            return (yield Resume(k, "value"))
+
+    assert callable(handler)
+    assert _non_tail_resume_warnings(caught) == []
+
+
+def test_assignment_return_resume_shape_does_not_warn() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @do
+        def handler(_effect: object, k: object):
+            value = yield Resume(k, "value")
+            return value
+
+    assert callable(handler)
+    assert _non_tail_resume_warnings(caught) == []
+
+
+def test_non_tail_resume_warns_without_marker() -> None:
+    with pytest.warns(RuntimeWarning, match="non-tail Resume/ResumeThrow"):
+
+        @do
+        def handler(_effect: object, k: object):
+            value = yield Resume(k, "value")
+            return (value, "after")
+
+    assert callable(handler)
+
+
+def test_non_tail_resume_marker_suppresses_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @do(non_tail=True)
+        def handler(_effect: object, k: object):
+            value = yield Resume(k, "value")
+            return (value, "after")
+
+    assert callable(handler)
+    assert _non_tail_resume_warnings(caught) == []
+
+
+def test_protected_tail_looking_resume_warns_without_marker() -> None:
+    with pytest.warns(RuntimeWarning, match="non-tail Resume/ResumeThrow"):
+
+        @do
+        def handler(_effect: object, k: object):
+            try:
+                return (yield Resume(k, "value"))
+            finally:
+                pass
+
+    assert callable(handler)

--- a/tests/test_double_resume_traceback.py
+++ b/tests/test_double_resume_traceback.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pytest
+from doeff_core_effects.handlers import state, try_handler, writer
+from doeff_core_effects.scheduler import scheduled
 
 from doeff import (
     EffectBase,
@@ -22,8 +24,6 @@ from doeff import (
     do,
     run,
 )
-from doeff_core_effects.handlers import writer, try_handler, state
-from doeff_core_effects.scheduler import scheduled
 
 
 @dataclass(frozen=True)
@@ -31,7 +31,7 @@ class Ping(EffectBase):
     value: int
 
 
-@do
+@do(non_tail=True)
 def double_resume_handler(effect, k):
     """Handler that incorrectly resumes k twice."""
     if not isinstance(effect, Ping):

--- a/tests/test_try_finally_in_do.py
+++ b/tests/test_try_finally_in_do.py
@@ -3,26 +3,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import doeff
-
 from doeff import (
     AcquireSemaphore,
     CreateSemaphore,
-    Discontinued,
     Effect,
+    EffectBase,
+    EffectGenerator,
     Gather,
     Get,
     Pass,
-    Pure,
     Put,
     ReleaseSemaphore,
     Resume,
     Spawn,
     Transfer,
-    Try,
     WithHandler,
     do,
 )
-from doeff import EffectBase, EffectGenerator
 from tests._run_helpers import run_with_defaults
 
 
@@ -112,6 +109,31 @@ def test_try_finally_with_transfer() -> None:
     def wrapper():
         value = yield WithHandler(_transfer_handler, program())
         cleaned = yield Get("cleaned")
+        return value, cleaned
+
+    result = run_with_defaults(wrapper(), store={})
+    assert result.value == ("handled:x", True)
+
+
+def test_tail_looking_resume_with_handler_finally_keeps_resume_semantics() -> None:
+    @do(non_tail=True)
+    def handler(effect: Effect, k: object) -> EffectGenerator:
+        if isinstance(effect, Ping):
+            try:
+                return (yield Resume(k, f"handled:{effect.label}"))
+            finally:
+                yield Put("handler_cleaned", True)
+        yield Pass(effect, k)
+
+    @do
+    def program():
+        return (yield Ping(label="x"))
+
+    @do
+    def wrapper():
+        yield Put("handler_cleaned", False)
+        value = yield WithHandler(handler, program())
+        cleaned = yield Get("handler_cleaned")
         return value, cleaned
 
     result = run_with_defaults(wrapper(), store={})

--- a/tests/test_vm_memory_leak.py
+++ b/tests/test_vm_memory_leak.py
@@ -20,15 +20,12 @@ import gc
 import resource
 from dataclasses import dataclass
 
-import pytest
-
 import doeff_vm
-
-from doeff import do, run, default_handlers
 from doeff_core_effects.effects import EffectBase
 from doeff_vm import WithHandler
-from tests._run_helpers import run_with_defaults
 
+from doeff import do
+from tests._run_helpers import run_with_defaults
 
 # ---------------------------------------------------------------------------
 # Custom effect: request a chunk of big data
@@ -80,7 +77,7 @@ def _sequential_yield_discard(n: int):
     """Yield BigDataEffect n times, discarding the result each time."""
     for i in range(n):
         _unused = yield BigDataEffect(iteration=i)
-        # Explicitly discard – this value should be GC-eligible immediately.
+        # Explicitly discard - this value should be GC-eligible immediately.
         del _unused
     return n
 
@@ -105,8 +102,7 @@ def _rss_mb() -> float:
     import sys
     if sys.platform == "darwin":
         return usage.ru_maxrss / (1024 * 1024)
-    else:
-        return usage.ru_maxrss / 1024
+    return usage.ru_maxrss / 1024
 
 
 def _run_program(program):
@@ -127,13 +123,6 @@ MAX_ALLOWED_GROWTH_MB = 50
 
 
 class TestVmMemoryLeak:
-    @pytest.mark.xfail(
-        reason=(
-            "TODO(vm-memory): resumed Python handler generators still retain large payloads "
-            "across deep Resume chains; re-enable after branch retention is fixed."
-        ),
-        strict=False,
-    )
     def test_sequential_discard_bounded_memory(self):
         """Yielding large objects in a loop without storing them must not leak.
 
@@ -167,13 +156,6 @@ class TestVmMemoryLeak:
             f"to yielded effect return values."
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "TODO(vm-memory): resumed Python handler generators still retain large payloads "
-            "across deep Resume chains; re-enable after branch retention is fixed."
-        ),
-        strict=False,
-    )
     def test_sequential_keep_last_bounded_memory(self):
         """Same as above but keeping a reference to the last result.
 


### PR DESCRIPTION
## Summary
- remove the remaining VM xfails for semaphore/finally and memory leak regressions
- replace the Rust bytecode peephole with `@do` AST analysis that passes explicit tail-Resume source-line metadata into `IRStream`
- auto-tail-optimize `return (yield Resume/ResumeThrow(...))` and `x = yield Resume/ResumeThrow(...); return x` outside `try`/`with` protected regions
- warn on non-tail `Resume`/`ResumeThrow` unless the handler opts in with `@do(non_tail=True)`
- keep `try/finally` tail-looking Resume as true Resume semantics and mark intentional non-tail tests explicitly

## Root Cause
The memory xfails were caused by handlers written in tail-resume style while still yielding `Resume`: the handler generator frame and its locals stayed live until the resumed continuation returned. Repeated effects with large handler locals therefore retained large payloads.

The fix now lives at the Python boundary: `@do` inspects handler source AST at decoration time and records only syntactically tail-safe Resume/ResumeThrow yield lines. The Rust VM no longer guesses from bytecode. It checks the current generator source line against that metadata and classifies those yields as Transfer/TransferThrow. Protected regions such as `try/finally`, `try/except`, and `with` are excluded, so cleanup semantics stay intact.

## Validation
- `make sync`
- `uv run --active pytest` -> 792 passed, 84 skipped
- `uv run --active pytest tests/test_do_tail_resume_ast.py tests/test_try_finally_in_do.py tests/test_vm_memory_leak.py::TestVmMemoryLeak tests/test_double_resume_traceback.py tests/effects/test_finally_semaphore_over_release.py::TestLayer2WithTell -q` -> 16 passed
- `uv run --active ruff check doeff/do.py tests/test_do_tail_resume_ast.py tests/test_try_finally_in_do.py tests/test_double_resume_traceback.py tests/test_vm_memory_leak.py tests/effects/test_finally_semaphore_over_release.py packages/doeff-vm/doeff_vm/__init__.pyi`
- `uv run --active pyright doeff/do.py packages/doeff-vm/doeff_vm/__init__.pyi`
- `cargo check` in `packages/doeff-vm`
- `PYO3_PYTHON=/Users/s22625/repos/doeff/.venv/bin/python3 cargo test` in `packages/doeff-vm`
- `PYO3_PYTHON=/Users/s22625/repos/doeff/.venv/bin/python3 cargo test --features python_bridge --lib` in `packages/doeff-vm-core`

## Notes
- Repo-wide `uv run --active pyright` still fails on existing project-wide typing debt outside this PR; the touched `do.py` and VM stub pass targeted pyright.
- Repo-wide `make lint-ruff` remains blocked by pre-existing lint debt; touched Python/stub files pass targeted ruff.
