### PR TITLE
docs(conductor): amend ADR 0001 + add workflow orchestration spec

### DIFF
--- a/packages/doeff-conductor/docs/adr-0001-workflow-dsl-and-attention-tiers.md
+++ b/packages/doeff-conductor/docs/adr-0001-workflow-dsl-and-attention-tiers.md
@@ -1,0 +1,440 @@
+# ADR 0001 (doeff-conductor) — Hy workflow DSL, schema-enforced agent boundary, and attention-tier review routing
+
+- **Status:** Proposed 2026-06-10; amended same day after a design session
+  with the maintainer (layer boundaries, profiles, DSL closure, L2 algebra,
+  workspace/medium model, overseer contract, no-backcompat policy). This
+  file is the implementation brief for agents — it is self-contained, you
+  do NOT need the originating conversation.
+- **Companion spec:** [`spec-workflow-orchestration.md`](spec-workflow-orchestration.md)
+  holds the detailed contracts (L2 signatures, DSL grammar, binding
+  resolution, validation rules). This ADR records decisions and rationale;
+  the spec records contracts. The ADR wins on conflict.
+- **Goal:** replace Claude Code's built-in `Workflow` tool (a sandboxed JS DSL
+  that can only spawn *Claude* subagents — the most expensive tokens) with a
+  doeff-conductor-native orchestration layer whose **workers are interchangeable
+  (Codex first), whose control flow is compiled and validated before any token
+  is spent, and whose review/verification load is routed through budgeted
+  attention tiers** instead of "the expensive model reads everything".
+
+## Context
+
+### What is being replaced
+
+Claude Code's `Workflow` tool executes a plain-JS script in a sandbox with
+injected primitives. Its contract (which WORKS and must be preserved, not
+discarded):
+
+- `agent(prompt, {schema, label, phase})` — spawn one worker; when `schema`
+  (JSON Schema) is given, the worker's final output is **validated structured
+  data, enforced at the call boundary** (the worker retries on mismatch);
+  returns the parsed object.
+- `parallel([thunks])` — barrier; `pipeline(items, ...stages)` — per-item
+  flow without barriers; `phase(title)` — progress grouping; `budget` —
+  token budget tracking.
+- **Replay resume**: re-running a script returns cached results for the
+  longest unchanged prefix of `agent()` calls, keyed by `(prompt, opts)`.
+  To make this sound, the sandbox *bans* nondeterminism syntactically:
+  no `Date.now()`, no `Math.random()`, no filesystem, `meta` must be a pure
+  literal.
+- Failure model: a failed/skipped agent resolves to `null` (callers
+  `.filter(Boolean)`) — i.e. silent-ish drops.
+
+Reference implementation to port (a real production run, 5 parallel
+implementers → compile-reconcile → 2 test writers → gate loop → 4 adversarial
+reviewers):
+`/Users/s22625/.claude/projects/-Users-s22625-repos-agent-control-plane/3911089d-cc6c-484c-ab7c-4f9a71de723d/workflows/scripts/k2-k3-merge-failure-routing-wf_158874ac-ae0.js`
+Use it as the pilot port and the acceptance benchmark for the DSL's
+expressiveness.
+
+### Why doeff is the right substrate
+
+The JS sandbox **fakes by prohibition** what an effect system provides **by
+construction**:
+
+- Nondeterminism (agent calls, clock, fs, subprocess) becomes *declared
+  effects*; the program between effects is pure, so replay/durable resume
+  falls out of the effect log instead of syntax bans.
+- Handlers make workers interchangeable: Codex / Claude / Gemini /
+  **stub** — so orchestration logic gets *unit tests that burn zero tokens*
+  (impossible with the JS tool).
+- `Try`-style typed failure replaces silent `null` drops: every branch's
+  failure path must be handled explicitly (fail-fast philosophy).
+- Hy macros give **compile-time validation of the workflow graph** — an
+  LLM-written workflow fails at expansion time (free) instead of mid-run
+  after burning agents.
+
+### Why "router by verification cost", not "review everything"
+
+The maintainer's concern: if the expensive model (Claude) conducts cheap
+workers (Codex), it ends up reviewing all their work — the cost moves, it
+doesn't shrink. The resolution adopted here:
+
+1. Delegation pays only where **verification ≪ generation**. Tasks are
+   therefore classified by *verification class*, a required field:
+   - `mechanical` — verified by deterministic gates (build/test/lint/golden).
+     Delegate fully; nobody reads the diff.
+   - `test-verifiable` — acceptance tests are part of the task spec; passing
+     them IS the review.
+   - `semantic` — verification requires re-deriving the work (subtle
+     invariants). **Reviewing properly costs as much as writing — route to
+     the expensive tier to WRITE, or pin with property tests first.**
+2. Review itself is a tiered, budgeted resource ("attention tiers"):
+
+   | Tier | Reviewer | Cost | Budgeting |
+   |---|---|---|---|
+   | 0 | deterministic gates (build, tests, linters, schema checks) | ~0 | always-on, exhaustive |
+   | 1 | cheap-model reviewers (Codex) emitting **structured verdicts** | low | bounded attempts per item |
+   | 2 | expensive model (Claude) adjudicating *verdicts*, not transcripts | high | explicit budget; sees only BLOCKERs, tier-1 disagreements, and calibration samples |
+   | 3 | human | scarcest | gate queue with stakes/priority metadata |
+
+   Rules (the "closure law", borrowed from agent-control-plane ADR 0008 —
+   see `~/repos/agent-control-plane/docs/adr/0008-*.md` for the prior art):
+   - Every tier-N review terminates in exactly one of: a verdict, an
+     escalation to tier N+1, or budget-exhausted → an open gate at tier N+1.
+     Never a silent drop.
+   - **Disagreement routes up** (never majority-voted away when stakes are
+     high). Cross-provider review is preferred (error modes decorrelate).
+   - **Calibration sampling**: tier N+1 audits a random % of tier-N PASSes;
+     the rate per lane is adjusted by observed escape rate (level-triggered).
+     Without this, cheap tiers drift into rubber-stamping.
+   - **Compile-down ratchet**: every escape that reaches tier N+1 must
+     produce a new tier-0 check (lint rule / property test) or a tier-1
+     prompt improvement. Expensive attention is an *investment that compiles
+     downward*, so total review demand decreases monotonically.
+
+## Decision
+
+### D1 — `agent!` effect with schema-enforced results
+
+A conductor workflow invokes workers only through an `agent!` effect:
+prompt, result JSON-schema (or pydantic model), a **semantic profile name**
+(a capability tier such as `:cheap-coder` / `:frontier-reviewer` — never a
+concrete agent kind or an account; the project env binds the name to
+adapter+model and the user env completes it with auth. `stub` is NOT a
+profile but an interpreter choice reachable only via the `validate` verb
+and tests), workspace, label/phase, and the
+**verification class** (required, always explicit, never inherited or
+defaulted). The handler (doeff-agents `LaunchConfig`
+sessions in tmux) launches the worker, obtains the worker's result through
+a **handler-private result channel** — e.g. an in-workdir result file as
+agentd's `await_result` already does (`.agentd-result.json`), native
+structured output (`codex exec --output-last-message`, `claude -p
+--output-format json`), or an MCP result tool. The mechanism is NEVER part
+of the contract and MUST work inside the worker's sandbox boundary (no
+out-of-workspace writes). The handler validates the result against the
+schema and **retries with the validation error appended** (bounded, e.g. 3)
+before failing typed. The validated object is the effect's return value:
+`agent!` awaits the worker and returns the artifact — there is no separate
+fetch effect at the workflow boundary, and concurrency is structural
+(parallel/pipeline forms compile to `Gather`), so workflow code never
+holds session handles or futures. This reproduces the JS
+`agent(prompt,{schema})` contract and agentd's `await_result` pattern.
+
+### D2 — Hy macro DSL: a closed vocabulary with expansion-time validation
+
+The DSL surface is **closed and complete**: `defworkflow (:params :roles)`,
+`defphase`, `agent!`, `gate!`, `parallel (:quorum)`, `parallel-for`,
+`pipeline` (v1-open, see spec §11), `loop (:max :until)`, result bindings
+(`<-`), explicit `time!`/`random!` effects, and pure glue functions.
+Nothing else. In particular, **none of doeff's binding machinery surfaces
+in the DSL** — no `ask`, no `Local`, no handler/interpreter access, no
+session handles or futures. Each carrier is replaced by a DSL-native
+concept: kleisli args → `:params`; effect payloads → form fields;
+`Local` → the flat `:roles` table + call-site overrides; interpreter env →
+system-side verbs; `ask` → name references resolved by the environment.
+
+**Binding locality (no dynamic scoping):** every `agent!`'s binding is
+derivable from its call site plus the flat top-of-file `:roles` table.
+This is what makes the DSL writable by LLM authors and totally checkable.
+
+**Glue purity by construction:** glue runs as plain (non-kleisli)
+functions, so it structurally cannot launch agents or touch the
+environment. The residual hole — raw Python nondeterminism that is not an
+effect — is closed by a **validator** (doeff-linter, ERROR severity, no
+baselines) banning `datetime.now`/`random`/`open`/network/subprocess/
+non-allowlisted imports in workflow modules, each diagnostic naming the
+replacement (`time!`, `random!`, `gate!`, a `:params` entry).
+
+Macros compile to a static DAG of doeff Programs. Expansion-time checks
+(all free, before any token is spent):
+
+- phase declarations vs uses match; no orphan nodes; joins well-formed;
+- every `agent!` carries a schema and an **explicit** verification class;
+- role references resolve against the `:roles` table;
+- **file-disjointness** between parallel same-workspace editors (declared
+  `:files` sets must not intersect) — or each writer takes its own
+  workspace + a downstream `merge!` node (D5);
+- every parallel branch's failure path is handled (`Try`), and every node
+  terminates in a gate, an artifact, or an escalation — the closure law as
+  a compile check;
+- **quorum typing**: `(parallel :quorum k)` with k < branch count makes the
+  bindings `Try`-typed; direct dereference is an expansion error, and
+  tolerated losses are journaled and surfaced, never silent;
+- dataflow well-formedness (references defined; unconsumed results
+  flagged); budget annotations parse and sum;
+- the nondeterminism validator passes on the containing module.
+
+Keep the JS tool's load-bearing constraints: static graph skeleton, pure
+metadata, effect-boundary caching for replay resume — with the cache key
+defined by the **result-distribution criterion**: prompt, schema, and the
+resolved identity fingerprint (adapter kind, model) enter the key;
+substrate never does (see D7).
+
+### D3 — Deterministic gates are plain steps, not agents
+
+build/test/lint/schema-parity gates run as subprocess effects (no LLM).
+Gate output is structured (pass/fail + log path). Logs are `tee`'d to
+files, never piped through `head`/`tail` (SIGPIPE truncation corrupts
+builds — maintainer house rule).
+
+### D4 — Review routing and the conductor protocol
+
+- Tier-1 reviewers are ordinary `agent!` calls returning a structured
+  verdict schema: `{verdict: PASS|CHANGES_REQUESTED, findings: [{title,
+  severity: BLOCKER|MAJOR|MINOR, detail, file}]}`.
+- Tier routing is implemented by the **router**, a pure injected function
+  `route(verification-class, stakes, remaining-budget) → profile-name`
+  supplying the default profile for any `agent!` without an explicit
+  `:profile` override; the conductor passes the remaining budget in, the
+  router holds no state.
+- The conductor (tier 2 — the **overseer**, typically a Claude session
+  driving this library; see D9) receives only: BLOCKER findings, tier-1
+  disagreements, and the calibration sample. It never reads raw transcripts
+  in the normal path.
+- Tier-3 (human) gates carry stakes metadata (verification class, blast
+  radius, reversibility, novelty) so the human queue can be prioritized.
+- Budget pressure degrades explicitly (lower sampling rate, defer
+  low-stakes items, batch) — never silently skips a review.
+
+### D5 — Workspace model, join strategy, and medium families
+
+Three nouns, strictly separated: a **site** is the execution host
+(1 per run in v1, interpreter-bound, system-only); a **workspace** is the
+logical unit of mutable state — for the git family, `(repo, ref)` — and is
+a first-class DSL dataflow value (`workspace!` creates, `agent!`
+consumes/returns, `merge!` reconciles, `gate!` runs on one); a **worktree**
+is the site-local materialization of a workspace and is L1-private —
+paths never surface. The workspace's portable identity is the *ref*, which
+is why multi-site execution later is a pure handler extension (clone +
+push/fetch as transport) with zero DSL change. Multi-repo workflows are a
+v1 requirement (the k2-k3 reference's TASK D edits a second repository).
+
+Default isolation is **workspace-per-task → branch → deterministic
+`merge!` node → tier-0 gate on the merged tree**; merge conflicts bounce
+back as fix tasks. Shared-workspace parallel editing is allowed only with
+the compile-checked disjoint `:files` declaration (D2). These are the two
+instances of the general rule the DSL core owns: concurrent mutators of
+shared state declare either **fork/reconcile** or a **statically
+partitioned write set**.
+
+**The DSL core is medium-agnostic.** git+worktree+merge is the *first
+medium family* implementing the fork/reconcile contract; core vocabulary
+and checks must not depend on a medium family's nouns. v1 implements the
+git family only — a scope decision, not a structural constraint. New media
+(document vaults, asset directories) arrive as new closed vocabulary
+families added by system designers, never by authors. The existing
+`CreateWorktree` effect name leaks the materialization noun and is renamed
+into the workspace vocabulary in C4.
+
+### D6 — Layer boundaries and the L2 session algebra
+
+```
+L3  intent vocabulary    agent! / gate! / workspace! / merge!
+L2  session algebra      Launch / AwaitResult / FollowUp / Stop / Release
+L1  substrate handlers   tmux | opencode | zellij | ssh | stub
+L0  identity environment profile registry, auth homes, model bindings
+```
+
+**Noun-ownership rule:** a layer's vocabulary never mentions a lower
+layer's nouns. Session handles are opaque (`session_id` only —
+`SessionHandle.pane_id` is removed; substrate nouns live in L1-private
+state). The L2 core is **total** (every substrate implements it):
+`Launch` takes a deterministic session name derived from
+`(run-id, node-id, attempt)` and is **idempotent** (already-exists →
+re-adopt; agentd supervises tmux sessions across conductor restarts);
+`AwaitResult` blocks and returns
+`{status: exited|awaiting-input|timed-out, exit-code?, result|absent}` in
+one journal entry (agentd's `session.await_result` generalized — no
+separate fetch effect, no race window); `FollowUp` is the total
+continuation primitive (in-session for interactive substrates,
+relaunch-with-context for batch ones). Status vocabulary is exactly
+`starting|running|awaiting-input|exited` — **success is decided solely by
+the result artifact**, never by session heuristics. Human steering
+(`AttachTTY`/`CaptureTranscript`/`Steer`) is capability-gated, ops-only,
+and not emittable from the DSL. Capability names (`interactive`,
+`durable-sessions`) are declared by substrates and checked at plan time.
+Full signatures and handler obligations: spec §5.
+
+### D7 — Binding model: one resolver, logged fingerprints, plan-time resolution
+
+Five configuration axes — intent / agent kind / identity / substrate /
+persona. "Profile" names the (agent kind + identity) bundle; substrate is
+runtime-scoped (one site per run, interpreter-bound); persona is
+intent-side. Per `agent!`, **exactly one resolver** evaluates the fixed
+cascade `explicit field > :roles entry > router default > interpreter
+env` — no ask-with-default fallbacks anywhere. The **resolved fingerprint**
+(adapter kind, model — the result-distribution-affecting subset) is
+journaled; cache hits require fingerprint match, so editing a profile's
+definition between resume invalidates correctly while substrate swaps do
+not. Before any worker starts, the conductor produces the **binding plan**
+(all static nodes resolved: profiles exist, capabilities satisfied,
+budgets sum) for overseer approval — resolve early, execute late.
+
+### D8 — Verbs, not interpreters
+
+Interpretation selection is system-internal: author- and overseer-facing
+interfaces are verb-shaped and never accept an interpreter, handler stack,
+or backend name. Named interpreter constants back the verbs:
+`conductor plan` = record/estimate interpretation (emits the binding
+plan); `conductor validate` = **stub scenario simulation** (zero tokens;
+deterministic failure scripts drive every branch, making the closure-law
+test a CI-runnable model check, and the kill-and-resume test runs under
+the same interpretation); `conductor run` = production. The stub is a
+branch-exploring simulator, not a happy-path mock.
+
+### D9 — Overseer contract
+
+Every workflow run has an **overseer** (an agent or a human) who must be
+able to track progress and resume on failure. Progress is contract, not
+telemetry: journal-materialized, delta-oriented views (`ps/show/watch`).
+Every parked failure and tier-3 escalation is an **open gate** carrying
+stakes metadata and closure-preserving options (each option states its
+outcome for the whole run — ADR 0008 R2b discipline; options include
+retry-with-feedback, edit-and-resume, justified-skip, abort). Resume is an
+overseer verb backed by D7 fingerprint caching and D6 session
+re-adoption. Tolerated degradation (quorum losses, budget downgrades,
+deferred reviews) always surfaces in the run report. The closure law is
+what bounds the overseer's load: no silently-wedged state exists to hunt
+for.
+
+## Implementation plan (stages; each lands with tests)
+
+- **C1 — agent boundary (L2 core + `agent!`)**: implement the D6 algebra
+  on doeff-agents' existing fine-grained effect layer, **wrapping agentd's
+  `session.await_result`** (already implemented: result file, expected
+  schema, retry counters) rather than building from scratch. `agent!`
+  handler = Launch → AwaitResult → validate → bounded FollowUp retry →
+  typed failure; result channel handler-private per D1; Codex adapter via
+  `--output-last-message`, Claude via headless structured output, tmux
+  interactive via in-workdir reserved path — start with the mechanisms
+  deliberately different per adapter (cheapest proof the abstraction
+  holds). Stub handler is **scenario-driven** from day one. Done: a unit
+  test runs a 2-node workflow entirely on stubs (incl. a failure
+  scenario); an integration test runs one real Codex worker returning
+  schema-valid JSON. This stage also deletes the condemned capture paths
+  (see "Condemned existing code").
+- **C2 — DSL + replay keying (co-designed)**: the closed vocabulary of D2
+  in doeff-hy, **including** `:roles`, quorum typing, `time!`/`random!`,
+  the nondeterminism validator, and the cache-key/fingerprint design from
+  D7 — keying is settled here, not retrofitted in C3, because it
+  constrains what the macros may emit. Expansion-time checks ship with
+  failing-case tests (each rule has a test proving it rejects). Done: the
+  k2-k3 reference JS script's structure expresses 1:1 (5-way parallel,
+  fixer loop ≤3, test writers, gate loop ≤3, 4-way review fan-out) — note
+  the gate phase decomposes into `gate!` (Exec) + conditional fixer
+  `agent!`, fixing the reference's waste of an LLM agent on running
+  builds.
+- **C3 — replay/durability**: effect-log-backed resume; longest-valid-
+  prefix caching gated on resolved fingerprints (D7); idempotent Launch
+  re-adoption (D6). A test kills a run mid-phase and resumes without
+  re-running completed agents, under the stub interpretation.
+- **C4 — gates + workspace family**: `Exec` gate steps with structured
+  results (tee'd full logs as mechanism); the git medium family —
+  `workspace!`/`merge!`/conflict bounce-back, renaming the worktree-noun
+  effects per D5; multi-repo workspaces. Done: parallel 3-task demo
+  merging into a green gate, plus a two-repo demo.
+- **C5 — attention tiers**: verdict schema, the pure router (D4/D7),
+  disagreement-routes-up, per-tier bounded budgets with exhaustion→gate;
+  calibration v1 = manually-set sampling rates + escape recording only
+  (autonomous rate adjustment deferred); a review-routing demo where only
+  BLOCKERs reach the tier-2 callback. Done-condition includes the
+  closure-law model check (D8): the stub scenario suite proves no
+  reachable terminal state lacks a verdict/escalation/gate.
+- **C6 — verbs + overseer surfaces**: `conductor env describe` (the
+  author's discoverable vocabulary: profiles, roles conventions, router
+  defaults), `conductor plan` (binding plan for overseer approval),
+  `conductor validate` (stub scenario runs); gate queue and delta-oriented
+  progress views per D9.
+- **C7 — pilot**: port the k2-k3 reference script and run it with Codex
+  workers against a scratch repo. Measure: (a) fraction of items
+  terminating at tier ≤1, (b) tier-2 token spend vs an all-Claude
+  baseline, (c) calibration escape rate. Notes into `docs/pilot-k2-k3.md`.
+
+## Condemned existing code — mark-for-fix (delete outright, no deprecation)
+
+Policy: **no backward compatibility, no deprecation periods, no migration
+ratchets.** A wrong contract is deleted and every consumer is rewritten in
+the same change. Limbo states ("legacy" extras, `deprecated` markers kept
+alive — e.g. doeff-agentic's `[legacy]` optional dependency on
+doeff-agents) are themselves violations: resolve them by decision (promote
+to a real backend or delete), never by deprecation. (Note: the
+"compile-down ratchet" in the tier rules above is a review-economics
+mechanism — escapes become new tier-0 checks — and has nothing to do with
+preserving legacy code; it is the only "ratchet" in this design.)
+
+The boundary that defines the violation class: **terminal capture is a
+human-facing channel and an L1-private mechanism.** A tmux adapter may use
+TTY heuristics internally to detect session liveness/awaiting-input (a TTY
+has no other channel). What is condemned is any **domain fact or
+workflow-facing result derived from captured terminal text** — the only
+worker→workflow data channel is the schema-validated result artifact.
+
+### A. Capture→domain-fact sniffing (delete)
+
+| Where | What |
+|---|---|
+| `doeff-agents/src/doeff_agents/monitor.py:253-261` | `PR_URL_PATTERN` / `detect_pr_url` — regex over screen text producing a domain fact |
+| `doeff-agents/src/doeff_agents/monitor.py:42` | `MonitorState.pr_url` |
+| `doeff-agents/src/doeff_agents/effects/agent.py:72,102,116,139,182,205` | `Observation.pr_url` / `AgentSessionSnapshot.pr_url` (+ serialization) — domain noun inside the session vocabulary |
+| `doeff-agents/src/doeff_agents/session.py:226,258-262` | `on_pr_detected` callback wiring |
+| `doeff-agents/src/doeff_agents/programs.py:78,198-233,466-497` | program results carrying observation-derived `pr_url` |
+| `doeff-agents/src/doeff_agents/handlers/production.py:413-418,427-434,451,565,575,598` | sniffing + propagation in the tmux handler |
+| `doeff-agents/src/doeff_agents/handlers/daemon.py:144`, `handlers/testing.py:309` | propagation |
+
+A PR URL must come from the typed result of the effect that created the PR
+(`CreatePR` / gh output) or from the worker's result artifact — never from
+screen text. (`doeff-conductor`'s issue-frontmatter `pr_url` fields are fed
+by `CreatePR`'s typed result and are NOT part of this list.)
+
+### B. Captured text as the workflow-facing result (replace the contract)
+
+| Where | What |
+|---|---|
+| `doeff-conductor/src/doeff_conductor/effects/agent.py` (`RunAgent`) | contract "Yields: str (agent output)" — a rendered text blob as the workflow result; superseded by `agent!` |
+| `doeff-conductor/src/doeff_conductor/handlers/agent_handler.py:201-221` | `handle_capture_output` joining `[role] content` as the result |
+| `doeff-conductor` templates consuming `RunAgent` text (`basic_pr`, `enforced_pr`, `reviewed_pr`, `multi_agent`) | rewrite onto `agent!` (schema-validated artifact) |
+| `doeff-agentic` `RunAgentEffect` result contract | same text-blob shape; superseded by `agent!` |
+| `doeff-conductor/src/doeff_conductor/effects/agent.py` (`CaptureOutput`) | as a data channel: condemned. Survives only as the ops/human transcript capability, never yielded by workflow code |
+
+### C. Success/failure judged from screen text
+
+`monitor.py detect_status`'s DONE/FAILED heuristics must not be
+workflow-facing truth: a session's terminal fact is `exited` (+ exit code
+where available); **success is decided solely by the result artifact**
+(present + schema-valid). Text heuristics survive only inside the L1 tmux
+adapter for liveness/awaiting-input detection.
+
+## Non-goals / cautions
+
+- Do not rebuild orch: doeff-conductor already owns workspaces/DAG; orch
+  remains the interactive ops tool (`capture`/`send` steering, now the
+  capability-gated `AttachTTY`/`CaptureTranscript`/`Steer` surface). A
+  later bridge is possible, not required.
+- Do not let the DSL grow dynamic graph construction in v1 — it breaks
+  replay identity; static skeleton first. `pipeline` with runtime-sized
+  fan-out is explicitly OPEN (spec §11): decide it together with the C2
+  keying design or defer — static `parallel`/`parallel-for` cover the
+  pilot.
+- v1 scope cuts (structure permits, scope defers): one site per run
+  (multi-site later via git-ref transport, no DSL change); the git medium
+  family only (no second medium); manual calibration rates (no autonomous
+  adjustment).
+- The maintainer's house rules apply: this repo is upstream — verify
+  locally (tests green) before merging to main; never pipe build output
+  through head/tail; fail fast, no silent fallbacks (no bare `except: pass`,
+  no defaulting on schema mismatch).
+- Prior art to read before implementing: `README.md` + `docs/api.md` in
+  this package; `doeff-agents` README (session_scope/LaunchConfig/
+  monitor_session); doeff-hy macro conventions (`defk`/`defhandler`/`Try`);
+  agent-control-plane ADR 0008 (closure law) and its `MergeAttempts`
+  bounded-budget pattern (durable, reap-safe counters).

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -1,0 +1,479 @@
+# doeff-conductor — Workflow Orchestration Specification
+
+- **Status:** Draft 2026-06-10, companion to
+  [ADR 0001](adr-0001-workflow-dsl-and-attention-tiers.md). The ADR records
+  *decisions and their rationale*; this spec records the *contracts* — layer
+  boundaries, the L2 session algebra, the DSL grammar, binding resolution,
+  and validation rules. Where they disagree, the ADR's Decision section wins
+  and this spec must be fixed.
+- **Policy (binding, from ADR 0001):** no backward compatibility, no
+  deprecation periods, no migration ratchets. Wrong contracts are deleted
+  and their consumers rewritten in the same change.
+
+## 1. Roles and surfaces
+
+Three parties interact with a workflow. Each sees a different surface and
+none may reach below it:
+
+| Party | Surface | Never sees |
+|---|---|---|
+| **Author** — an LLM agent writing a workflow on demand | the DSL (closed vocabulary, §4); expansion/validation errors; `conductor env describe` output | effects machinery, handler stacks, interpreters, account names, substrate names, filesystem paths |
+| **Overseer** — the agent or human responsible for a run | verbs: `plan` (binding table, budget, capability check) → approve; progress views; the gate queue; `resume` | interpreter names, session internals (except via capability-gated ops escape hatches: attach/transcript/steer) |
+| **System** — conductor runtime + environment config | everything: interpreter constants, profile registry, substrate handlers, stub scenarios, calibration state | — |
+
+Interfaces are **verb-shaped**. No author- or overseer-facing interface
+accepts an interpreter, handler stack, or backend name as an argument.
+Interpretation selection is system-internal (§7).
+
+## 2. Layer model and noun ownership
+
+```
+L3  intent vocabulary    agent! / gate! / workspace! / merge!  — what the DSL compiles to
+L2  session algebra      Launch / AwaitResult / FollowUp / Stop / Release  (opaque handles)
+L1  substrate handlers   tmux | opencode | zellij | ssh | stub  — interpret L2
+L0  identity environment profile registry (ask-resolved), auth homes, model bindings
+```
+
+**Noun-ownership rule:** a layer's vocabulary must not mention a lower
+layer's nouns. L3 does not mention sessions. L2 does not mention panes,
+HTTP, or terminal text. Substrate nouns (`pane_id`, server URLs, capture
+text) live only in L1 handler-private state, keyed by the opaque
+`session_id`. The current `SessionHandle.pane_id` field violates this and
+is removed: handles carry `session_id` only.
+
+Five configuration axes, and where each binds:
+
+| Axis | Scope | Mechanism |
+|---|---|---|
+| (A) intent: prompt, schema, verification class, workspace topology | task — author writes it | DSL form fields (effect payload) |
+| (B) agent kind (claude/codex/gemini adapter) | bundled into profile | resolved from profile at handle time |
+| (C) identity: account, auth home, model | bundled into profile | profile registry (L0), env-completed |
+| (D) execution substrate / site | runtime — one site per run (v1) | interpreter composition, system-side |
+| (E) persona (role prompt) | task | `:persona` field, intent-side |
+
+The word **profile** is reserved for (B)+(C). The old `RunAgent.profile`
+(persona) meaning is renamed. Call-site defaults for agent kind (e.g.
+`agent_type: str = "claude"`) are abolished — identity comes only from
+profile resolution; defaulting at a call site is a fail-fast violation.
+
+## 3. Profiles, roles, and binding resolution
+
+### 3.1 Profiles are semantic names
+
+Workflows reference **capability tiers**, never accounts or concrete agent
+kinds: `:cheap-coder`, `:cheap-reviewer`, `:frontier-reviewer`,
+`:frontier-author`. The environment binds names in two stages, both outside
+the DSL:
+
+- the **project env** maps semantic name → adapter + model
+  (`cheap-coder → codex / gpt-x`);
+- the **user env** completes it with identity (auth home, e.g. a
+  `CODEX_HOME`); secrets never appear in repo config.
+
+`stub` is NOT a profile; it is an interpreter choice reachable only through
+the `validate` verb and the test suite (§7).
+
+### 3.2 The router
+
+`route(verification-class, stakes, remaining-budget) → profile-name` is a
+**pure function**, injected as environment policy. It supplies the default
+profile for any `agent!` that does not override; budget is passed in by the
+conductor, the router holds no state. The DSL call-site `:profile` field is
+an explicit override and is locally visible.
+
+### 3.3 Binding cascade — single resolver, logged fingerprint
+
+Per `agent!` node, exactly one resolver evaluates, in fixed precedence:
+
+```
+explicit call-site field  >  role entry (workflow :roles table)
+                          >  router default  >  interpreter env default
+```
+
+Rules:
+
+- Resolution happens in ONE function. No ask-with-default fallbacks
+  sprinkled at call sites or in handlers.
+- The **resolved fingerprint** (the result-distribution-affecting subset:
+  adapter kind, model, schema, prompt) is recorded in the effect journal.
+  Cache hits on resume require fingerprint match — a profile *name* whose
+  definition changed does not produce stale hits (§9).
+- **Verification class is never resolved** — it is task-intrinsic, required
+  and explicit on every `agent!`, never inherited from a role, never
+  defaulted. (Misclassification is audited by calibration sampling, ADR D4.)
+
+### 3.4 Launch-time binding plan — resolve early, execute late
+
+Before any worker starts, the conductor resolves the cascade for every
+static `agent!` node and validates:
+
+- every profile name resolves in the registry;
+- required capabilities (e.g. `interactive`, `durable-sessions`) are
+  provided by the run's site/substrate;
+- resolved budgets sum within the declared budget annotations;
+- workspace repo names resolve.
+
+The output is the **binding plan** shown to the overseer for approval:
+"5× cheap-coder (tmux), 2× frontier-reviewer, estimated budget X,
+capabilities satisfied".
+
+## 4. The DSL
+
+### 4.1 Principles
+
+1. **Closed vocabulary.** The DSL surfaces none of doeff's binding
+   machinery — no `ask`, no `Local`, no handlers, no interpreters, no
+   session handles, no futures. Every binding carrier is replaced by a
+   DSL-native concept (params, form fields, roles table, name references).
+2. **Local readability.** Every `agent!` node's binding must be derivable
+   from (a) the call site and (b) the flat `:roles` table at the top of the
+   file. No dynamic scoping, no nesting, no shadowing — an LLM author,
+   a reviewer, and the expansion-time checker all reason locally.
+3. **Intrinsic facts only.** The workflow text contains task-intrinsic
+   facts (prompts, schemas, classes, topology, relative budget weights).
+   Everything environment-contingent (profile definitions, router policy,
+   substrate, paths, auth, absolute budgets) enters by name reference.
+   Portability test: the file must keep its meaning in any conforming
+   environment.
+4. **Concurrency is structural.** `parallel` / `pipeline` forms compile to
+   `Gather`; `agent!` is one effect that awaits the worker and returns the
+   validated artifact. Authors never manage asynchrony.
+5. **Medium-agnostic core.** The core (workflow/phase/agent!/gate!/control
+   flow/bindings/glue) mentions no version-control nouns. git+worktree+
+   merge is the first *medium family* (§6); core vocabulary and checks must
+   not depend on a medium family's nouns.
+
+### 4.2 Grammar
+
+```hy
+(defworkflow NAME
+  :params {param-name schema ...}        ;; supplied at launch, schema-validated
+  :roles  {role-name {:profile semantic-name
+                      :retry   n
+                      :persona name} ...} ;; flat table; the only sharing mechanism
+  body...)
+
+(defphase NAME body...)                   ;; progress grouping; matched against uses
+
+(agent! :role ROLE                        ;; row in :roles
+        :class CLASS                      ;; REQUIRED, always explicit, never inherited
+        :prompt EXPR                      ;; pure glue expression
+        :schema SCHEMA                    ;; REQUIRED (JSON Schema / pydantic)
+        :workspace WS                     ;; optional; a workspace value (§6)
+        :files #{...}                     ;; required iff sharing a workspace
+                                          ;;   with another parallel writer
+        :profile NAME                     ;; optional explicit override
+        :persona NAME                     ;; optional
+        :retry N)                         ;; optional override
+  ;; ⇒ awaits the worker, returns the schema-validated artifact
+  ;;   (plus its workspace ref when a workspace was given)
+
+(gate!  :cmd STR :workspace WS [:timeout N])
+  ;; deterministic step, no LLM ⇒ {exit-code, log-path}; ADR D3
+
+(parallel [:quorum K] branch...)          ;; default quorum = all branches
+(parallel-for [x LITERAL-SEQ] body)       ;; homogeneous static fan-out
+(pipeline ...)                            ;; OPEN for v1 — see §11
+(loop :max N :until PRED body)            ;; bounded, statically declared
+
+(<- NAME expr)                            ;; result binding
+(<- [a b c] expr)                         ;; destructuring bind
+
+(time!) (random! spec)                    ;; explicit, journaled effects
+
+;; plus: pure glue functions (prompt builders, predicates, filters)
+```
+
+### 4.3 Failure semantics
+
+Typed, explicit, never silent (replaces the JS tool's `null` +
+`filter(Boolean)`):
+
+- `parallel` (default, quorum = all): bindings are plain values. Any branch
+  failure fails the whole form; the failure path must be handled — retry,
+  branch abort, or park as an overseer gate — and the expansion-time
+  closure check requires one of these.
+- `(parallel :quorum k)` with k < total: bindings are `Try`-typed
+  (`Ok x | Err e`); direct field access on them is an expansion-time error,
+  forcing explicit handling (e.g. `(oks ...)` glue). Tolerated losses are
+  journaled and surfaced in the overseer's view — declared, not silent.
+  Below-quorum → typed failure of the form.
+- `agent!` failure (retry budget exhausted, awaiting-input under the
+  default policy, typed worker error): parks as an overseer gate whose
+  options are closure-preserving (each option states the outcome for the
+  whole run; cf. agent-control-plane ADR 0008 R2b).
+
+### 4.4 Glue code and nondeterminism
+
+Glue (prompt builders, predicates, transforms) is **pure Hy functions
+invoked as plain functions** — not kleisli, so they structurally cannot
+yield effects: no agent launches, no `ask`, no `Local`, by construction.
+
+The remaining hole — raw Python calls that are not effects — is closed by
+the **nondeterminism validator** (doeff-linter rule set over workflow
+modules):
+
+- ban `datetime.now` / `time.time` / `random.*` / `open` / network and
+  subprocess calls / non-allowlisted imports inside workflow modules;
+- each diagnostic names the replacement (`time!`, `random!`, `gate!`,
+  a `:params` entry);
+- severity is ERROR; there is no baseline and no allowlist-by-file.
+
+### 4.5 Expansion-time checks (complete list, all pre-token)
+
+1. phase declarations vs uses; no orphan nodes; joins well-formed;
+2. every `agent!` carries `:schema` and an explicit `:class`;
+3. role references resolve against the `:roles` table;
+4. shared-workspace parallel writers declare pairwise-disjoint `:files`,
+   OR each writer has its own workspace + a downstream `merge!`;
+5. closure law: every node and every failure path terminates in an
+   artifact, a verdict, an escalation, or a gate;
+6. quorum typing (§4.3): `Try`-typed bindings cannot be dereferenced
+   directly;
+7. budget annotations parse and sum;
+8. binding locality: no dynamic scoping constructs; bindings come only from
+   the `:roles` table and call-site fields;
+9. dataflow: every reference defined before use; unconsumed results are
+   flagged;
+10. nondeterminism validator (§4.4) over the containing module.
+
+### 4.6 Example — 4 parallel feature implementations
+
+```hy
+(defworkflow four-features
+  :params {:base-ref str}
+  :roles  {:implementer {:profile :cheap-coder :retry 3}}
+
+  (defphase Implement
+    (<- [auth search export i18n]
+        (parallel
+          (agent! :role :implementer :class :test-verifiable
+                  :workspace (workspace! :from base-ref)
+                  :prompt (impl-prompt "OAuth2 login") :schema AuthImplResult)
+          (agent! :role :implementer :class :test-verifiable
+                  :workspace (workspace! :from base-ref)
+                  :prompt (impl-prompt "full-text search") :schema SearchImplResult)
+          (agent! :role :implementer :class :test-verifiable
+                  :workspace (workspace! :from base-ref)
+                  :prompt (impl-prompt "CSV export") :schema ExportImplResult)
+          (agent! :role :implementer :class :test-verifiable
+                  :workspace (workspace! :from base-ref)
+                  :prompt (impl-prompt "i18n") :schema I18nImplResult))))
+
+  (defphase Merge
+    (<- merged (merge! :workspaces [(:workspace auth) (:workspace search)
+                                    (:workspace export) (:workspace i18n)]))
+    (gate! :workspace merged :cmd "cargo build && cargo test")))
+```
+
+## 5. L2 — the session algebra
+
+### 5.1 Core (total: every substrate must implement)
+
+```
+Launch      (spec)            → handle
+AwaitResult (handle, timeout) → Outcome
+FollowUp    (handle, message) → handle
+Stop        (handle, reason)  → ()        ;; idempotent abort
+Release     (handle)          → ()        ;; resource reclamation
+```
+
+- **`Launch`** — `spec` carries: a **deterministic session name** derived
+  from `(run-id, node-id, attempt)` (no randomness — required for replay
+  and re-adoption); the site-local workspace view (if any); adapter +
+  identity env from the resolved profile; the prompt envelope; lifecycle
+  and non-interactive policy. **Idempotent:** if a session with the derived
+  name already exists, the handler re-adopts it (level-triggered resume
+  safety; doeff-agentd is the supervising daemon for the tmux substrate).
+- **`AwaitResult`** — blocks until terminal / awaiting-input / timeout and
+  returns
+  `Outcome {status: exited | awaiting-input | timed-out, exit-code?, result: payload | absent}`.
+  One journal entry. This is agentd's `session.await_result` generalized to
+  a contract; the former Await/Fetch split is rejected (two journal entries
+  and a race window between exit and result flush).
+- **`FollowUp`** — the **total continuation primitive**: interactive
+  substrates send into the live session; batch substrates relaunch with
+  reconstructed context (adapter-private, e.g. CLI `--resume`). Used by the
+  L3 schema-retry loop. Returns a possibly-new handle.
+
+Status vocabulary is exactly `starting | running | awaiting-input |
+exited`. There is no session-level DONE/FAILED: **success is decided solely
+by the result artifact** (present + schema-valid + its own status fields).
+Terminal-text heuristics survive only inside the L1 tmux adapter for
+liveness/awaiting-input detection, and never produce domain facts or
+workflow-facing results (see ADR 0001 "Condemned existing code").
+
+### 5.2 The `agent!` handler is the composition proof
+
+```
+Launch → AwaitResult → schema-validate
+  absent/invalid → FollowUp(validation error appended) → AwaitResult …
+  (bounded by resolved :retry) → typed failure
+  valid → return artifact → Release
+```
+
+The distinction *absent* (worker produced nothing — retry says "report your
+result") vs *invalid* (present but schema-rejected — retry carries the
+validation errors) is preserved end to end, never collapsed.
+
+### 5.3 Result channel (handler-private)
+
+The contract is only "AwaitResult returns the result payload attributable
+to this session and attempt". Mechanisms are adapter-private and MUST work
+inside the worker's sandbox boundary (no out-of-workspace writes):
+
+- in-workdir reserved file (agentd: `.agentd-result.json`), mechanically
+  excluded by the conductor from merges and `:files` checks;
+- native structured output (`codex exec --output-last-message`,
+  `claude -p --output-format json`);
+- an MCP result tool exposed by the conductor (schema enforced at the
+  tool-call boundary).
+
+Handler obligations regardless of mechanism: attribution (correct session
+and attempt, never a stale prior-attempt result), atomicity (no
+partially-written payload observed), and absent-vs-invalid distinction.
+The prompt envelope splits accordingly: L3 contributes intent + schema +
+contract framing; L1 appends the mechanism instruction. **The journal
+records the L3 view only** — envelope materialization happens below the
+journaling boundary, so changing adapters does not invalidate caches.
+
+### 5.4 Ops capabilities (never DSL-emitted)
+
+```
+AttachTTY(handle)            requires capability: interactive
+CaptureTranscript(handle)    human-facing transcript rendering
+Steer(handle, message)       ops-initiated mid-run injection
+```
+
+These exist for the overseer's escape hatches (`conductor attach` etc.) and
+are reachable only from the ops CLI. Capability names (initial registry):
+`interactive`, `durable-sessions` (sessions survive conductor death;
+affects resume guarantees — `plan` warns when absent).
+
+### 5.5 Sibling site-bound families
+
+- **`Exec(cmd, workdir) → {exit-code, log-path}`** — deterministic gates
+  (ADR D3). The handler tees full output to the log file as mechanism
+  (never `head`/`tail` truncation); `gate!` compiles to this.
+- **Workspace family** (§6) — same-site co-location with sessions.
+
+## 6. Workspace and medium model
+
+### 6.1 Three nouns
+
+| Noun | Meaning | Multiplicity | Visibility |
+|---|---|---|---|
+| **site** | execution host (processes + filesystem) | 1 per run (v1) | system only (interpreter-bound) |
+| **workspace** | logical unit of mutable state; for the git family: `(repo, ref)` | many per run | first-class DSL value |
+| **worktree** | site-local materialization of a workspace | handler's business | nobody (L1-private) |
+
+Workspaces are dataflow values: `(workspace! :from ref)` creates one,
+`agent!` consumes and returns one, `merge!` combines several, `gate!` runs
+on one. Paths never appear. A workspace's portable identity is the **ref**;
+the worktree is a site-local cache — which is why multi-site later is a
+handler extension (clone + push/fetch as transport) with zero DSL change.
+
+Multi-repo is a v1 requirement (the k2-k3 reference's TASK D edits a second
+repository): `(workspace! :repo "name" :from ref)`, with repo names
+resolved by the environment.
+
+### 6.2 Medium families
+
+The general rule the core owns: **concurrent mutators of shared state must
+declare one of two disciplines** —
+
+1. **fork / reconcile** — isolated views + a deterministic reconcile node;
+   conflicts bounce back as fix tasks; or
+2. **write-set partition** — statically disjoint declared write sets on a
+   shared view.
+
+The git family implements both (worktree-per-task → branch → `merge!` →
+tier-0 gate; or shared workspace + `:files`). Other media (document vaults,
+asset directories, databases) would arrive as new closed vocabulary
+families with their own checks — added by system designers, never by
+authors. **v1 implements the git family only** (a scope decision, not a
+structural constraint).
+
+The current `CreateWorktree` effect name leaks the materialization noun and
+is renamed into the workspace vocabulary during stage C4.
+
+## 7. Verbs and interpreters
+
+Interpreter selection is system-internal. Named interpreter constants
+(committed, module-level, per doeff convention) back the verbs:
+
+| Verb | Interpretation | Cost | Guarantees |
+|---|---|---|---|
+| (expansion) | none — macro checks | 0 | §4.5 list |
+| `conductor plan` | record/estimate handlers | 0 | binding plan: §3.4 list |
+| `conductor validate` | **stub scenario simulator** | 0 tokens | control flow, joins, schema plumbing, closure law (dynamic), resume |
+| `conductor run` | production handlers | real | the run |
+
+The stub is **scenario-driven, not happy-path**: deterministic scripts
+("gate fails twice then passes", "all retries exhausted") drive every
+branch, making the closure-law test a model check over failure scenarios,
+runnable in CI on every commit. The C3 kill-and-resume test runs under the
+same interpretation. `validate` belongs to the author⇆system loop and CI;
+overseers ask for outcomes (`plan`, `--dry-run`), never name interpreters.
+
+## 8. Overseer contract
+
+- **Progress is contract, not telemetry.** Phases, labels, and node states
+  materialize from the journal into queryable views (`conductor ps / show /
+  watch`), delta-oriented ("what changed", "what is blocked on me").
+- **Gate queue.** Every parked failure and tier-3 escalation appears as an
+  open gate carrying stakes metadata (verification class, blast radius,
+  reversibility) and **closure-preserving options** — each option states
+  its outcome for the whole run (ADR 0008 R2b discipline).
+- **Resume is an overseer verb.** Stable run identity; journal +
+  fingerprints give longest-valid-prefix caching; sessions re-adopt by
+  deterministic name where `durable-sessions` holds. The overseer chooses:
+  resume as-is, resume with an edited workflow, or abort.
+- **Tolerated degradation is visible.** Quorum losses, budget-pressure
+  downgrades, deferred reviews — all surface in the run report; nothing is
+  silently skipped (ADR D4).
+
+The closure law bounds the overseer's cognitive load: there is no "silently
+wedged" state to hunt for; every terminal is a verdict, an artifact, an
+escalation, or an open gate.
+
+## 9. Replay, caching, durability
+
+- **Journal levels.** The effect journal records L3 `agent!` entries
+  (author prompt, schema, resolved identity fingerprint) and L2 entries as
+  handler-internal detail. Cache identity lives at L3.
+- **Cache-key criterion.** A field enters the cache key iff it affects the
+  result distribution: prompt, schema, adapter kind, model/identity
+  fingerprint. **Substrate never enters** — a run started on a laptop
+  (tmux) resumes in CI (headless) with caches intact. If a cache key ever
+  *needs* a substrate noun, a layer has leaked.
+- **Fingerprint, not name.** Profiles are indirection; hits require the
+  recorded resolved fingerprint to match the current resolution.
+- **Resume.** Unfinished `Launch` at crash → idempotent re-adoption by
+  deterministic session name (level-triggered, supervised by agentd on the
+  tmux substrate).
+
+## 10. Enforcement summary
+
+- expansion-time checks: §4.5 (each rule ships with a failing-case test);
+- nondeterminism validator: §4.4 (doeff-linter, ERROR, no baselines);
+- layer-boundary lint: workflow modules must not import L1 handler modules
+  or the profile registry (same enforcement pattern as agent-control-plane
+  ADR 0005's semgrep boundary rules);
+- closure-law model check: stub scenario suite in CI (§7);
+- condemned-code list: ADR 0001 "Condemned existing code" — deletions, not
+  deprecations.
+
+## 11. Open items (v1 decisions pending)
+
+1. **`pipeline` with runtime fan-out** — requires item-keyed replay
+   identity for dynamically-sized `Gather`s; design together with C2/C3
+   replay keying, or defer (static `parallel` / `parallel-for` cover the
+   pilot).
+2. **`loop :until` predicate form** — pure glue function vs a dedicated
+   restricted form.
+3. **Exact `Outcome` payload shape** and the capability-name registry
+   beyond `interactive` / `durable-sessions`.
+4. **Calibration state store** — cross-run, level-triggered; v1 ships
+   manual sampling rates + escape recording only (no autonomous rate
+   adjustment).


### PR DESCRIPTION
## Summary

Outcome of the 2026-06-10 design session on doeff-conductor orchestration:

- **ADR 0001 amendments**: semantic profile names (D1), closed DSL vocabulary with expansion-time validation (D2), workspace/medium model — site/workspace/worktree, medium-agnostic core (D5), L2 session algebra `Launch/AwaitResult/FollowUp/Stop/Release` (D6), binding model — single resolver, logged fingerprints, plan-time resolution (D7), verbs-not-interpreters (D8), overseer contract (D9), restaged implementation plan C1–C7.
- **Condemned code list**: capture-based output paths (`Observation.pr_url`, `detect_pr_url`, text-blob `RunAgent` contract, DONE/FAILED screen heuristics) marked for outright deletion — explicit no-backward-compat / no-ratchet policy.
- **New companion spec** `spec-workflow-orchestration.md`: the contracts — L2 signatures + handler obligations, DSL grammar + failure semantics (quorum typing), binding cascade, expansion-time check list, verb→interpreter mapping, replay/cache criteria, open items (§11).

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)