### PR TITLE
fix(claude-adapter): write trust to ~/.claude/.claude.json (Claude Code 2.1+)

### DIFF
--- a/packages/doeff-agents/src/doeff_agents/handlers/production.py
+++ b/packages/doeff-agents/src/doeff_agents/handlers/production.py
@@ -412,27 +412,48 @@ class TmuxAgentHandler(AgentHandler):
         claude_dir = agent_home / ".claude"
         claude_dir.mkdir(parents=True, exist_ok=True)
 
-        claude_json = agent_home / ".claude.json"
+        # Claude Code 2.1+ reads `${CLAUDE_HOME}/.claude.json` (CLAUDE_HOME is
+        # set to `${agent_home}/.claude` below). Older versions read
+        # `${HOME}/.claude.json`. Write trust state to both so the
+        # workspace-trust dialog is skipped regardless of which version of
+        # Claude Code is installed (the dialog is interactive and would
+        # block the tmux launch indefinitely otherwise).
+        candidate_json_paths: list[Path] = [
+            agent_home / ".claude.json",                # legacy
+            agent_home / ".claude" / ".claude.json",    # 2.1+ — read by CLI
+        ]
         source_claude_json = source_home / ".claude.json"
-        if (
-            agent_home != source_home
-            and not claude_json.exists()
-            and source_claude_json.exists()
-        ):
-            shutil.copy2(source_claude_json, claude_json)
-        data = json.loads(claude_json.read_text()) if claude_json.exists() else {}
-        projects = data.setdefault("projects", {})
-        for workspace in trusted_workspaces:
-            projects.setdefault(
-                str(workspace),
-                {
-                    "allowedTools": [],
-                    "hasTrustDialogAccepted": True,
-                    "hasCompletedProjectOnboarding": True,
-                    "projectOnboardingSeenCount": 0,
-                },
+
+        # Reuse the user's authentication blob in agent_home (only if the
+        # caller explicitly relocated to a non-default home).
+        for claude_json in candidate_json_paths:
+            if (
+                agent_home != source_home
+                and not claude_json.exists()
+                and source_claude_json.exists()
+            ):
+                claude_json.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_claude_json, claude_json)
+
+        for claude_json in candidate_json_paths:
+            data = (
+                json.loads(claude_json.read_text()) if claude_json.exists() else {}
             )
-        claude_json.write_text(json.dumps(data))
+            projects = data.setdefault("projects", {})
+            for workspace in trusted_workspaces:
+                entry = projects.setdefault(str(workspace), {})
+                # Claude Code keeps each project entry's existing fields
+                # (allowedTools, mcpServers, etc.) intact; we only need to
+                # ensure the trust + onboarding flags are set so no dialog
+                # appears on launch. Always overwrite — a stale entry from
+                # a previous launch where trust was declined would still
+                # show the dialog otherwise.
+                entry.setdefault("allowedTools", [])
+                entry["hasTrustDialogAccepted"] = True
+                entry["hasCompletedProjectOnboarding"] = True
+                entry.setdefault("projectOnboardingSeenCount", 0)
+            claude_json.parent.mkdir(parents=True, exist_ok=True)
+            claude_json.write_text(json.dumps(data))
 
         config_path = claude_dir / "config.json"
         source_config = source_home / ".claude" / "config.json"


### PR DESCRIPTION
## Summary

Claude Code 2.1+ migrated the per-project trust state read path from `\$HOME/.claude.json` to `\$CLAUDE_HOME/.claude.json` (where `CLAUDE_HOME = <agent_home>/.claude`). `_prepare_claude_home` was only writing the legacy location, so launches with the modern CLI hit the workspace trust dialog ("Yes, I trust this folder / No, exit") and hung indefinitely inside tmux.

## Repro

nakagawa `simtime-agent-paper` readiness test:
1. Launches Claude Code in a tmux session with workdir `/private/tmp/nak-executor-...-<uuid>`
2. Pre-launch writes trust to `~/.claude.json` ✓
3. Claude Code 2.1.119 reads `~/.claude/.claude.json` (NEW path), sees no entry for the workdir, shows the trust dialog
4. Dismiss-onboarding pattern matcher runs but the dialog rendered first, agent parked at prompt
5. `Wait result-ep.future` polls `result.json` for 30 minutes → timeout

## Fix

Write trust state to BOTH `<agent_home>/.claude.json` (legacy) AND `<agent_home>/.claude/.claude.json` (2.1+). Files are managed independently — we read+merge each file's existing project entry so unrelated user state isn't clobbered. Trust flags become explicit assignments (the previous `setdefault`-only placement could leave a stale "declined" entry blocking).

## Test

- doeff-agents suite: 67 passed, 1 skipped
- Will validate end-to-end on the proboscis-ema readiness test after merge + lock refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)