### PR TITLE
[codex] Allow defhandler docstrings

### DIFF
--- a/packages/doeff-hy/src/doeff_hy/handle.hy
+++ b/packages/doeff-hy/src/doeff_hy/handle.hy
@@ -32,7 +32,7 @@
 ;;; S-expr preservation:
 ;;;   - defhandler stores __doeff_body__ for introspection (like defk)
 
-(import hy.models [Expression Symbol List Keyword Sequence])
+(import hy.models [Expression Symbol List Keyword Sequence String])
 
 
 ;; ---------------------------------------------------------------------------
@@ -477,7 +477,7 @@
 
 
 (defmacro defhandler [name #* rest]
-  "Named handler with optional parameters. Preserves s-expr body.
+  "Named handler with optional parameters and docstring. Preserves s-expr body.
 
    ;; No params — plain handler value
    (defhandler my-handler
@@ -485,6 +485,11 @@
 
    ;; With params — handler factory function
    (defhandler my-handler [config timeout]
+     (Effect [field] (resume (process field config))))
+
+   ;; With docstring
+   (defhandler documented-handler [config]
+     \"Handle documented effects.\"
      (Effect [field] (resume (process field config))))
 
    ;; With guard
@@ -508,15 +513,22 @@
    ;; Non-terminal operation:
    ;;   (<- result effect)  — delegate to outer handler, get result back, continue
 
-   The handler's __doeff_body__ stores the original s-expr clauses."
+   The handler's __doeff_body__ stores handler clauses, excluding docstring metadata."
 
-  (setv params None)
-  (setv clauses rest)
+  (setv params None
+        docstring None
+        clauses rest)
 
   ;; First item after name: List = params, Expression = first clause
   (when (and (> (len rest) 0) (isinstance (get rest 0) List))
     (setv params (get rest 0))
     (setv clauses (cut rest 1 None)))
+
+  ;; Optional docstring after params, or immediately after name for handlers
+  ;; without params. Docstrings are metadata, not handler clauses.
+  (when (and (> (len clauses) 0) (isinstance (get clauses 0) String))
+    (setv docstring (get clauses 0))
+    (setv clauses (cut clauses 1 None)))
 
   ;; Separate lazy defs from effect clauses
   (setv #(lazy-defs effect-clauses) (_extract-lazy-clauses clauses))
@@ -527,6 +539,15 @@
                              :lazy-defs lazy-defs
                              :handler-name name)
         (_build-handler-expr effect-clauses)))
+
+  (setv set-handler-doc
+    (if (is docstring None)
+        `(do)
+        `(setv (. __doeff-handler-fn__ __doc__) ~docstring)))
+  (setv set-name-doc
+    (if (is docstring None)
+        `(do)
+        `(setv (. ~name __doc__) ~docstring)))
 
   ;; Preserve s-expr body as quoted list of all clauses (including lazy)
   (setv quoted-body `(quote ~(list clauses)))
@@ -559,8 +580,10 @@
               (setv (. __doeff-handler-fn__ _doeff_is_handler_fn) True)
               (setv (. __doeff-handler-fn__ __doeff_handler_data__)
                     __doeff-handler-data__)
+              ~set-handler-doc
               __doeff-handler-fn__)))
          (setv (. ~name __doeff_body__) ~quoted-body)
+         ~set-name-doc
          (setv (. ~name __doeff_name__) ~(str name)))
       `(do
          (import doeff.do [do :as _doeff-do])
@@ -574,6 +597,8 @@
            (setv (. __doeff-handler-fn__ __doeff_handler_data__)
                  __doeff-handler-data__)
            (setv (. __doeff-handler-fn__ __doeff_name__) ~(str name))
+           ~set-handler-doc
            __doeff-handler-fn__)
          (setv (. ~name __doeff_body__) ~quoted-body)
+         ~set-name-doc
          (setv (. ~name __doeff_name__) ~(str name)))))

--- a/packages/doeff-hy/tests/test_defhandler_docstring.py
+++ b/packages/doeff-hy/tests/test_defhandler_docstring.py
@@ -1,0 +1,75 @@
+"""Tests for defhandler docstring support."""
+
+
+def _hy_eval_in_module(code, mod_name):
+    import sys
+    import types
+
+    import doeff_hy  # noqa: F401
+    import hy
+
+    mod = types.ModuleType(mod_name)
+    mod.__file__ = "<test>"
+    sys.modules[mod_name] = mod
+    hy.eval(hy.read_many(code), module=mod)
+    return mod
+
+
+def test_defhandler_docstrings_are_metadata_not_clauses():
+    import sys
+
+    code = """
+(require doeff-hy.macros [defp <-])
+(require doeff-hy.handle [defhandler])
+(import doeff [EffectBase WithHandler run :as doeff-run])
+(import doeff_core_effects [state])
+(import doeff_core_effects.scheduler [scheduled])
+(import dataclasses [dataclass])
+
+(defclass [(dataclass :frozen True)] Ping [EffectBase])
+
+(defhandler no-param-handler
+  "No params handler docs."
+  (Ping []
+    (resume "plain")))
+
+(defhandler param-handler [prefix]
+  "Param handler docs."
+  (Ping []
+    (resume (+ prefix ":plain"))))
+
+(defhandler lazy-doc-handler
+  "Lazy handler docs."
+  (lazy-val msg "lazy")
+  (Ping []
+    (resume msg)))
+
+(defp body {:post [(: % str)]}
+  (<- value (Ping))
+  value)
+
+(setv no-param-result
+  (doeff-run (scheduled (no-param-handler body))))
+
+(setv param-instance (param-handler "x"))
+(setv param-result
+  (doeff-run (scheduled (param-instance body))))
+
+(setv lazy-result
+  (doeff-run (scheduled (WithHandler (state) (lazy-doc-handler body)))))
+"""
+    mod = _hy_eval_in_module(code, "_test_defhandler_docstring")
+    try:
+        assert mod.no_param_handler.__doc__ == "No params handler docs."
+        assert mod.param_handler.__doc__ == "Param handler docs."
+        assert mod.param_instance.__doc__ == "Param handler docs."
+        assert mod.lazy_doc_handler.__doc__ == "Lazy handler docs."
+        assert mod.no_param_result == "plain"
+        assert mod.param_result == "x:plain"
+        assert mod.lazy_result == "lazy"
+
+        body = str(mod.param_handler.__doeff_body__)
+        assert "Param handler docs." not in body
+        assert "Ping" in body
+    finally:
+        del sys.modules["_test_defhandler_docstring"]


### PR DESCRIPTION
## Summary
- Teach `defhandler` to treat an optional string literal after params or name as a docstring, not as a handler clause.
- Set the docstring on both parameterized handler factories and returned handler functions.
- Keep `__doeff_body__` focused on handler clauses so docstrings do not interfere with `lazy-val` / `lazy-var` extraction or handler introspection.

## Validation
- `git diff --check`
- `UV_CACHE_DIR=/private/tmp/uv-cache-doeff uv run --python /opt/homebrew/bin/python3.12 ruff check packages/doeff-hy/tests/test_defhandler_docstring.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-doeff uv run --python /opt/homebrew/bin/python3.12 pytest packages/doeff-hy/tests/test_defhandler_docstring.py packages/doeff-hy/tests/test_lazy_and_threading.py -q`