### PR TITLE
fix(memo): treat UnhandledEffect at storage layer as broadcast/miss signal

### DIFF
--- a/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
+++ b/packages/doeff-core-effects/doeff_core_effects/memo_handlers.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, TypeAlias
 
 from doeff import UnhandledEffect, do
-from doeff.program import Pass, Resume, TransferThrow
+from doeff.program import Pass, Resume
 from doeff_core_effects.memo_effects import (
     MemoExists,
     MemoExistsEffect,
@@ -183,11 +183,13 @@ def memo_handler(
             if exists:
                 result = yield Resume(k, True)
                 return result
-            # Not in this layer — re-perform to check outer layers
+            # Not in this layer — re-perform to check outer layers.
+            # UnhandledEffect = no further outer storage = definitively not
+            # in any layer beyond this one, so resume with False.
             try:
                 outer_exists = yield effect
-            except UnhandledEffect as exc:
-                return (yield TransferThrow(k, exc))
+            except UnhandledEffect:
+                outer_exists = False
             result = yield Resume(k, outer_exists)
             return result
 
@@ -198,24 +200,31 @@ def memo_handler(
                 yield Slog(f"[memo-layer:{label}] HIT key={key[:16]}...")
                 result = yield Resume(k, value)
                 return result
-            # Miss — re-perform (outer handler resolves) → cache result
+            # Miss — re-perform (outer handler resolves) → cache result.
+            # UnhandledEffect = no further outer storage AND not here →
+            # established miss signal: raise KeyError. Callers (@cache,
+            # make_memo_rewriter, sessioned-memo) catch KeyError as miss.
             yield Slog(f"[memo-layer:{label}] MISS key={key[:16]}... → re-performing")
             try:
                 outer_value = yield effect
-            except UnhandledEffect as exc:
-                return (yield TransferThrow(k, exc))
+            except UnhandledEffect:
+                raise KeyError(effect.key)
             yield storage.put(key, outer_value)
             yield Slog(f"[memo-layer:{label}] WRITE-THROUGH key={key[:16]}...")
             result = yield Resume(k, outer_value)
             return result
 
-        # MemoPutEffect — write to this layer AND propagate to outer layers
+        # MemoPutEffect — write to this layer AND broadcast to outer layers.
+        # UnhandledEffect from re-perform = no further outer storage =
+        # broadcast complete (this layer was the outermost). Swallow and
+        # resume the caller with None — the user should not see an exception
+        # when all storage layers successfully stored.
         yield storage.put(key, effect.value)
         yield Slog(f"[memo-layer:{label}] PUT key={key[:16]}...")
         try:
             yield effect  # re-perform → outer handlers also store
-        except UnhandledEffect as exc:
-            return (yield TransferThrow(k, exc))
+        except UnhandledEffect:
+            pass  # no further outer = broadcast complete
         result = yield Resume(k, None)
         return result
 


### PR DESCRIPTION
## Summary

Each \`memo_handler\` layer used to catch \`UnhandledEffect\` from its \`yield effect\` re-perform and forward via \`TransferThrow(k, exc)\`. That was wrong for three reasons:

### MemoPut — broadcast semantics

Memo write is **broadcast**: all matching storage layers should store. When the outermost layer's re-perform falls through, that's the **positive signal "broadcast complete"** — every layer already stored. \`TransferThrow\`ing the \`UnhandledEffect\` made the user's \`yield MemoPut(...)\` site see an exception **even when every layer succeeded**, forcing every caller (\`@cache\`, \`make_memo_rewriter\`, \`sessioned-memo-handler\`, plain user code) to wrap with \`try/except UnhandledEffect: pass\`. Pure boilerplate.

After this fix: \`yield MemoPut(...)\` from user code never raises \`UnhandledEffect\` when at least one storage layer is installed. Broadcast completes silently.

### MemoExists — definitive answer

Outermost fall-through definitively means "not in any storage". \`Resume(k, False)\` is the natural answer; surfacing it as exception is wrong.

### MemoGet — established miss signal

Outermost fall-through means "miss everywhere". The established miss signal in this codebase is \`KeyError\` — already used by the deprecated \`memo_terminal\`, caught by \`@cache\` / \`make_memo_rewriter\` / \`sessioned-memo-handler\`. Convert \`UnhandledEffect\` → \`KeyError\` to keep that contract consistent.

## Side effects

- \`TransferThrow\` import is removed from \`memo_handlers.py\` (no longer used).
- Compute-layer callers no longer need \`try/except UnhandledEffect\` around \`yield MemoPut(...)\` — only \`yield MemoGet(...)\` (KeyError) and the truly absent-storage case (UnhandledEffect on \`yield MemoExists/Get/Put\` when the chain has zero memo handlers).
- Memory of @cache decorator after this change: catches KeyError on MemoGet (existing), catches UnhandledEffect on MemoExists/MemoGet/MemoPut for "no memo stack at all" (existing).

## Out of scope

A related VM-level bug remains: when a handler clause body's \`<-\` (non-terminal delegate) raises (Python exception OR \`TransferThrow\` from outer), the exception does NOT propagate back to the caller's \`<-\` site through intermediate handlers. Tracked separately on branch \`fix/vm-exception-propagates-through-bind\` with 3 failing tests as the regression spec.

## Test plan

- [x] Full doeff suite: **808 passed, 84 skipped** (3 unrelated failures are the VM bug repros above)
- [ ] proboscis-ema readiness suite — will be validated after VM fix lands and proboscis-ema lock refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)