### PR TITLE
fix(do): catch tokenize.TokenError when source is non-Python (Hy handlers)

### DIFF
--- a/doeff/do.py
+++ b/doeff/do.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import tokenize
 import warnings
 from collections.abc import Callable, Generator
 from functools import wraps
@@ -167,14 +168,18 @@ def _call_leaf_name(node: ast.AST) -> str | None:
 
 
 def _analyze_resume_yields(fn: Callable[..., Any], *, non_tail: bool) -> tuple[int, ...]:
+    # tail-resume analysis is purely a warning/diagnostic optimization. If we
+    # cannot recover Python source for `fn` (e.g. Hy-defined handlers, lambdas
+    # generated at runtime, frozen functions), silently skip — the runtime
+    # behavior of the @do wrapper is unaffected.
     try:
         source_lines, start_line = inspect.getsourcelines(fn)
-    except (OSError, TypeError):
+    except (OSError, TypeError, tokenize.TokenError, SyntaxError):
         return ()
 
     try:
         module = ast.parse(dedent("".join(source_lines)))
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         return ()
 
     function_node = next(

--- a/tests/test_do_tail_resume_ast.py
+++ b/tests/test_do_tail_resume_ast.py
@@ -71,3 +71,46 @@ def test_protected_tail_looking_resume_warns_without_marker() -> None:
                 pass
 
     assert callable(handler)
+
+
+def test_do_decorator_handles_unparseable_source() -> None:
+    """Hy-defined handlers and other non-Python source bodies must not crash @do.
+
+    inspect.getsourcelines on a Hy function returns the Hy source verbatim,
+    which Python's tokenizer rejects with tokenize.TokenError. The tail-resume
+    analysis is purely diagnostic and must silently skip when source cannot be
+    parsed — runtime behavior of the wrapped generator is unchanged.
+    """
+    import inspect
+    import tokenize
+
+    from doeff.do import _analyze_resume_yields
+
+    def real_handler(_effect: object, k: object):
+        yield Resume(k, "value")
+
+    real_getsourcelines = inspect.getsourcelines
+
+    def raising_getsourcelines(fn):
+        if fn is real_handler:
+            raise tokenize.TokenError("unexpected EOF in multi-line statement", (81, 0))
+        return real_getsourcelines(fn)
+
+    inspect.getsourcelines = raising_getsourcelines
+    try:
+        result = _analyze_resume_yields(real_handler, non_tail=False)
+    finally:
+        inspect.getsourcelines = real_getsourcelines
+
+    assert result == ()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        inspect.getsourcelines = raising_getsourcelines
+        try:
+            wrapped = do(real_handler)
+        finally:
+            inspect.getsourcelines = real_getsourcelines
+
+    assert callable(wrapped)
+    assert _non_tail_resume_warnings(caught) == []


### PR DESCRIPTION
## Summary

`@do` calls `inspect.getsourcelines(fn)` for tail-resume AST analysis (added in `5c9352f3 Fix VM xfail regressions`). When `fn` is a Hy-defined handler, `getsourcelines` returns Hy source verbatim and Python's tokenizer (run by `inspect.getblock`) raises `tokenize.TokenError`. The previous catch `(OSError, TypeError)` does not match, so the exception propagated out and crashed every Hy `defhandler` at decoration time.

This was first surfaced when proboscis-ema refreshed its doeff lock to include the post-`5c9352f3` revisions and tried to run its readiness test:

```
File ".../doeff/do.py", line 171, in _analyze_resume_yields
    source_lines, start_line = inspect.getsourcelines(fn)
File ".../inspect.py", line 1244, in getblock
    for _token in tokens:
File ".../tokenize.py", line 590, in _generate_tokens_from_c_tokenizer
    raise TokenError(msg, (e.lineno, e.offset)) from None
tokenize.TokenError: ('unexpected EOF in multi-line statement', (81, 0))
```

## Fix

Tail-resume analysis is a diagnostic optimization (it only emits warnings about non-tail Resume positions). The runtime behavior of the wrapped @do function is identical regardless of analysis success or failure. So: when source recovery fails for any reason — including \`tokenize.TokenError\` and \`SyntaxError\` from non-Python sources, or \`ValueError\` from \`ast.parse\` — silently skip and return \`()\`.

\`\`\`python
try:
    source_lines, start_line = inspect.getsourcelines(fn)
except (OSError, TypeError, tokenize.TokenError, SyntaxError):
    return ()

try:
    module = ast.parse(dedent(\"\".join(source_lines)))
except (SyntaxError, ValueError):
    return ()
\`\`\`

## Test plan

- [x] New regression test \`test_do_decorator_handles_unparseable_source\` simulates Hy-style source by monkey-patching \`inspect.getsourcelines\` to raise \`TokenError\`. Verifies that \`_analyze_resume_yields\` returns \`()\` and \`@do\` succeeds without warning.
- [x] Full doeff suite: **805 passed, 84 skipped, 0 failed** (was 804 — +1 from the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)