### PR TITLE
fix(claude-adapter): isolate per-launch CLAUDE_HOME in handle_launch

### DIFF
--- a/packages/doeff-agents/src/doeff_agents/handlers/production.py
+++ b/packages/doeff-agents/src/doeff_agents/handlers/production.py
@@ -148,19 +148,34 @@ class TmuxAgentHandler(AgentHandler):
         if self._backend.has_session(effect.session_name):
             raise SessionAlreadyExistsError(f"Session {effect.session_name} already exists")
 
-        # Pre-trust the workdir for Claude Code so the workspace-trust dialog
-        # never appears in the tmux pane. Without this, Claude Code 2.1+ shows
-        # an interactive prompt that the dismiss-onboarding pattern matcher
-        # may not catch in time, causing the agent to hang at "Yes, I trust
-        # this folder" indefinitely. _prepare_claude_home writes the trust
-        # flags to BOTH ~/.claude.json (legacy) and ~/.claude/.claude.json
-        # (Claude Code 2.1+), covering both CLI versions.
+        # Isolate Claude Code state per launch so the agent's `.claude.json`
+        # is not shared with any concurrently-running Claude Code instance
+        # on the host (e.g. the user's editor session). Without this, two
+        # Claude processes race on `~/.claude/.claude.json` writes and the
+        # workspace-trust entry we plant gets clobbered, causing the agent
+        # to hang at "Yes, I trust this folder" forever.
+        agent_env_exports: dict[str, str] = {}
         if effect.agent_type == AgentType.CLAUDE:
-            agent_home = self._claude_runtime_policy.agent_home or Path.home()
+            agent_home = self._claude_runtime_policy.agent_home
+            if agent_home is None:
+                # Default to a per-launch isolated home under the workdir so
+                # state cannot leak between concurrent agent runs or with
+                # the user's interactive Claude Code session.
+                agent_home = effect.work_dir / ".agent-home"
             trusted_workspaces = self._claude_runtime_policy.trusted_workspaces or (
                 effect.work_dir,
             )
             self._prepare_claude_home(agent_home, trusted_workspaces)
+            agent_env_exports = {
+                "HOME": str(agent_home),
+                "CLAUDE_HOME": str(agent_home / ".claude"),
+                **(
+                    {"CLAUDE_CODE_OAUTH_TOKEN": os.environ["CLAUDE_CODE_OAUTH_TOKEN"]}
+                    if "CLAUDE_CODE_OAUTH_TOKEN" in os.environ
+                    else {}
+                ),
+                **self._claude_runtime_policy.bootstrap_exports,
+            }
 
         # Start MCP server if tools are provided
         if effect.mcp_tools and run_tool is not None:
@@ -182,6 +197,8 @@ class TmuxAgentHandler(AgentHandler):
             )
         )
         command = shlex.join(argv)
+        if agent_env_exports:
+            command = self._wrap_with_shell_exports(command, agent_env_exports)
 
         if adapter.injection_method == InjectionMethod.ARG:
             self._backend.send_keys(session_info.pane_id, command, literal=False)

--- a/packages/doeff-agents/tests/test_session_backend.py
+++ b/packages/doeff-agents/tests/test_session_backend.py
@@ -132,7 +132,13 @@ def test_tmux_agent_handler_uses_injected_backend(monkeypatch) -> None:
 
     assert backend.created[0].session_name == "worker"
     assert backend.sent[0][0] == handle.pane_id
-    assert backend.sent[0][1] == "fake-agent --run"
+    # handle_launch wraps the command with HOME/CLAUDE_HOME exports for
+    # AgentType.CLAUDE so the launched agent's `.claude.json` is isolated
+    # from any concurrently-running Claude Code instance on the host.
+    sent_command = backend.sent[0][1]
+    assert "fake-agent --run" in sent_command
+    assert "export HOME=" in sent_command
+    assert "export CLAUDE_HOME=" in sent_command
 
     observation = handler.handle_monitor(MonitorEffect(handle=handle))
     assert observation.status == SessionStatus.DONE


### PR DESCRIPTION
## Root cause

PRs #405 (write trust to both legacy + 2.1+ paths) and #406 (call _prepare_claude_home from handle_launch) were both correct fixes — but neither addressed the underlying shared-state problem: the launched agent's `~/.claude/.claude.json` is the SAME file as the host's interactive Claude Code session. Whenever a developer is using Claude Code while a readiness test runs (the normal case), the interactive session continuously rewrites that file as a side-effect of normal operation. Whatever trust entry the launcher plants gets clobbered before the agent reads it → trust dialog → tmux hang.

Verified by inspection: `~/.claude/.claude.json` contained only the user's session's projects (mediagen, doeff, doeff-agents) and 0 nak-executor entries even immediately after the launcher's pre-trust write. The 200-project legacy file `~/.claude.json` had all 34 historical nak-executor entries — Claude Code 2.1 doesn't read it.

## Fix

When handle_launch is dispatched for AgentType.CLAUDE, isolate the launched agent's HOME and CLAUDE_HOME to a per-launch directory (default `<work_dir>/.agent-home`). `_prepare_claude_home` seeds the isolated home with the trust entry + auth blob (already supported via shutil.copy2 of `~/.claude.json` when agent_home != source_home). The launched agent reads from a path no other process touches, so the trust entry is stable.

This brings handle_launch (LaunchEffect path used by agent_execution_handler) to parity with handle_claude_launch's existing env-isolation pattern.

## Test

- doeff-agents: 67 passed, 1 skipped
- Updated test_session_backend.test_tmux_agent_handler_uses_injected_backend to assert the new env exports are present
- proboscis-ema readiness: pending validation after merge + lock refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)