### PR TITLE
fix(agents): suppress oh-my-zsh update prompt that ate first launch char

### DIFF
--- a/packages/doeff-agents/src/doeff_agents/handlers/claude.hy
+++ b/packages/doeff-agents/src/doeff_agents/handlers/claude.hy
@@ -35,22 +35,27 @@
 ;; ---------------------------------------------------------------------------
 
 (defn _trust-workdir [work-dir]
-  "Mark work_dir as trusted in ~/.claude.json."
+  "Mark work_dir as trusted in BOTH ~/.claude.json (legacy) and
+   ~/.claude/.claude.json (Claude Code 2.1+ — the path the CLI actually reads).
+   Without the 2.1+ path the agent hits the workspace-trust dialog and hangs
+   even though `--dangerously-skip-permissions` is set."
   (setv home (Path.home))
-  (setv claude-json (/ home ".claude.json"))
-  (setv data (if (.exists claude-json)
-                 (json.loads (.read-text claude-json))
-                 {}))
-  (setv projects (.setdefault data "projects" {}))
-  (setv workdir-str (str (.resolve work-dir)))
-  (.setdefault projects workdir-str
-    {"allowedTools" []
-     "hasTrustDialogAccepted" True
-     "hasCompletedProjectOnboarding" True})
-  (.write-text claude-json (json.dumps data))
-  ;; Ensure onboarding config exists
   (setv claude-dir (/ home ".claude"))
   (.mkdir claude-dir :parents True :exist-ok True)
+  (setv workdir-str (str (.resolve work-dir)))
+  (for [claude-json [(/ home ".claude.json") (/ claude-dir ".claude.json")]]
+    (setv data (if (.exists claude-json)
+                   (json.loads (.read-text claude-json))
+                   {}))
+    (setv projects (.setdefault data "projects" {}))
+    (setv entry (.setdefault projects workdir-str {"allowedTools" []}))
+    ;; Always overwrite trust + onboarding flags. A stale entry from a previous
+    ;; launch where the dialog was declined would still show the prompt
+    ;; otherwise.
+    (setv (get entry "hasTrustDialogAccepted") True)
+    (setv (get entry "hasCompletedProjectOnboarding") True)
+    (.write-text claude-json (json.dumps data)))
+  ;; Ensure onboarding config exists
   (setv config-path (/ claude-dir "config.json"))
   (when (not (.exists config-path))
     (.write-text config-path (json.dumps {"hasCompletedOnboarding" True}))))

--- a/packages/doeff-agents/src/doeff_agents/handlers/production.py
+++ b/packages/doeff-agents/src/doeff_agents/handlers/production.py
@@ -181,9 +181,20 @@ class TmuxAgentHandler(AgentHandler):
         if effect.mcp_tools and run_tool is not None:
             self._start_mcp_server(effect, run_tool)
 
+        # Disable oh-my-zsh's auto-update prompt. Without isolated HOME the
+        # user's `.zshrc` would suppress this, but with `HOME=<work_dir>/
+        # .agent-home` the agent's shell starts without that config and omz
+        # blocks on its `[Y/n]` prompt — eating the first character of the
+        # launch command we send next.
+        session_env: dict[str, str] = {}
+        if effect.agent_type == AgentType.CLAUDE:
+            session_env["DISABLE_AUTO_UPDATE"] = "true"
+            session_env["DISABLE_UPDATE_PROMPT"] = "true"
+
         tmux_config = tmux.SessionConfig(
             session_name=effect.session_name,
             work_dir=effect.work_dir,
+            env=session_env or None,
         )
         session_info = self._backend.new_session(tmux_config)
 

--- a/packages/doeff-agents/src/doeff_agents/tmux.py
+++ b/packages/doeff-agents/src/doeff_agents/tmux.py
@@ -66,12 +66,14 @@ class TmuxSessionBackend(SessionBackend):
             args.extend(["-c", str(cfg.work_dir)])
         if cfg.window_name:
             args.extend(["-n", cfg.window_name])
-
-        env = dict(os.environ)
+        # Propagate env vars into the pane shell. Setting them on the
+        # tmux client subprocess doesn't reach the pane (the daemon spawns
+        # the shell), so we must use `-e KEY=VAL`.
         if cfg.env:
-            env.update(cfg.env)
+            for key, value in cfg.env.items():
+                args.extend(["-e", f"{key}={value}"])
 
-        result = subprocess.run(args, env=env, capture_output=True, text=True, check=True)
+        result = subprocess.run(args, capture_output=True, text=True, check=True)
         pane_id = result.stdout.strip()
 
         return SessionInfo(


### PR DESCRIPTION
## Summary
- After PR #407 isolated `HOME=<work_dir>/.agent-home`, the agent's tmux shell starts without the user's `.zshrc`.
- oh-my-zsh's update check then prompts `[Y/n]` mid-startup and consumes the first character of the launch command — `claude ...` becomes `laude ...`, causing `zsh: command not found: laude`.
- Fix: route env vars to the pane shell via `tmux new-session -e KEY=VAL` (the daemon spawns the shell, so subprocess env doesn't reach it), then plant `DISABLE_AUTO_UPDATE=true` / `DISABLE_UPDATE_PROMPT=true` for `AgentType.CLAUDE`.

## Test plan
- [x] doeff-agents unit tests: 67 passed, 1 skipped
- [ ] proboscis-ema readiness simtime-agent-paper completes without trust dialog hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)