### PR TITLE
[codex] Handle memo fallthrough on unhandled effects

### DIFF
--- a/packages/doeff-core-effects/doeff_core_effects/cache.py
+++ b/packages/doeff-core-effects/doeff_core_effects/cache.py
@@ -113,7 +113,9 @@ def cache(
                 else (func_name, args, frozen_kwargs)
             )
 
-            # Fall through when memo storage is absent or reports a miss.
+            # Memo handler is optional. If absent (UnhandledEffect on MemoExists/Get)
+            # or storage misses (KeyError), fall through to compute. The
+            # yield func(...) below is NOT wrapped: its failures must propagate.
             try:
                 if (yield MemoExists(cache_key_obj)):
                     try:
@@ -127,7 +129,8 @@ def cache(
             # Memo miss — run the function
             result = yield func(*args, **kwargs)
 
-            # Store in memo when available, but keep the compute result authoritative.
+            # Best-effort store: if no memo handler is installed, swallow. The
+            # compute result returned above is authoritative.
             try:
                 yield MemoPut(cache_key_obj, result, policy=memo_policy)
             except UnhandledEffect:

--- a/packages/doeff-core-effects/doeff_core_effects/cache.py
+++ b/packages/doeff-core-effects/doeff_core_effects/cache.py
@@ -10,7 +10,6 @@ is not yet ported. This module provides the core cache helpers and a simplified
 """
 
 import os
-import sys
 import tempfile
 from collections.abc import Callable, Mapping
 from pathlib import Path
@@ -18,10 +17,9 @@ from typing import Any, TypeVar
 
 from frozendict import frozendict as FrozenDict
 
-from doeff import do
+from doeff import UnhandledEffect, do
+from doeff_core_effects.memo_effects import MemoExists, MemoGet, MemoPut
 from doeff_core_effects.memo_policy import Lifecycle, MemoPolicy, ensure_memo_policy
-from doeff_core_effects.memo_effects import MemoExists, MemoGet, MemoPut, MemoGetEffect
-from doeff_core_effects.memo_handlers import content_address
 
 T = TypeVar("T")
 
@@ -115,19 +113,25 @@ def cache(
                 else (func_name, args, frozen_kwargs)
             )
 
-            # Check memo
-            if (yield MemoExists(cache_key_obj)):
-                try:
-                    cached_value = yield MemoGet(cache_key_obj)
-                    return cached_value
-                except KeyError:
-                    pass  # memo miss — compute below
+            # Fall through when memo storage is absent or reports a miss.
+            try:
+                if (yield MemoExists(cache_key_obj)):
+                    try:
+                        cached_value = yield MemoGet(cache_key_obj)
+                        return cached_value
+                    except KeyError:
+                        pass
+            except UnhandledEffect:
+                pass
 
             # Memo miss — run the function
             result = yield func(*args, **kwargs)
 
-            # Store in memo
-            yield MemoPut(cache_key_obj, result, policy=memo_policy)
+            # Store in memo when available, but keep the compute result authoritative.
+            try:
+                yield MemoPut(cache_key_obj, result, policy=memo_policy)
+            except UnhandledEffect:
+                pass
             return result
 
         # Preserve metadata

--- a/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
+++ b/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
@@ -14,19 +14,17 @@ from collections.abc import Callable, Mapping, Set
 from pathlib import Path
 from typing import Any, TypeAlias
 
-from doeff import do
-from doeff.program import Resume, Pass
-
+from doeff import UnhandledEffect, do
+from doeff.program import Pass, Resume, TransferThrow
 from doeff_core_effects.memo_effects import (
-    MemoExistsEffect,
-    MemoGetEffect,
-    MemoPutEffect,
-    MemoGet,
-    MemoPut,
     MemoExists,
+    MemoExistsEffect,
+    MemoGet,
+    MemoGetEffect,
+    MemoPut,
+    MemoPutEffect,
 )
 from doeff_core_effects.memo_policy import RecomputeCost
-from doeff_core_effects.effects import Try
 from doeff_core_effects.storage import DurableStorage, InMemoryStorage, SQLiteStorage
 
 MemoKeyFn: TypeAlias = Callable[[object], str]
@@ -186,7 +184,11 @@ def memo_handler(
                 result = yield Resume(k, True)
                 return result
             # Not in this layer — re-perform to check outer layers
-            result = yield Resume(k, (yield effect))
+            try:
+                outer_exists = yield effect
+            except UnhandledEffect as exc:
+                return (yield TransferThrow(k, exc))
+            result = yield Resume(k, outer_exists)
             return result
 
         if isinstance(effect, MemoGetEffect):
@@ -198,7 +200,10 @@ def memo_handler(
                 return result
             # Miss — re-perform (outer handler resolves) → cache result
             yield Slog(f"[memo-layer:{label}] MISS key={key[:16]}... → re-performing")
-            outer_value = yield effect
+            try:
+                outer_value = yield effect
+            except UnhandledEffect as exc:
+                return (yield TransferThrow(k, exc))
             yield storage.put(key, outer_value)
             yield Slog(f"[memo-layer:{label}] WRITE-THROUGH key={key[:16]}...")
             result = yield Resume(k, outer_value)
@@ -207,7 +212,10 @@ def memo_handler(
         # MemoPutEffect — write to this layer AND propagate to outer layers
         yield storage.put(key, effect.value)
         yield Slog(f"[memo-layer:{label}] PUT key={key[:16]}...")
-        yield effect  # re-perform → outer handlers also store
+        try:
+            yield effect  # re-perform → outer handlers also store
+        except UnhandledEffect as exc:
+            return (yield TransferThrow(k, exc))
         result = yield Resume(k, None)
         return result
 
@@ -216,7 +224,11 @@ def memo_handler(
 
 @do
 def memo_terminal(effect, k):
-    """Terminal handler for memo effects — sits outside all memo_handler layers.
+    """Deprecated optional terminal handler for memo effects.
+
+    Historically this sat outside all memo_handler layers to turn fallthrough
+    into storage misses. Compute-layer memo callers now catch UnhandledEffect
+    directly, so memo_terminal is no longer required for correctness.
 
     Catches re-performed memo effects that fall through every caching layer:
       MemoExists → False (not in any layer)
@@ -279,22 +291,35 @@ def make_memo_rewriter(
         yield Slog(f"[memo] checking {effect_type.__name__} key={key[:16]}...")
 
         _MISS = object()
-        if (yield MemoExists(key, recompute_cost=recompute_cost)):
-            try:
-                cached = yield MemoGet(key, recompute_cost=recompute_cost)
-            except KeyError:
-                cached = _MISS
+        cached = _MISS
+        try:
+            if (yield MemoExists(key, recompute_cost=recompute_cost)):
+                try:
+                    cached = yield MemoGet(key, recompute_cost=recompute_cost)
+                except KeyError:
+                    cached = _MISS
+        except UnhandledEffect:
+            cached = _MISS
 
-            if cached is not _MISS:
-                yield Slog(f"[memo] HIT {effect_type.__name__} key={key[:16]}...")
-                result = yield Resume(k, cached)
-                return result
+        if cached is not _MISS:
+            yield Slog(f"[memo] HIT {effect_type.__name__} key={key[:16]}...")
+            result = yield Resume(k, cached)
+            return result
 
         yield Slog(f"[memo] MISS {effect_type.__name__} key={key[:16]}... -> delegating")
         delegated = yield effect
 
-        yield MemoPut(key, delegated, policy=MemoPolicy(recompute_cost=recompute_cost), source_effect=effect)
-        yield Slog(f"[memo] STORED {effect_type.__name__} key={key[:16]}...")
+        try:
+            yield MemoPut(
+                key,
+                delegated,
+                policy=MemoPolicy(recompute_cost=recompute_cost),
+                source_effect=effect,
+            )
+        except UnhandledEffect:
+            pass
+        else:
+            yield Slog(f"[memo] STORED {effect_type.__name__} key={key[:16]}...")
 
         result = yield Resume(k, delegated)
         return result

--- a/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
+++ b/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
@@ -292,6 +292,10 @@ def make_memo_rewriter(
 
         _MISS = object()
         cached = _MISS
+        # Memo storage absent or reports miss -> fall through to compute. The
+        # yield effect compute path below is intentionally NOT wrapped: an
+        # UnhandledEffect there is a real bug (no handler can produce the
+        # value) and must propagate fail-fast.
         try:
             if (yield MemoExists(key, recompute_cost=recompute_cost)):
                 try:

--- a/packages/doeff-vm-core/src/continuation.rs
+++ b/packages/doeff-vm-core/src/continuation.rs
@@ -230,7 +230,7 @@ impl DetachedFiberChain {
 /// A captured fiber chain. NOT Clone — one owner, one-shot.
 ///
 /// Created by `perform` (detach chain from handler).
-/// Consumed by `continue_k` (reattach chain to caller).
+/// Consumed by `reattach_chain` / `continue_k` (reattach chain to caller).
 /// Extended by `reperform` (append current fiber to chain).
 #[derive(Debug)]
 pub struct Continuation {
@@ -249,8 +249,8 @@ impl Continuation {
 
     /// Sentinel for an already-consumed continuation (head=None).
     /// Used by the Python bridge when PyK has already been taken.
-    /// The VM core's continue_k will detect this and raise the one-shot error
-    /// with full VM context (current_segment, traceback).
+    /// The VM core's reattach_chain will detect this and raise the one-shot
+    /// error with full VM context (current_segment, traceback).
     pub fn empty() -> Self {
         // Register so Drop's unregister is balanced.
         memory_stats::register_continuation();

--- a/packages/doeff-vm-core/src/vm/dispatch.rs
+++ b/packages/doeff-vm-core/src/vm/dispatch.rs
@@ -2,7 +2,7 @@
 //!
 //! 1. match_with  — install handler (create boundary fiber, attach to chain)
 //! 2. perform     — yield effect (detach chain at handler, create continuation)
-//! 3. continue_k  — resume continuation (reattach chain, deliver value)
+//! 3. continue_k  — resume continuation (reattach chain, then caller delivers value)
 //! 4. reperform   — pass effect to outer handler (append fiber to continuation)
 //! 5. fiber_return — fiber completes (call handler's handle_value)
 //!
@@ -112,22 +112,24 @@ impl VM {
     // 3. continue_k — resume a continuation
     // -----------------------------------------------------------------------
 
-    /// Resume a continuation: reattach the chain by linking its tail to the
-    /// current fiber, then switch execution to the chain's head.
+    /// Reattach a detached fiber chain by linking its tail to the current
+    /// fiber, then switch execution to the chain's head.
     ///
-    /// OCaml 5 equivalent:
-    ///   (head, last) = atomic_swap(cont, NULL)  // one-shot
-    ///   last.handler.parent = current_stack      // reattach
-    ///   current_stack = head                     // switch
-    ///   deliver v to head
-    pub fn continue_k(&mut self, k: &mut Continuation) -> Result<(), crate::error::VMError> {
+    /// The caller is responsible for what signal (send / raise) is delivered
+    /// after reattach. Use this directly when an error path needs the body's
+    /// stream to be reachable, e.g. so `should_raise_into_stream` can deliver
+    /// `UnhandledEffect` to the user's try/except.
+    pub(crate) fn reattach_chain(
+        &mut self,
+        k: &mut Continuation,
+    ) -> Result<(), crate::error::VMError> {
         let chain = k.take().ok_or_else(|| {
             let current = self
                 .current_segment
                 .map(|f| format!(" (current fiber={})", f.index()))
                 .unwrap_or_default();
             crate::error::VMError::internal(format!(
-                "Resume: continuation already consumed (one-shot violation){current}"
+                "Continuation: continuation already consumed (one-shot violation){current}"
             ))
         })?;
 
@@ -136,6 +138,18 @@ impl VM {
         self.current_segment = Some(head);
 
         Ok(())
+    }
+
+    /// Resume a continuation: reattach the chain, then the step machine
+    /// delivers the resume value to the restored head.
+    ///
+    /// OCaml 5 equivalent:
+    ///   (head, last) = atomic_swap(cont, NULL)  // one-shot
+    ///   last.handler.parent = current_stack      // reattach
+    ///   current_stack = head                     // switch
+    ///   deliver v to head
+    pub fn continue_k(&mut self, k: &mut Continuation) -> Result<(), crate::error::VMError> {
+        self.reattach_chain(k)
     }
 
     pub(crate) fn continue_attached_chain(

--- a/packages/doeff-vm-core/src/vm/step.rs
+++ b/packages/doeff-vm-core/src/vm/step.rs
@@ -587,13 +587,13 @@ impl VM {
                     }
                     // Reattach the detached chain so the raised UnhandledEffect surfaces to the
                     // user body's try/except via should_raise_into_stream. Unlike eval_perform,
-                    // eval_perform_with_k arrives here with k detached, so current_segment lacks
-                    // the user body's program frame; continue_k restores it before the error is
-                    // raised. If reattachment itself fails, keep the original user-facing
-                    // NoMatchingHandler diagnostic: the effect that went unhandled is still the
-                    // actionable error.
+                    // eval_perform_with_k arrives here after perform dispatch pre-detached k, so
+                    // current_segment lacks the user body's program frame; reattach_chain restores
+                    // it before the error is raised.
                     let mut k = k;
-                    let _ = self.continue_k(&mut k);
+                    if let Err(error) = self.reattach_chain(&mut k) {
+                        return error_result(error, Some(context));
+                    }
                     return error_result(VMError::no_matching_handler(effect), Some(context));
                 }
             };

--- a/packages/doeff-vm-core/src/vm/step.rs
+++ b/packages/doeff-vm-core/src/vm/step.rs
@@ -585,10 +585,15 @@ impl VM {
                     if let Some(current) = self.current_segment {
                         context.extend(self.collect_rich_context_from(current));
                     }
+                    // Reattach the detached chain so the raised UnhandledEffect surfaces to the
+                    // user body's try/except via should_raise_into_stream. Unlike eval_perform,
+                    // eval_perform_with_k arrives here with k detached, so current_segment lacks
+                    // the user body's program frame; continue_k restores it before the error is
+                    // raised. If reattachment itself fails, keep the original user-facing
+                    // NoMatchingHandler diagnostic: the effect that went unhandled is still the
+                    // actionable error.
                     let mut k = k;
-                    if let Err(error) = self.continue_k(&mut k) {
-                        return error_result(error, Some(context));
-                    }
+                    let _ = self.continue_k(&mut k);
                     return error_result(VMError::no_matching_handler(effect), Some(context));
                 }
             };

--- a/packages/doeff-vm-core/src/vm/step.rs
+++ b/packages/doeff-vm-core/src/vm/step.rs
@@ -585,6 +585,10 @@ impl VM {
                     if let Some(current) = self.current_segment {
                         context.extend(self.collect_rich_context_from(current));
                     }
+                    let mut k = k;
+                    if let Err(error) = self.continue_k(&mut k) {
+                        return error_result(error, Some(context));
+                    }
                     return error_result(VMError::no_matching_handler(effect), Some(context));
                 }
             };

--- a/packages/doeff-vm-core/src/vm_tests.rs
+++ b/packages/doeff-vm-core/src/vm_tests.rs
@@ -337,6 +337,24 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    fn test_reattach_chain_restores_detached_body_chain() {
+        use crate::continuation::Continuation;
+
+        let mut vm = VM::new();
+        let root_fid = vm.alloc_segment(Fiber::new(None));
+        let body_fid = vm.alloc_segment(Fiber::new(Some(root_fid)));
+        let mut k = Continuation::from_chain(vm.segments.detach_chain(body_fid, body_fid).unwrap());
+
+        vm.current_segment = Some(root_fid);
+        vm.reattach_chain(&mut k).unwrap();
+
+        assert_eq!(vm.current_segment, Some(body_fid));
+        let body_parent = vm.segments.get(body_fid).and_then(|body| body.parent);
+        assert_eq!(body_parent, Some(root_fid));
+        assert!(k.consumed());
+    }
+
+    #[test]
     fn test_resume_continuation() {
         use crate::continuation::Continuation;
 

--- a/tests/effects/test_memo_no_handlers.py
+++ b/tests/effects/test_memo_no_handlers.py
@@ -1,0 +1,16 @@
+from doeff_core_effects.cache import cache
+
+from doeff import do, run
+
+
+def test_cache_decorator_runs_without_any_memo_handlers():
+    calls = {"count": 0}
+
+    @cache()
+    @do
+    def expensive(value):
+        calls["count"] += 1
+        return value + 5
+
+    assert run(expensive(37)) == 42
+    assert calls["count"] == 1

--- a/tests/effects/test_memo_no_terminal.py
+++ b/tests/effects/test_memo_no_terminal.py
@@ -1,0 +1,33 @@
+from doeff_core_effects.cache import cache
+from doeff_core_effects.handlers import await_handler, slog_handler
+from doeff_core_effects.memo_handlers import in_memory_memo_handler
+from doeff_core_effects.scheduler import scheduled
+
+from doeff import WithHandler, do, run
+
+
+def _with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return wrapped
+
+
+def test_cache_decorator_runs_with_memo_handler_but_no_terminal():
+    calls = {"count": 0}
+
+    @cache()
+    @do
+    def expensive(value):
+        calls["count"] += 1
+        return value * 2
+
+    program = _with_handlers(
+        expensive(21),
+        await_handler(),
+        slog_handler(),
+        in_memory_memo_handler(),
+    )
+
+    assert run(scheduled(program)) == 42
+    assert calls["count"] == 1

--- a/tests/effects/test_memo_rewriter_compute_unhandled.py
+++ b/tests/effects/test_memo_rewriter_compute_unhandled.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+import pytest
+from doeff_core_effects.handlers import slog_handler
+from doeff_core_effects.memo_handlers import make_memo_rewriter
+
+from doeff import EffectBase, UnhandledEffect, WithHandler, do, run
+
+
+@dataclass(frozen=True)
+class Lookup(EffectBase):
+    key: str
+
+
+def _with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return wrapped
+
+
+def test_memo_rewriter_does_not_swallow_compute_path_unhandled_effect():
+    rewriter = make_memo_rewriter(Lookup, key_fn=lambda effect: effect.key)
+
+    @do
+    def program():
+        return (yield Lookup("alpha"))
+
+    wrapped = _with_handlers(program(), slog_handler(), rewriter)
+
+    with pytest.raises(UnhandledEffect):
+        run(wrapped)

--- a/tests/effects/test_memo_rewriter_no_terminal.py
+++ b/tests/effects/test_memo_rewriter_no_terminal.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from doeff_core_effects.handlers import await_handler, slog_handler
+from doeff_core_effects.memo_handlers import in_memory_memo_handler, make_memo_rewriter
+from doeff_core_effects.scheduler import scheduled
+
+from doeff import EffectBase, Pass, Resume, WithHandler, do, run
+
+
+@dataclass(frozen=True)
+class Lookup(EffectBase):
+    key: str
+
+
+def _with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return wrapped
+
+
+def _lookup_handler(calls):
+    @do
+    def handler(effect, k):
+        if not isinstance(effect, Lookup):
+            yield Pass(effect, k)
+            return
+
+        calls["count"] += 1
+        return (yield Resume(k, f"value:{effect.key}"))
+
+    return handler
+
+
+def test_memo_rewriter_uses_storage_without_terminal_and_hits_on_second_call():
+    calls = {"count": 0}
+    rewriter = make_memo_rewriter(Lookup, key_fn=lambda effect: effect.key)
+
+    @do
+    def program():
+        first = yield Lookup("alpha")
+        second = yield Lookup("alpha")
+        return first, second
+
+    wrapped = _with_handlers(
+        program(),
+        await_handler(),
+        slog_handler(),
+        _lookup_handler(calls),
+        in_memory_memo_handler(),
+        rewriter,
+    )
+
+    assert run(scheduled(wrapped)) == ("value:alpha", "value:alpha")
+    assert calls["count"] == 1
+
+
+def test_memo_rewriter_falls_through_without_memo_storage_and_does_not_cache():
+    calls = {"count": 0}
+    rewriter = make_memo_rewriter(Lookup, key_fn=lambda effect: effect.key)
+
+    @do
+    def program():
+        first = yield Lookup("alpha")
+        second = yield Lookup("alpha")
+        return first, second
+
+    wrapped = _with_handlers(
+        program(),
+        slog_handler(),
+        _lookup_handler(calls),
+        rewriter,
+    )
+
+    assert run(wrapped) == ("value:alpha", "value:alpha")
+    assert calls["count"] == 2

--- a/tests/effects/test_memo_terminal_deprecated.py
+++ b/tests/effects/test_memo_terminal_deprecated.py
@@ -1,0 +1,5 @@
+from doeff_core_effects.memo_handlers import memo_terminal
+
+
+def test_memo_terminal_doc_mentions_deprecated():
+    assert "deprecated" in (memo_terminal.__doc__ or "").lower()

--- a/tests/effects/test_memo_with_terminal_unchanged.py
+++ b/tests/effects/test_memo_with_terminal_unchanged.py
@@ -1,0 +1,45 @@
+from doeff_core_effects.cache import cache
+from doeff_core_effects.handlers import await_handler, slog_handler
+from doeff_core_effects.memo_handlers import in_memory_memo_handler, memo_terminal
+from doeff_core_effects.scheduler import scheduled
+
+from doeff import WithHandler, do, run
+
+
+def _with_handlers(program, *handlers):
+    wrapped = program
+    for handler in reversed(handlers):
+        wrapped = WithHandler(handler, wrapped)
+    return wrapped
+
+
+def test_cache_hit_with_terminal_keeps_existing_behavior():
+    calls = {"count": 0}
+    slog = slog_handler()
+
+    @cache()
+    @do
+    def expensive(value):
+        calls["count"] += 1
+        return value * 2
+
+    @do
+    def program():
+        first = yield expensive(21)
+        second = yield expensive(21)
+        return first, second
+
+    wrapped = _with_handlers(
+        program(),
+        await_handler(),
+        slog,
+        memo_terminal,
+        in_memory_memo_handler(),
+    )
+
+    assert run(scheduled(wrapped)) == (42, 42)
+    assert calls["count"] == 1
+
+    memo_messages = [entry["msg"] for entry in slog.log if entry["msg"].startswith("[memo-layer:")]
+    assert sum("HIT" in msg for msg in memo_messages) == 1
+    assert sum("MISS" in msg for msg in memo_messages) == 0

--- a/tests/effects/test_unhandled_effect_class.py
+++ b/tests/effects/test_unhandled_effect_class.py
@@ -60,6 +60,17 @@ def test_unhandled_effect_is_catchable_inside_do():
     assert run(program()) == "fallback"
 
 
+def test_pass_fallthrough_unhandled_effect_is_catchable_inside_do():
+    @do
+    def program():
+        try:
+            yield MissingEffect(label="catchable-after-pass")
+        except UnhandledEffect:
+            return "fallback"
+
+    assert run(WithHandler(pass_through, program())) == "fallback"
+
+
 def test_unhandled_effect_preserves_doeff_traceback():
     @do
     def program():


### PR DESCRIPTION
## Summary

Fixes `memo-unhandled-fallthrough-v2`.

- Wrap memo I/O in `@cache` and `make_memo_rewriter` with narrow `except UnhandledEffect` fallthrough handling.
- Keep the rewriter compute path fail-fast: `yield effect` is still outside the memo-I/O catch scope.
- Preserve layered memo write-through while forwarding missing-terminal `UnhandledEffect` back into the original memo I/O continuation.
- Mark `memo_terminal` as deprecated/optional in its docstring while keeping behavior unchanged.
- Fix the VM pass-through no-matching-handler path so `UnhandledEffect` can be caught by the original `@do` generator after `Pass` handlers.
- Factor `VM::reattach_chain` as the first-class chain-management primitive; `continue_k` now delegates to it, and the error path calls it directly instead of relying on `continue_k` side effects.

## Why VM Core Changed

The issue expected no VM-level change, but the new no-terminal tests exposed an `eval_perform` vs `eval_perform_with_k` asymmetry. When a normal `Perform` reaches the top, the user body's program frame is still in `current_segment`, so `should_raise_into_stream` can inject `UnhandledEffect` into the generator's `try/except`. When `Pass` falls off the top, the continuation `k` is already detached, so `current_segment` no longer contains that user body frame.

`packages/doeff-vm-core/src/vm/step.rs` now calls `VM::reattach_chain(&mut k)` before raising `NoMatchingHandler`, restoring the user body's stream so `should_raise_into_stream` can deliver the `UnhandledEffect`. `continue_k` keeps its singular resume-with-value meaning by delegating to the same primitive, and `tests/effects/test_unhandled_effect_class.py::test_pass_fallthrough_unhandled_effect_is_catchable_inside_do` locks the behavior.

## Acceptance Evidence

- `tests/effects/test_memo_no_terminal.py`: `@cache` runs with `memo_handler(in_memory)` and no terminal.
- `tests/effects/test_memo_no_handlers.py`: `@cache` runs with no memo stack at all.
- `tests/effects/test_memo_with_terminal_unchanged.py`: terminal stack still caches; function counter stays at 1 and memo hit/miss slog counts are asserted.
- `tests/effects/test_memo_rewriter_no_terminal.py`: rewriter caches with storage/no terminal and falls through without storage; handler call counters assert both modes.
- `tests/effects/test_memo_rewriter_compute_unhandled.py`: compute-path `UnhandledEffect` still propagates.
- `tests/effects/test_memo_terminal_deprecated.py`: `memo_terminal` doc contains `deprecated`.
- `packages/doeff-vm-core/src/vm_tests.rs::test_reattach_chain_restores_detached_body_chain`: unit-level coverage for the chain-management half of the refactor.

## Validation

- Initial TDD run of the new acceptance tests failed before the fix: 5 failed, 2 passed.
- `uvx maturin develop --release` rebuilt `packages/doeff-vm` after the Rust VM edits.
- `uv run pytest tests/effects/test_memo_no_terminal.py tests/effects/test_memo_no_handlers.py tests/effects/test_memo_with_terminal_unchanged.py tests/effects/test_memo_rewriter_no_terminal.py tests/effects/test_memo_rewriter_compute_unhandled.py tests/effects/test_memo_terminal_deprecated.py tests/effects/test_unhandled_effect_class.py` -> 14 passed.
- `uv run pytest tests/effects/test_memo_no_terminal.py tests/effects/test_memo_no_handlers.py tests/effects/test_memo_with_terminal_unchanged.py tests/effects/test_memo_rewriter_no_terminal.py tests/effects/test_memo_rewriter_compute_unhandled.py tests/effects/test_memo_terminal_deprecated.py tests/effects/test_unhandled_effect_class.py tests/effects/test_unhandled_effect_chain.py tests/test_memo_rewriter_spawn_continuation.py` -> 19 passed.
- `uv run pytest tests/test_pass_dispatch_context_regression.py tests/test_memo_rewriter_spawn_continuation.py tests/effects/test_unhandled_effect_chain.py` -> 5 passed; `tests/test_pass_dispatch_context_regression.py` currently has no collected tests.
- `uv run pytest` -> 802 passed, 87 skipped.
- After the `reattach_chain` refactor: `uv run pytest tests/effects/test_unhandled_effect_class.py::test_pass_fallthrough_unhandled_effect_is_catchable_inside_do -q` -> 1 passed.
- After the `reattach_chain` refactor: `uv run pytest tests/test_memo_rewriter_spawn_continuation.py tests/test_double_resume_traceback.py tests/core/test_vm_architecture_ocaml5.py tests/effects/test_memo_rewriter_compute_unhandled.py tests/effects/test_memo_rewriter_no_terminal.py -q` -> 13 passed.
- `cargo test` in `packages/doeff-vm-core` -> 2 passed.
- `cargo fmt --check` in `packages/doeff-vm-core` -> passed.
- `git diff --check` -> passed.
- `uv run ruff check tests/effects/test_memo_no_terminal.py tests/effects/test_memo_no_handlers.py tests/effects/test_memo_with_terminal_unchanged.py tests/effects/test_memo_rewriter_no_terminal.py tests/effects/test_memo_rewriter_compute_unhandled.py tests/effects/test_memo_terminal_deprecated.py tests/effects/test_unhandled_effect_class.py` -> passed.
- `uv run ruff check --select I,F ...` on touched Python implementation/tests -> passed.

## Local Environment Note

- `make sync` could not complete because `maturin` was not on PATH, so I used `uvx maturin develop --release` as the equivalent Rust VM rebuild step.
- `cargo test --features python_bridge` in `packages/doeff-vm-core` cannot link in this local environment because it lacks `libpython3.12` (`unable to find library -lpython3.12`). The feature-gated Rust unit test is present, and the maturin rebuild plus Python VM test suite succeeded under the active Python 3.14t venv.