### PR TITLE
Fix memo fallthrough without terminal

### DIFF
--- a/packages/doeff-core-effects/doeff_core_effects/cache.py
+++ b/packages/doeff-core-effects/doeff_core_effects/cache.py
@@ -20,7 +20,7 @@ from frozendict import frozendict
 
 from doeff import GetOuterHandlers, do
 from doeff_core_effects.memo_effects import MemoExists, MemoGet, MemoPut
-from doeff_core_effects.memo_handlers import _has_memo_handler
+from doeff_core_effects.memo_handlers import has_memo_handler
 from doeff_core_effects.memo_policy import Lifecycle, MemoPolicy, ensure_memo_policy
 
 T = TypeVar("T")
@@ -116,7 +116,8 @@ def cache(
                 else (func_name, args, frozen_kwargs)
             )
 
-            if not _has_memo_handler((yield GetOuterHandlers())):
+            # Transparent passthrough: with no memo storage installed, skip cache I/O; MemoExists would otherwise raise UnhandledEffect.
+            if not has_memo_handler((yield GetOuterHandlers())):
                 return (yield func(*args, **kwargs))
 
             # Check memo

--- a/packages/doeff-core-effects/doeff_core_effects/cache.py
+++ b/packages/doeff-core-effects/doeff_core_effects/cache.py
@@ -10,20 +10,21 @@ is not yet ported. This module provides the core cache helpers and a simplified
 """
 
 import os
-import sys
 import tempfile
 from collections.abc import Callable, Mapping
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, TypeVar
 
-from frozendict import frozendict as FrozenDict
+from frozendict import frozendict
 
-from doeff import do
+from doeff import GetOuterHandlers, do
+from doeff_core_effects.memo_effects import MemoExists, MemoGet, MemoPut
+from doeff_core_effects.memo_handlers import _has_memo_handler
 from doeff_core_effects.memo_policy import Lifecycle, MemoPolicy, ensure_memo_policy
-from doeff_core_effects.memo_effects import MemoExists, MemoGet, MemoPut, MemoGetEffect
-from doeff_core_effects.memo_handlers import content_address
 
 T = TypeVar("T")
+FrozenDict = frozendict
 
 CACHE_PATH_ENV_KEY = "DOEFF_CACHE_PATH"
 
@@ -71,7 +72,7 @@ def _function_identifier(target: Any) -> str:
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
-def default_cache_key(func_name: str, args: tuple, kwargs: FrozenDict) -> tuple:
+def default_cache_key(func_name: str, args: tuple, kwargs: frozendict) -> tuple:
     """Default cache key: (func_name, args, FrozenDict(kwargs))."""
     return (func_name, args, kwargs)
 
@@ -108,12 +109,15 @@ def cache(
 
         @do
         def cached_fn(*args, **kwargs):
-            frozen_kwargs = FrozenDict(kwargs) if kwargs else FrozenDict()
+            frozen_kwargs = frozendict(kwargs) if kwargs else frozendict()
             cache_key_obj = (
                 key_func(func_name, args, frozen_kwargs)
                 if key_func
                 else (func_name, args, frozen_kwargs)
             )
+
+            if not _has_memo_handler((yield GetOuterHandlers())):
+                return (yield func(*args, **kwargs))
 
             # Check memo
             if (yield MemoExists(cache_key_obj)):
@@ -134,10 +138,8 @@ def cache(
         for attr in ("__name__", "__qualname__", "__doc__", "__module__"):
             val = getattr(func, attr, None)
             if val is not None:
-                try:
+                with suppress(AttributeError, TypeError):
                     setattr(cached_fn, attr, val)
-                except (AttributeError, TypeError):
-                    pass
 
         return cached_fn
 

--- a/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
+++ b/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
@@ -15,18 +15,16 @@ from pathlib import Path
 from typing import Any, TypeAlias
 
 from doeff import do
-from doeff.program import Resume, Pass
-
+from doeff.program import GetOuterHandlers, Pass, Resume
 from doeff_core_effects.memo_effects import (
-    MemoExistsEffect,
-    MemoGetEffect,
-    MemoPutEffect,
-    MemoGet,
-    MemoPut,
     MemoExists,
+    MemoExistsEffect,
+    MemoGet,
+    MemoGetEffect,
+    MemoPut,
+    MemoPutEffect,
 )
 from doeff_core_effects.memo_policy import RecomputeCost
-from doeff_core_effects.effects import Try
 from doeff_core_effects.storage import DurableStorage, InMemoryStorage, SQLiteStorage
 
 MemoKeyFn: TypeAlias = Callable[[object], str]
@@ -62,7 +60,7 @@ def _dumps(value: object) -> bytes:
     return serializer.dumps(value)
 
 
-def _normalize_for_hash(value: object) -> object:
+def _normalize_for_hash(value: object) -> object:  # noqa: PLR0911
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return {
             "__type__": f"{type(value).__module__}.{type(value).__qualname__}",
@@ -71,27 +69,27 @@ def _normalize_for_hash(value: object) -> object:
                 for field in dataclasses.fields(value)
             },
         }
-    elif isinstance(value, Mapping):
+    if isinstance(value, Mapping):
         return {
             str(key): _normalize_for_hash(item)
             for key, item in sorted(value.items(), key=lambda item: str(item[0]))
         }
-    elif isinstance(value, tuple):
+    if isinstance(value, tuple):
         return {"__tuple__": [_normalize_for_hash(item) for item in value]}
-    elif isinstance(value, list):
+    if isinstance(value, list):
         return [_normalize_for_hash(item) for item in value]
-    elif isinstance(value, Set) and not isinstance(value, (str, bytes, bytearray)):
+    if isinstance(value, Set) and not isinstance(value, (str, bytes, bytearray)):
         normalized = [_normalize_for_hash(item) for item in value]
         return {
             "__set__": sorted(normalized, key=lambda item: json.dumps(item, sort_keys=True))
         }
-    elif isinstance(value, Path):
+    if isinstance(value, Path):
         return {"__path__": str(value)}
-    elif isinstance(value, bytes):
+    if isinstance(value, bytes):
         return {"__bytes__": value.hex()}
-    elif isinstance(value, type):
+    if isinstance(value, type):
         return f"{value.__module__}.{value.__qualname__}"
-    elif hasattr(value, "__dict__") and not isinstance(value, type):
+    if hasattr(value, "__dict__") and not isinstance(value, type):
         return {
             "__type__": f"{type(value).__module__}.{type(value).__qualname__}",
             **{
@@ -135,6 +133,22 @@ def _effect_cost(effect) -> RecomputeCost:
     return effect.recompute_cost
 
 
+def _is_memo_handler(handler: object) -> bool:
+    return hasattr(handler, "_doeff_memo_handler") and handler._doeff_memo_handler is True
+
+
+def _is_memo_terminal(handler: object) -> bool:
+    return hasattr(handler, "_doeff_memo_terminal") and handler._doeff_memo_terminal is True
+
+
+def _has_memo_handler(handlers: list[object]) -> bool:
+    return any(_is_memo_handler(handler) for handler in handlers)
+
+
+def _has_memo_fallthrough_handler(handlers: list[object]) -> bool:
+    return any(_is_memo_handler(handler) or _is_memo_terminal(handler) for handler in handlers)
+
+
 def memo_handler(
     storage: DurableStorage,
     *,
@@ -169,6 +183,48 @@ def memo_handler(
     from doeff_core_effects.effects import WriterTellEffect as Slog
 
     @do
+    def _resume_exists(effect, k, key):
+        exists = yield storage.exists(key)
+        if exists:
+            return (yield Resume(k, True))
+
+        outer_handlers = yield GetOuterHandlers()
+        if not _has_memo_fallthrough_handler(outer_handlers):
+            return (yield Resume(k, False))
+
+        return (yield Resume(k, (yield effect)))
+
+    @do
+    def _resume_get(effect, k, key):
+        exists = yield storage.exists(key)
+        if exists:
+            value = yield storage.get(key)
+            yield Slog(f"[memo-layer:{label}] HIT key={key[:16]}...")
+            return (yield Resume(k, value))
+
+        outer_handlers = yield GetOuterHandlers()
+        if not _has_memo_fallthrough_handler(outer_handlers):
+            raise KeyError(effect.key)
+
+        yield Slog(f"[memo-layer:{label}] MISS key={key[:16]}... → re-performing")
+        outer_value = yield effect
+        yield storage.put(key, outer_value)
+        yield Slog(f"[memo-layer:{label}] WRITE-THROUGH key={key[:16]}...")
+        return (yield Resume(k, outer_value))
+
+    @do
+    def _resume_put(effect, k, key):
+        yield storage.put(key, effect.value)
+        yield Slog(f"[memo-layer:{label}] PUT key={key[:16]}...")
+
+        outer_handlers = yield GetOuterHandlers()
+        if not _has_memo_fallthrough_handler(outer_handlers):
+            return (yield Resume(k, None))
+
+        yield effect
+        return (yield Resume(k, None))
+
+    @do
     def handler(effect, k):
         if not isinstance(effect, (MemoGetEffect, MemoExistsEffect, MemoPutEffect)):
             yield Pass(effect, k)
@@ -181,44 +237,27 @@ def memo_handler(
         key = _storage_key(effect.key)
 
         if isinstance(effect, MemoExistsEffect):
-            exists = yield storage.exists(key)
-            if exists:
-                result = yield Resume(k, True)
-                return result
-            # Not in this layer — re-perform to check outer layers
-            result = yield Resume(k, (yield effect))
-            return result
+            return (yield _resume_exists(effect, k, key))
 
         if isinstance(effect, MemoGetEffect):
-            exists = yield storage.exists(key)
-            if exists:
-                value = yield storage.get(key)
-                yield Slog(f"[memo-layer:{label}] HIT key={key[:16]}...")
-                result = yield Resume(k, value)
-                return result
-            # Miss — re-perform (outer handler resolves) → cache result
-            yield Slog(f"[memo-layer:{label}] MISS key={key[:16]}... → re-performing")
-            outer_value = yield effect
-            yield storage.put(key, outer_value)
-            yield Slog(f"[memo-layer:{label}] WRITE-THROUGH key={key[:16]}...")
-            result = yield Resume(k, outer_value)
-            return result
+            return (yield _resume_get(effect, k, key))
 
-        # MemoPutEffect — write to this layer AND propagate to outer layers
-        yield storage.put(key, effect.value)
-        yield Slog(f"[memo-layer:{label}] PUT key={key[:16]}...")
-        yield effect  # re-perform → outer handlers also store
-        result = yield Resume(k, None)
-        return result
+        return (yield _resume_put(effect, k, key))
 
+    handler._doeff_memo_handler = True
     return handler
 
 
 @do
 def memo_terminal(effect, k):
-    """Terminal handler for memo effects — sits outside all memo_handler layers.
+    """Deprecated terminal handler for memo effects.
 
-    Catches re-performed memo effects that fall through every caching layer:
+    Deprecated: memo callers now treat missing memo storage as a miss, so
+    ``memo_terminal`` is optional and retained only for backward compatibility.
+
+    This handler sits outside all ``memo_handler`` layers and catches
+    re-performed memo effects that fall through every caching layer:
+
       MemoExists → False (not in any layer)
       MemoGet    → KeyError (propagates to memo_rewriter's except KeyError)
       MemoPut    → None (all layers already stored before re-performing)
@@ -232,6 +271,9 @@ def memo_terminal(effect, k):
         result = yield Resume(k, None)
         return result
     yield Pass(effect, k)
+
+
+memo_terminal._doeff_memo_terminal = True
 
 
 def in_memory_memo_handler():
@@ -278,14 +320,16 @@ def make_memo_rewriter(
         key = key_fn(effect)
         yield Slog(f"[memo] checking {effect_type.__name__} key={key[:16]}...")
 
-        _MISS = object()
-        if (yield MemoExists(key, recompute_cost=recompute_cost)):
+        outer_handlers = yield GetOuterHandlers()
+        memo_storage_available = _has_memo_handler(outer_handlers)
+        _miss = object()
+        if memo_storage_available and (yield MemoExists(key, recompute_cost=recompute_cost)):
             try:
                 cached = yield MemoGet(key, recompute_cost=recompute_cost)
             except KeyError:
-                cached = _MISS
+                cached = _miss
 
-            if cached is not _MISS:
+            if cached is not _miss:
                 yield Slog(f"[memo] HIT {effect_type.__name__} key={key[:16]}...")
                 result = yield Resume(k, cached)
                 return result
@@ -293,8 +337,14 @@ def make_memo_rewriter(
         yield Slog(f"[memo] MISS {effect_type.__name__} key={key[:16]}... -> delegating")
         delegated = yield effect
 
-        yield MemoPut(key, delegated, policy=MemoPolicy(recompute_cost=recompute_cost), source_effect=effect)
-        yield Slog(f"[memo] STORED {effect_type.__name__} key={key[:16]}...")
+        if memo_storage_available:
+            yield MemoPut(
+                key,
+                delegated,
+                policy=MemoPolicy(recompute_cost=recompute_cost),
+                source_effect=effect,
+            )
+            yield Slog(f"[memo] STORED {effect_type.__name__} key={key[:16]}...")
 
         result = yield Resume(k, delegated)
         return result

--- a/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
+++ b/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
@@ -134,14 +134,14 @@ def _effect_cost(effect) -> RecomputeCost:
 
 
 def _is_memo_handler(handler: object) -> bool:
-    return hasattr(handler, "_doeff_memo_handler") and handler._doeff_memo_handler is True
+    return getattr(handler, "_doeff_memo_handler", False) is True
 
 
 def _is_memo_terminal(handler: object) -> bool:
-    return hasattr(handler, "_doeff_memo_terminal") and handler._doeff_memo_terminal is True
+    return getattr(handler, "_doeff_memo_terminal", False) is True
 
 
-def _has_memo_handler(handlers: list[object]) -> bool:
+def has_memo_handler(handlers: list[object]) -> bool:
     return any(_is_memo_handler(handler) for handler in handlers)
 
 
@@ -167,8 +167,10 @@ def memo_handler(
             WithHandler(memo_handler(memory, name="L1"),
               program)))
 
-    Each handler is a caching proxy. Position determines terminal behavior:
-    the outermost handler's miss re-perform is unhandled → memo_rewriter treats as miss.
+    Each handler is a caching proxy. When a miss reaches the outermost memo
+    layer and there is no outer memo layer or ``memo_terminal``, that layer
+    returns the terminal behavior locally (False / KeyError / None) instead
+    of re-performing into an unhandled memo effect.
 
     Args:
         storage: The storage backend for this handler.
@@ -321,7 +323,7 @@ def make_memo_rewriter(
         yield Slog(f"[memo] checking {effect_type.__name__} key={key[:16]}...")
 
         outer_handlers = yield GetOuterHandlers()
-        memo_storage_available = _has_memo_handler(outer_handlers)
+        memo_storage_available = has_memo_handler(outer_handlers)
         _miss = object()
         if memo_storage_available and (yield MemoExists(key, recompute_cost=recompute_cost)):
             try:
@@ -365,3 +367,17 @@ def memo_rewriters(
         recompute_cost: Cost tier for all provided types.
     """
     return [make_memo_rewriter(et, key_fn=key_fn, recompute_cost=recompute_cost) for et in effect_types]
+
+
+__all__ = [
+    "content_address",
+    "has_memo_handler",
+    "in_memory_memo_handler",
+    "json_gzip_deserialize",
+    "json_gzip_serialize",
+    "make_memo_rewriter",
+    "memo_handler",
+    "memo_rewriters",
+    "memo_terminal",
+    "sqlite_memo_handler",
+]

--- a/tests/effects/test_memo_no_handlers.py
+++ b/tests/effects/test_memo_no_handlers.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from doeff_core_effects.cache import cache
+
+from doeff import do, run
+
+
+def test_cache_without_memo_handlers_computes_without_caching():
+    calls = {"count": 0}
+
+    @cache()
+    @do
+    def cached_double(value: int):
+        calls["count"] += 1
+        return value * 2
+
+    @do
+    def program():
+        first = yield cached_double(21)
+        second = yield cached_double(21)
+        return (first, second)
+
+    result = run(program())
+
+    assert result == (42, 42)
+    assert calls["count"] == 2

--- a/tests/effects/test_memo_no_terminal.py
+++ b/tests/effects/test_memo_no_terminal.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from doeff_core_effects.cache import cache
+from doeff_core_effects.handlers import await_handler, slog_handler
+from doeff_core_effects.memo_handlers import memo_handler
+from doeff_core_effects.scheduler import scheduled
+from doeff_core_effects.storage import InMemoryStorage
+
+from doeff import WithHandler, do, run
+
+
+def _run_with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return run(scheduled(wrapped))
+
+
+def test_cache_without_memo_terminal_falls_through_to_compute():
+    calls = {"count": 0}
+    storage = InMemoryStorage()
+
+    @cache()
+    @do
+    def cached_double(value: int):
+        calls["count"] += 1
+        return value * 2
+
+    @do
+    def program():
+        first = yield cached_double(21)
+        second = yield cached_double(21)
+        return (first, second)
+
+    result = _run_with_handlers(
+        program(),
+        await_handler(),
+        slog_handler(),
+        memo_handler(storage, name="memory"),
+    )
+
+    assert result == (42, 42)
+    assert calls["count"] == 1
+    assert len(storage) == 1

--- a/tests/effects/test_memo_rewriter_no_terminal.py
+++ b/tests/effects/test_memo_rewriter_no_terminal.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from doeff_core_effects.handlers import await_handler, slog_handler
+from doeff_core_effects.memo_handlers import make_memo_rewriter, memo_handler
+from doeff_core_effects.scheduler import scheduled
+from doeff_core_effects.storage import InMemoryStorage
+
+from doeff import EffectBase, Pass, Resume, WithHandler, do, run
+
+
+class FetchValue(EffectBase):
+    def __init__(self, key: str) -> None:
+        super().__init__()
+        self.key = key
+
+
+@do
+def fetch_value_handler(effect, k):
+    if not isinstance(effect, FetchValue):
+        yield Pass(effect, k)
+        return
+    value = f"value:{effect.key}"
+    return (yield Resume(k, value))
+
+
+def _run_with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return run(scheduled(wrapped))
+
+
+def test_memo_rewriter_without_terminal_uses_original_handler():
+    storage = InMemoryStorage()
+
+    @do
+    def program():
+        first = yield FetchValue("alpha")
+        second = yield FetchValue("alpha")
+        return (first, second)
+
+    result = _run_with_handlers(
+        program(),
+        await_handler(),
+        slog_handler(),
+        memo_handler(storage, name="memory"),
+        fetch_value_handler,
+        make_memo_rewriter(FetchValue, key_fn=lambda effect: effect.key),
+    )
+
+    assert result == ("value:alpha", "value:alpha")
+    assert len(storage) == 1

--- a/tests/effects/test_memo_rewriter_no_terminal.py
+++ b/tests/effects/test_memo_rewriter_no_terminal.py
@@ -14,13 +14,19 @@ class FetchValue(EffectBase):
         self.key = key
 
 
-@do
-def fetch_value_handler(effect, k):
-    if not isinstance(effect, FetchValue):
-        yield Pass(effect, k)
-        return
-    value = f"value:{effect.key}"
-    return (yield Resume(k, value))
+def _make_fetch_value_handler():
+    calls = {"count": 0}
+
+    @do
+    def fetch_value_handler(effect, k):
+        if not isinstance(effect, FetchValue):
+            yield Pass(effect, k)
+            return
+        calls["count"] += 1
+        value = f"value:{effect.key}"
+        return (yield Resume(k, value))
+
+    return fetch_value_handler, calls
 
 
 def _run_with_handlers(program, *handlers):
@@ -32,6 +38,7 @@ def _run_with_handlers(program, *handlers):
 
 def test_memo_rewriter_without_terminal_uses_original_handler():
     storage = InMemoryStorage()
+    fetch_value_handler, calls = _make_fetch_value_handler()
 
     @do
     def program():
@@ -49,4 +56,5 @@ def test_memo_rewriter_without_terminal_uses_original_handler():
     )
 
     assert result == ("value:alpha", "value:alpha")
+    assert calls["count"] == 1
     assert len(storage) == 1

--- a/tests/effects/test_memo_with_terminal_unchanged.py
+++ b/tests/effects/test_memo_with_terminal_unchanged.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import inspect
+
+from doeff_core_effects.cache import cache
+from doeff_core_effects.handlers import await_handler, slog_handler
+from doeff_core_effects.memo_handlers import memo_handler, memo_terminal
+from doeff_core_effects.scheduler import scheduled
+from doeff_core_effects.storage import InMemoryStorage
+
+from doeff import WithHandler, do, run
+
+
+def _run_with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return run(scheduled(wrapped))
+
+
+def test_cache_with_terminal_still_hits_l1_and_writes_through():
+    calls = {"count": 0}
+    l1 = InMemoryStorage()
+    l2 = InMemoryStorage()
+
+    @cache()
+    @do
+    def cached_double(value: int):
+        calls["count"] += 1
+        return value * 2
+
+    @do
+    def program():
+        first = yield cached_double(21)
+        second = yield cached_double(21)
+        return (first, second)
+
+    result = _run_with_handlers(
+        program(),
+        await_handler(),
+        slog_handler(),
+        memo_terminal,
+        memo_handler(l2, name="L2"),
+        memo_handler(l1, name="L1"),
+    )
+
+    assert result == (42, 42)
+    assert calls["count"] == 1
+    assert len(l1) == 1
+    assert len(l2) == 1
+    assert list(l1.items()) == list(l2.items())
+
+
+def test_memo_terminal_docstring_marks_it_deprecated():
+    doc = inspect.getdoc(memo_terminal)
+    assert doc is not None
+    assert "deprecated" in doc.lower()


### PR DESCRIPTION
## Summary
- make `@cache` and `make_memo_rewriter()` skip memo I/O entirely when no memo storage handler is installed
- make `memo_handler()` self-terminate on miss/write-back when no outer memo layer or `memo_terminal` exists
- add regression tests for no-terminal, no-handler, unchanged terminal behavior, and rewriter parity
- mark `memo_terminal` deprecated in its docstring while keeping backward-compatible behavior

## Acceptance Criteria Evidence
1. Regression test without `memo_terminal`
   - Command: `PYTHONPATH=packages/doeff-core-effects:packages/doeff-time:packages/doeff-traverse uv run pytest tests/effects/test_memo_no_terminal.py tests/effects/test_memo_no_handlers.py tests/effects/test_memo_with_terminal_unchanged.py tests/effects/test_memo_rewriter_no_terminal.py tests/test_with_observe_visibility.py tests/test_memo_rewriter_spawn_continuation.py`
   - Result: `9 passed`
   - Coverage: `tests/effects/test_memo_no_terminal.py`
2. Transparent fallthrough with no memo handlers at all
   - Verified by `tests/effects/test_memo_no_handlers.py`
   - Result in same pytest run above: pass
3. Existing stack with `memo_terminal` unchanged
   - Verified by `tests/effects/test_memo_with_terminal_unchanged.py`
   - Asserts cached hit path and L1/L2 write-through still work
4. `make_memo_rewriter` parity
   - Verified by `tests/effects/test_memo_rewriter_no_terminal.py`
   - Confirms original effect handler still produces the value when terminal is absent
5. `memo_terminal` marked deprecated
   - Verified by `tests/effects/test_memo_with_terminal_unchanged.py::test_memo_terminal_docstring_marks_it_deprecated`

## Validation
- `uv run ruff check packages/doeff-core-effects/doeff_core_effects/cache.py packages/doeff-core-effects/doeff_core_effects/memo_handlers.py tests/effects/test_memo_no_terminal.py tests/effects/test_memo_no_handlers.py tests/effects/test_memo_with_terminal_unchanged.py tests/effects/test_memo_rewriter_no_terminal.py`
- `PYTHONPATH=packages/doeff-core-effects:packages/doeff-time:packages/doeff-traverse uv run pytest tests/effects/test_memo_no_terminal.py tests/effects/test_memo_no_handlers.py tests/effects/test_memo_with_terminal_unchanged.py tests/effects/test_memo_rewriter_no_terminal.py tests/test_with_observe_visibility.py tests/test_memo_rewriter_spawn_continuation.py`

Refs: memo-unhandled-fallthrough
