### PR TITLE
[codex] Add workflow nondeterminism lint rule

### DIFF
--- a/packages/doeff-linter/README.md
+++ b/packages/doeff-linter/README.md
@@ -4,7 +4,7 @@ A high-performance linter for enforcing code quality and immutability patterns i
 
 ## Features
 
-- **14 specialized rules** for code quality and immutability
+- **27 specialized rules** for code quality, immutability, and workflow replay safety
 - **Configurable via pyproject.toml**
 - **noqa comments** for per-line rule suppression
 - **Fast** - written in Rust for maximum performance
@@ -81,6 +81,22 @@ skip_test_functions = true
 | DOEFF012 | No Append Loop Pattern | Use list comprehension instead of empty list + for loop append |
 | DOEFF013 | Prefer Maybe Monad | Use `Maybe[T]` instead of `Optional[T]` or `T \| None` |
 | DOEFF014 | No Try-Except Blocks | Use doeff's error handling effects instead of try-except |
+| DOEFF032 | Workflow Nondeterminism | Workflow modules must use `time!`, `random!`, `gate!`, or `:params` instead of raw nondeterminism |
+
+## Workflow Modules
+
+`DOEFF032` applies only to workflow modules. Prefer marking those files with a
+top-level pragma:
+
+```python
+# doeff: workflow
+```
+
+Files under a `workflows/` path component and files named `*_workflow.py` are
+also treated as workflow modules. In those modules, raw clock reads,
+`random.*`, `open`, pathlib writes, subprocess/network access, and
+non-allowlisted imports are ERROR diagnostics. The rule intentionally has no
+baseline or per-file allowlist; `noqa` does not suppress `DOEFF032`.
 
 ## Inline Suppression
 
@@ -334,4 +350,3 @@ When violations are found, the hook outputs:
 ## License
 
 MIT License - see LICENSE file for details.
-

--- a/packages/doeff-linter/docs/rules/DOEFF032.md
+++ b/packages/doeff-linter/docs/rules/DOEFF032.md
@@ -1,0 +1,56 @@
+# DOEFF032: Workflow Nondeterminism
+
+Workflow modules must keep glue code deterministic so workflow replay and
+durable resume stay sound.
+
+## When It Applies
+
+Mark workflow modules with:
+
+```python
+# doeff: workflow
+```
+
+Files under a `workflows/` path component and files named `*_workflow.py` are
+also treated as workflow modules.
+
+## Banned Patterns
+
+- `datetime.now`, `datetime.today`, `time.time`, `time.monotonic`:
+  use `time!`.
+- `random.*`: use `random!`.
+- `open`, pathlib write methods, `subprocess`, `requests`, `httpx`, `socket`,
+  and `urllib`: move the operation behind `gate!`.
+- Non-allowlisted imports: pass external values through `:params`.
+
+Severity is ERROR. This rule intentionally has no baseline or per-file
+allowlist, and `noqa` does not suppress it.
+
+## Good
+
+```python
+# doeff: workflow
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromptFacts:
+    timestamp: str
+    seed: int
+
+
+def build_prompt(facts: PromptFacts) -> str:
+    return f"Run at {facts.timestamp} with seed {facts.seed}"
+```
+
+## Bad
+
+```python
+# doeff: workflow
+import random
+from datetime import datetime
+
+
+def build_prompt() -> str:
+    return f"{datetime.now()} {random.choice(['a', 'b'])}"
+```

--- a/packages/doeff-linter/src/main.rs
+++ b/packages/doeff-linter/src/main.rs
@@ -540,6 +540,11 @@ fn get_rule_info(rule_id: &str) -> RuleInfo {
             description: "Avoid creating Program entrypoints by calling @do wrappers that only forward args to a single yielded call and return it.",
             fix: "Replace `p_x: Program[...] = wrapper(...)` with `p_x: Program[...] = underlying(...)` using the same arguments. If the wrapper is intentional (naming/tracing), add `# noqa: DOEFF031`.",
         },
+        "DOEFF032" => RuleInfo {
+            name: "Workflow Nondeterminism",
+            description: "Workflow modules must not use raw clock, random, filesystem, subprocess, network, or non-allowlisted imports.",
+            fix: "Use `time!` for clock reads, `random!` for random values, `gate!` for filesystem/subprocess/network work, or pass external inputs through `:params`. Mark workflow modules with `# doeff: workflow`; this rule is not suppressible by noqa.",
+        },
         "NOQA001" => RuleInfo {
             name: "Malformed noqa Comment",
             description: "The noqa comment format appears incorrect and may not suppress the intended rule.",

--- a/packages/doeff-linter/src/noqa.rs
+++ b/packages/doeff-linter/src/noqa.rs
@@ -169,6 +169,12 @@ impl NoqaDirectives {
 
     /// Check if a rule is suppressed at a given line
     pub fn is_suppressed(&self, line: usize, rule_id: &str) -> bool {
+        // Workflow nondeterminism is a replay-safety invariant from ADR 0001.
+        // It intentionally has no baseline or per-file allowlist mechanism.
+        if rule_id == "DOEFF032" {
+            return false;
+        }
+
         // Check file-level suppressions first
         if self.file_suppress_all {
             return true;
@@ -687,6 +693,5 @@ line4
         assert_eq!(directives.warnings[0].line, 3);
     }
 }
-
 
 

--- a/packages/doeff-linter/src/report.rs
+++ b/packages/doeff-linter/src/report.rs
@@ -116,6 +116,13 @@ fn get_all_rule_info() -> Vec<RuleInfo> {
             fix: "Use Safe(program) to get a Result, program.recover(fallback) for fallbacks.",
             severity: "warning",
         },
+        RuleInfo {
+            id: "DOEFF032",
+            name: "Workflow Nondeterminism",
+            description: "Workflow modules must not use raw clock, random, filesystem, subprocess, network, or non-allowlisted imports.",
+            fix: "Use time! for clock reads, random! for random values, gate! for filesystem/subprocess/network work, or pass external inputs through :params.",
+            severity: "error",
+        },
     ]
 }
 

--- a/packages/doeff-linter/src/rules/doeff032_workflow_nondeterminism.rs
+++ b/packages/doeff-linter/src/rules/doeff032_workflow_nondeterminism.rs
@@ -1,0 +1,634 @@
+//! DOEFF032: Workflow Glue Nondeterminism
+//!
+//! Workflow modules must keep glue deterministic. Raw clock, random, I/O,
+//! subprocess, network, and non-allowlisted imports must cross explicit DSL
+//! effect boundaries instead.
+
+use crate::models::{RuleContext, Severity, Violation};
+use crate::rules::base::LintRule;
+use rustpython_ast::{Expr, Mod, Stmt};
+use std::collections::HashMap;
+use std::path::Path;
+
+const RULE_ID: &str = "DOEFF032";
+
+const ALLOWLISTED_IMPORTS: &[&str] = &[
+    "__future__",
+    "abc",
+    "collections",
+    "dataclasses",
+    "decimal",
+    "doeff",
+    "doeff_conductor",
+    "enum",
+    "fractions",
+    "functools",
+    "itertools",
+    "json",
+    "math",
+    "operator",
+    "pydantic",
+    "pydantic_core",
+    "re",
+    "types",
+    "typing",
+    "typing_extensions",
+];
+
+const NETWORK_MODULES: &[&str] = &["requests", "httpx", "socket", "urllib"];
+const PATHLIB_WRITE_METHODS: &[&str] = &[
+    "chmod",
+    "mkdir",
+    "open",
+    "rename",
+    "replace",
+    "rmdir",
+    "symlink_to",
+    "touch",
+    "unlink",
+    "write_bytes",
+    "write_text",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Replacement {
+    Time,
+    Random,
+    Gate,
+    Params,
+}
+
+impl Replacement {
+    fn token(self) -> &'static str {
+        match self {
+            Replacement::Time => "time!",
+            Replacement::Random => "random!",
+            Replacement::Gate => "gate!",
+            Replacement::Params => ":params",
+        }
+    }
+
+    fn suggestion(self) -> &'static str {
+        match self {
+            Replacement::Time => "use the explicit `time!` workflow effect",
+            Replacement::Random => "use the explicit `random!` workflow effect",
+            Replacement::Gate => "move the operation behind a deterministic `gate!` step",
+            Replacement::Params => "pass the value through a workflow `:params` entry",
+        }
+    }
+}
+
+pub struct WorkflowNondeterminismRule;
+
+impl WorkflowNondeterminismRule {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn is_workflow_module(file_path: &str, source: &str) -> bool {
+        if source
+            .lines()
+            .take(20)
+            .any(|line| line.contains("doeff: workflow") || line.contains("doeff:workflow"))
+        {
+            return true;
+        }
+
+        let path = Path::new(file_path);
+        let has_workflows_component = path
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .any(|component| component == "workflows");
+        let has_workflow_suffix = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map_or(false, |name| name.ends_with("_workflow.py"));
+
+        has_workflows_component || has_workflow_suffix
+    }
+
+    fn root_module(module: &str) -> &str {
+        module.split('.').next().unwrap_or(module)
+    }
+
+    fn is_module_or_child(module: &str, root: &str) -> bool {
+        module == root || module.starts_with(&format!("{root}."))
+    }
+
+    fn is_allowlisted_import(module: &str) -> bool {
+        ALLOWLISTED_IMPORTS
+            .iter()
+            .any(|allowed| Self::is_module_or_child(module, allowed))
+    }
+
+    fn classify_import(module: &str) -> Option<Replacement> {
+        let root = Self::root_module(module);
+
+        if root == "datetime" || root == "time" {
+            Some(Replacement::Time)
+        } else if root == "random" {
+            Some(Replacement::Random)
+        } else if root == "pathlib" || root == "subprocess" {
+            Some(Replacement::Gate)
+        } else if NETWORK_MODULES.contains(&root) {
+            Some(Replacement::Gate)
+        } else if Self::is_allowlisted_import(module) {
+            None
+        } else {
+            Some(Replacement::Params)
+        }
+    }
+
+    fn collect_import_aliases(ast: &Mod) -> HashMap<String, String> {
+        let mut aliases = HashMap::new();
+
+        if let Mod::Module(module) = ast {
+            for stmt in &module.body {
+                match stmt {
+                    Stmt::Import(import) => {
+                        for alias in &import.names {
+                            let module_name = alias.name.as_str();
+                            let local_name = alias
+                                .asname
+                                .as_ref()
+                                .map(|name| name.as_str())
+                                .unwrap_or_else(|| Self::root_module(module_name));
+                            let resolved = if alias.asname.is_some() {
+                                module_name
+                            } else {
+                                Self::root_module(module_name)
+                            };
+                            aliases.insert(local_name.to_string(), resolved.to_string());
+                        }
+                    }
+                    Stmt::ImportFrom(import_from) => {
+                        let Some(module_name) = import_from.module.as_ref().map(|m| m.as_str())
+                        else {
+                            continue;
+                        };
+
+                        for alias in &import_from.names {
+                            let imported_name = alias.name.as_str();
+                            if imported_name == "*" {
+                                continue;
+                            }
+                            let local_name = alias
+                                .asname
+                                .as_ref()
+                                .map(|name| name.as_str())
+                                .unwrap_or(imported_name);
+                            aliases.insert(
+                                local_name.to_string(),
+                                format!("{module_name}.{imported_name}"),
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        aliases
+    }
+
+    fn check_import(stmt: &Stmt, violations: &mut Vec<Violation>, file_path: &str) {
+        match stmt {
+            Stmt::Import(import) => {
+                for alias in &import.names {
+                    let module_name = alias.name.as_str();
+                    if let Some(replacement) = Self::classify_import(module_name) {
+                        violations.push(Self::create_violation(
+                            format!("import `{module_name}`"),
+                            replacement,
+                            import.range.start().to_usize(),
+                            file_path,
+                        ));
+                    }
+                }
+            }
+            Stmt::ImportFrom(import_from) => {
+                let module_name = import_from
+                    .module
+                    .as_ref()
+                    .map(|module| module.as_str())
+                    .unwrap_or("<relative>");
+
+                if let Some(replacement) = Self::classify_import(module_name) {
+                    violations.push(Self::create_violation(
+                        format!("import from `{module_name}`"),
+                        replacement,
+                        import_from.range.start().to_usize(),
+                        file_path,
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn resolve_expr_path(expr: &Expr, aliases: &HashMap<String, String>) -> Option<String> {
+        match expr {
+            Expr::Name(name) => Some(
+                aliases
+                    .get(name.id.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| name.id.to_string()),
+            ),
+            Expr::Attribute(attr) => {
+                let base = Self::resolve_expr_path(&attr.value, aliases)?;
+                Some(format!("{}.{}", base, attr.attr))
+            }
+            Expr::Call(call) => Self::resolve_expr_path(&call.func, aliases),
+            Expr::Subscript(subscript) => Self::resolve_expr_path(&subscript.value, aliases),
+            _ => None,
+        }
+    }
+
+    fn classify_call(path: &str) -> Option<Replacement> {
+        match path {
+            "datetime.now"
+            | "datetime.today"
+            | "datetime.datetime.now"
+            | "datetime.datetime.today"
+            | "time.time"
+            | "time.monotonic" => Some(Replacement::Time),
+            "open" => Some(Replacement::Gate),
+            _ if path.starts_with("random.") => Some(Replacement::Random),
+            _ if path.starts_with("subprocess.") => Some(Replacement::Gate),
+            _ if NETWORK_MODULES
+                .iter()
+                .any(|module| Self::is_module_or_child(path, module)) =>
+            {
+                Some(Replacement::Gate)
+            }
+            _ if Self::is_pathlib_write_call(path) => Some(Replacement::Gate),
+            _ => None,
+        }
+    }
+
+    fn is_pathlib_write_call(path: &str) -> bool {
+        let Some(method_name) = path.rsplit('.').next() else {
+            return false;
+        };
+
+        PATHLIB_WRITE_METHODS.contains(&method_name)
+            && (path.starts_with("pathlib.Path.")
+                || path.starts_with("pathlib.PosixPath.")
+                || path.starts_with("pathlib.WindowsPath.")
+                || path.starts_with("Path.")
+                || path.starts_with("PosixPath.")
+                || path.starts_with("WindowsPath."))
+    }
+
+    fn check_expr(
+        expr: &Expr,
+        aliases: &HashMap<String, String>,
+        violations: &mut Vec<Violation>,
+        file_path: &str,
+    ) {
+        if let Expr::Call(call) = expr {
+            if let Some(path) = Self::resolve_expr_path(&call.func, aliases) {
+                if let Some(replacement) = Self::classify_call(&path) {
+                    violations.push(Self::create_violation(
+                        format!("call `{path}`"),
+                        replacement,
+                        call.range.start().to_usize(),
+                        file_path,
+                    ));
+                }
+            }
+        }
+
+        Self::check_nested_exprs(expr, aliases, violations, file_path);
+    }
+
+    fn check_nested_exprs(
+        expr: &Expr,
+        aliases: &HashMap<String, String>,
+        violations: &mut Vec<Violation>,
+        file_path: &str,
+    ) {
+        match expr {
+            Expr::BoolOp(boolop) => {
+                for value in &boolop.values {
+                    Self::check_expr(value, aliases, violations, file_path);
+                }
+            }
+            Expr::NamedExpr(named) => {
+                Self::check_expr(&named.value, aliases, violations, file_path);
+            }
+            Expr::BinOp(binop) => {
+                Self::check_expr(&binop.left, aliases, violations, file_path);
+                Self::check_expr(&binop.right, aliases, violations, file_path);
+            }
+            Expr::UnaryOp(unaryop) => {
+                Self::check_expr(&unaryop.operand, aliases, violations, file_path);
+            }
+            Expr::Lambda(lambda) => {
+                Self::check_expr(&lambda.body, aliases, violations, file_path);
+            }
+            Expr::IfExp(ifexp) => {
+                Self::check_expr(&ifexp.test, aliases, violations, file_path);
+                Self::check_expr(&ifexp.body, aliases, violations, file_path);
+                Self::check_expr(&ifexp.orelse, aliases, violations, file_path);
+            }
+            Expr::Dict(dict) => {
+                for key in dict.keys.iter().flatten() {
+                    Self::check_expr(key, aliases, violations, file_path);
+                }
+                for value in &dict.values {
+                    Self::check_expr(value, aliases, violations, file_path);
+                }
+            }
+            Expr::Set(set) => {
+                for elt in &set.elts {
+                    Self::check_expr(elt, aliases, violations, file_path);
+                }
+            }
+            Expr::ListComp(listcomp) => {
+                Self::check_expr(&listcomp.elt, aliases, violations, file_path);
+            }
+            Expr::SetComp(setcomp) => {
+                Self::check_expr(&setcomp.elt, aliases, violations, file_path);
+            }
+            Expr::DictComp(dictcomp) => {
+                Self::check_expr(&dictcomp.key, aliases, violations, file_path);
+                Self::check_expr(&dictcomp.value, aliases, violations, file_path);
+            }
+            Expr::GeneratorExp(genexp) => {
+                Self::check_expr(&genexp.elt, aliases, violations, file_path);
+            }
+            Expr::Await(await_expr) => {
+                Self::check_expr(&await_expr.value, aliases, violations, file_path);
+            }
+            Expr::Yield(yield_expr) => {
+                if let Some(value) = &yield_expr.value {
+                    Self::check_expr(value, aliases, violations, file_path);
+                }
+            }
+            Expr::YieldFrom(yieldfrom) => {
+                Self::check_expr(&yieldfrom.value, aliases, violations, file_path);
+            }
+            Expr::Compare(compare) => {
+                Self::check_expr(&compare.left, aliases, violations, file_path);
+                for comparator in &compare.comparators {
+                    Self::check_expr(comparator, aliases, violations, file_path);
+                }
+            }
+            Expr::Call(call) => {
+                Self::check_expr(&call.func, aliases, violations, file_path);
+                for arg in &call.args {
+                    Self::check_expr(arg, aliases, violations, file_path);
+                }
+                for keyword in &call.keywords {
+                    Self::check_expr(&keyword.value, aliases, violations, file_path);
+                }
+            }
+            Expr::FormattedValue(formatted) => {
+                Self::check_expr(&formatted.value, aliases, violations, file_path);
+            }
+            Expr::JoinedStr(joined) => {
+                for value in &joined.values {
+                    Self::check_expr(value, aliases, violations, file_path);
+                }
+            }
+            Expr::Attribute(attribute) => {
+                Self::check_expr(&attribute.value, aliases, violations, file_path);
+            }
+            Expr::Subscript(subscript) => {
+                Self::check_expr(&subscript.value, aliases, violations, file_path);
+                Self::check_expr(&subscript.slice, aliases, violations, file_path);
+            }
+            Expr::Starred(starred) => {
+                Self::check_expr(&starred.value, aliases, violations, file_path);
+            }
+            Expr::List(list) => {
+                for elt in &list.elts {
+                    Self::check_expr(elt, aliases, violations, file_path);
+                }
+            }
+            Expr::Tuple(tuple) => {
+                for elt in &tuple.elts {
+                    Self::check_expr(elt, aliases, violations, file_path);
+                }
+            }
+            Expr::Slice(slice) => {
+                if let Some(lower) = &slice.lower {
+                    Self::check_expr(lower, aliases, violations, file_path);
+                }
+                if let Some(upper) = &slice.upper {
+                    Self::check_expr(upper, aliases, violations, file_path);
+                }
+                if let Some(step) = &slice.step {
+                    Self::check_expr(step, aliases, violations, file_path);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn check_stmt_exprs(
+        stmt: &Stmt,
+        aliases: &HashMap<String, String>,
+        violations: &mut Vec<Violation>,
+        file_path: &str,
+    ) {
+        match stmt {
+            Stmt::Expr(expr_stmt) => {
+                Self::check_expr(&expr_stmt.value, aliases, violations, file_path);
+            }
+            Stmt::Assign(assign) => {
+                Self::check_expr(&assign.value, aliases, violations, file_path);
+            }
+            Stmt::AnnAssign(ann_assign) => {
+                if let Some(value) = &ann_assign.value {
+                    Self::check_expr(value, aliases, violations, file_path);
+                }
+            }
+            Stmt::AugAssign(aug_assign) => {
+                Self::check_expr(&aug_assign.value, aliases, violations, file_path);
+            }
+            Stmt::Return(return_stmt) => {
+                if let Some(value) = &return_stmt.value {
+                    Self::check_expr(value, aliases, violations, file_path);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                Self::check_expr(&if_stmt.test, aliases, violations, file_path);
+            }
+            Stmt::While(while_stmt) => {
+                Self::check_expr(&while_stmt.test, aliases, violations, file_path);
+            }
+            Stmt::For(for_stmt) => {
+                Self::check_expr(&for_stmt.iter, aliases, violations, file_path);
+            }
+            Stmt::With(with_stmt) => {
+                for item in &with_stmt.items {
+                    Self::check_expr(&item.context_expr, aliases, violations, file_path);
+                }
+            }
+            Stmt::Assert(assert_stmt) => {
+                Self::check_expr(&assert_stmt.test, aliases, violations, file_path);
+                if let Some(msg) = &assert_stmt.msg {
+                    Self::check_expr(msg, aliases, violations, file_path);
+                }
+            }
+            Stmt::Raise(raise_stmt) => {
+                if let Some(exc) = &raise_stmt.exc {
+                    Self::check_expr(exc, aliases, violations, file_path);
+                }
+                if let Some(cause) = &raise_stmt.cause {
+                    Self::check_expr(cause, aliases, violations, file_path);
+                }
+            }
+            Stmt::FunctionDef(function) => {
+                for decorator in &function.decorator_list {
+                    Self::check_expr(decorator, aliases, violations, file_path);
+                }
+                if let Some(returns) = &function.returns {
+                    Self::check_expr(returns, aliases, violations, file_path);
+                }
+            }
+            Stmt::AsyncFunctionDef(function) => {
+                for decorator in &function.decorator_list {
+                    Self::check_expr(decorator, aliases, violations, file_path);
+                }
+                if let Some(returns) = &function.returns {
+                    Self::check_expr(returns, aliases, violations, file_path);
+                }
+            }
+            Stmt::ClassDef(class_def) => {
+                for decorator in &class_def.decorator_list {
+                    Self::check_expr(decorator, aliases, violations, file_path);
+                }
+                for base in &class_def.bases {
+                    Self::check_expr(base, aliases, violations, file_path);
+                }
+                for keyword in &class_def.keywords {
+                    Self::check_expr(&keyword.value, aliases, violations, file_path);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn create_violation(
+        construct: String,
+        replacement: Replacement,
+        offset: usize,
+        file_path: &str,
+    ) -> Violation {
+        let message = format!(
+            "Workflow glue code must be deterministic, but this module uses {construct}.\n\n\
+             Problem: raw nondeterminism breaks workflow replay and durable resume.\n\n\
+             Replacement: {} ({}).",
+            replacement.suggestion(),
+            replacement.token()
+        );
+
+        Violation::new(
+            RULE_ID.to_string(),
+            message,
+            offset,
+            file_path.to_string(),
+            Severity::Error,
+        )
+    }
+}
+
+impl LintRule for WorkflowNondeterminismRule {
+    fn rule_id(&self) -> &str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &str {
+        "Ban raw nondeterminism in workflow modules"
+    }
+
+    fn check(&self, context: &RuleContext) -> Vec<Violation> {
+        let mut violations = Vec::new();
+
+        if !Self::is_workflow_module(context.file_path, context.source) {
+            return violations;
+        }
+
+        Self::check_import(context.stmt, &mut violations, context.file_path);
+
+        let aliases = Self::collect_import_aliases(context.ast);
+        Self::check_stmt_exprs(context.stmt, &aliases, &mut violations, context.file_path);
+
+        violations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustpython_ast::Mod;
+    use rustpython_parser::{parse, Mode};
+
+    fn check_code_with_path(code: &str, file_path: &str) -> Vec<Violation> {
+        let ast = parse(code, Mode::Module, file_path).unwrap();
+        let rule = WorkflowNondeterminismRule::new();
+        let mut violations = Vec::new();
+
+        if let Mod::Module(module) = &ast {
+            for stmt in &module.body {
+                let context = RuleContext {
+                    stmt,
+                    file_path,
+                    source: code,
+                    ast: &ast,
+                };
+                violations.extend(rule.check(&context));
+            }
+        }
+
+        violations
+    }
+
+    fn check_code(code: &str) -> Vec<Violation> {
+        check_code_with_path(code, "workflow.py")
+    }
+
+    #[test]
+    fn test_requires_workflow_marker_or_path() {
+        let violations =
+            check_code_with_path("import random\nvalue = random.random()", "module.py");
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_datetime_now_suggests_time_effect() {
+        let violations =
+            check_code("# doeff: workflow\nfrom datetime import datetime\nnow = datetime.now()");
+        assert!(violations.iter().any(|v| v.message.contains("time!")));
+    }
+
+    #[test]
+    fn test_random_suggests_random_effect() {
+        let violations = check_code("# doeff: workflow\nimport random\nvalue = random.choice([1])");
+        assert!(violations.iter().any(|v| v.message.contains("random!")));
+    }
+
+    #[test]
+    fn test_gate_suggested_for_open() {
+        let violations = check_code("# doeff: workflow\nvalue = open('x').read()");
+        assert!(violations.iter().any(|v| v.message.contains("gate!")));
+    }
+
+    #[test]
+    fn test_params_suggested_for_non_allowlisted_import() {
+        let violations =
+            check_code("# doeff: workflow\nimport yaml\nvalue = yaml.safe_load('x: 1')");
+        assert!(violations.iter().any(|v| v.message.contains(":params")));
+    }
+
+    #[test]
+    fn test_clean_workflow_imports_allowed() {
+        let violations = check_code(
+            "# doeff: workflow\nfrom dataclasses import dataclass\nfrom typing import Mapping\n",
+        );
+        assert!(violations.is_empty());
+    }
+}

--- a/packages/doeff-linter/src/rules/mod.rs
+++ b/packages/doeff-linter/src/rules/mod.rs
@@ -29,6 +29,7 @@ pub mod doeff023_pipeline_marker;
 pub mod doeff024_no_recover_ask;
 pub mod doeff030_ask_result_type_annotation;
 pub mod doeff031_no_redundant_do_wrapper_entrypoint;
+pub mod doeff032_workflow_nondeterminism;
 
 use base::LintRule;
 use std::collections::HashMap;
@@ -64,6 +65,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
         Box::new(
             doeff031_no_redundant_do_wrapper_entrypoint::NoRedundantDoWrapperEntrypointRule::new(),
         ),
+        Box::new(doeff032_workflow_nondeterminism::WorkflowNondeterminismRule::new()),
     ]
 }
 
@@ -103,7 +105,7 @@ mod tests {
     #[test]
     fn test_all_rules_loaded() {
         let rules = get_all_rules();
-        assert_eq!(rules.len(), 26);
+        assert_eq!(rules.len(), 27);
 
         let rule_ids: Vec<_> = rules.iter().map(|r| r.rule_id()).collect();
         assert!(rule_ids.contains(&"DOEFF001"));
@@ -124,6 +126,7 @@ mod tests {
         assert!(rule_ids.contains(&"DOEFF024"));
         assert!(rule_ids.contains(&"DOEFF030"));
         assert!(rule_ids.contains(&"DOEFF031"));
+        assert!(rule_ids.contains(&"DOEFF032"));
     }
 
     #[test]

--- a/packages/doeff-linter/tests/conftest.py
+++ b/packages/doeff-linter/tests/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore_glob = ["fixtures/*.py", "fixtures/**/*.py"]

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/clean_workflow.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/clean_workflow.py
@@ -1,0 +1,13 @@
+# doeff: workflow
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class PromptFacts:
+    timestamp: str
+    seed: int
+
+
+def build_prompt(facts: PromptFacts, params: Mapping[str, str]) -> str:
+    return f"{params['task']} at {facts.timestamp} with seed {facts.seed}"

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/datetime_now.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/datetime_now.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+from datetime import datetime
+
+
+def build_prompt() -> str:
+    return datetime.now().isoformat()

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/datetime_today.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/datetime_today.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import datetime
+
+
+def build_prompt() -> str:
+    return datetime.datetime.today().isoformat()

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/file_noqa_workflow.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/file_noqa_workflow.py
@@ -1,0 +1,7 @@
+# noqa: file=DOEFF032
+# doeff: workflow
+import random
+
+
+def choose(items: list[str]) -> str:
+    return random.choice(items)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/httpx_import.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/httpx_import.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import httpx
+
+
+def fetch_status(url: str) -> int:
+    return httpx.get(url).status_code

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/non_allowlisted_import.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/non_allowlisted_import.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import yaml
+
+
+def parse_config(raw: str) -> object:
+    return yaml.safe_load(raw)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/open_call.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/open_call.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+
+
+def write_log(message: str) -> None:
+    with open("workflow.log", "w") as handle:
+        handle.write(message)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/pathlib_write.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/pathlib_write.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+from pathlib import Path
+
+
+def write_log(message: str) -> None:
+    Path("workflow.log").write_text(message)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/plain_module_with_random.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/plain_module_with_random.py
@@ -1,0 +1,5 @@
+import random
+
+
+def pick(items: list[str]) -> str:
+    return random.choice(items)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/random_call.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/random_call.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import random
+
+
+def pick_reviewer(reviewers: list[str]) -> str:
+    return random.choice(reviewers)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/requests_import.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/requests_import.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import requests
+
+
+def fetch_status(url: str) -> int:
+    return requests.get(url).status_code

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/socket_import.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/socket_import.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import socket
+
+
+def host_name() -> str:
+    return socket.gethostname()

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/subprocess_call.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/subprocess_call.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import subprocess
+
+
+def run_tests() -> None:
+    subprocess.run(["pytest"], check=True)

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/time_monotonic.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/time_monotonic.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import time
+
+
+def build_prompt() -> str:
+    return str(time.monotonic())

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/time_time.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/time_time.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+import time
+
+
+def build_prompt() -> str:
+    return str(time.time())

--- a/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/urllib_import.py
+++ b/packages/doeff-linter/tests/fixtures/workflow_nondeterminism/urllib_import.py
@@ -1,0 +1,6 @@
+# doeff: workflow
+from urllib import request
+
+
+def fetch(url: str) -> bytes:
+    return request.urlopen(url).read()

--- a/packages/doeff-linter/tests/test_workflow_nondeterminism.py
+++ b/packages/doeff-linter/tests/test_workflow_nondeterminism.py
@@ -1,0 +1,90 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+LINTER_DIR = ROOT / "packages" / "doeff-linter"
+FIXTURES = LINTER_DIR / "tests" / "fixtures" / "workflow_nondeterminism"
+
+
+def run_linter(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--",
+            "--no-config",
+            "--no-log",
+            "--enable",
+            "DOEFF032",
+            "--output-format",
+            "json",
+            str(path),
+        ],
+        cwd=LINTER_DIR,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def parse_json_output(result: subprocess.CompletedProcess[str]) -> list[dict]:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "replacement"),
+    [
+        ("datetime_now.py", "time!"),
+        ("datetime_today.py", "time!"),
+        ("time_time.py", "time!"),
+        ("time_monotonic.py", "time!"),
+        ("random_call.py", "random!"),
+        ("open_call.py", "gate!"),
+        ("pathlib_write.py", "gate!"),
+        ("subprocess_call.py", "gate!"),
+        ("requests_import.py", "gate!"),
+        ("httpx_import.py", "gate!"),
+        ("socket_import.py", "gate!"),
+        ("urllib_import.py", "gate!"),
+        ("non_allowlisted_import.py", ":params"),
+    ],
+)
+def test_workflow_nondeterminism_fixture_fires(
+    fixture_name: str,
+    replacement: str,
+) -> None:
+    result = run_linter(FIXTURES / fixture_name)
+
+    assert result.returncode == 1, result.stderr
+    payload = parse_json_output(result)
+    assert [entry["rule"] for entry in payload] == ["DOEFF032"]
+    assert payload[0]["severity"] == "error"
+    assert replacement in payload[0]["fix"]
+
+
+def test_clean_workflow_fixture_passes() -> None:
+    result = run_linter(FIXTURES / "clean_workflow.py")
+
+    assert result.returncode == 0, result.stderr
+    assert parse_json_output(result) == []
+
+
+def test_non_workflow_module_is_not_checked() -> None:
+    result = run_linter(FIXTURES / "plain_module_with_random.py")
+
+    assert result.returncode == 0, result.stderr
+    assert parse_json_output(result) == []
+
+
+def test_workflow_nondeterminism_has_no_file_allowlist() -> None:
+    result = run_linter(FIXTURES / "file_noqa_workflow.py")
+
+    assert result.returncode == 1, result.stderr
+    payload = parse_json_output(result)
+    assert [entry["rule"] for entry in payload] == ["DOEFF032"]


### PR DESCRIPTION
## Summary

Adds DOEFF032, a workflow-module nondeterminism validator for doeff-linter, covering the ADR 0001 D2 / workflow spec §4.4 replay-safety requirement.

## Changes

- Adds workflow module opt-in detection via `# doeff: workflow`, plus `workflows/` and `*_workflow.py` path conventions.
- Bans raw clock reads, random calls/imports, `open`, pathlib writes, subprocess, network libraries, and non-allowlisted imports in workflow modules.
- Emits ERROR diagnostics with explicit replacement guidance: `time!`, `random!`, `gate!`, or `:params`.
- Makes DOEFF032 non-suppressible through `noqa`, matching the no-baseline / no-per-file-allowlist policy.
- Adds docs, CLI/report rule metadata, and fixture-backed pytest coverage for each banned construct plus clean and non-workflow fixtures.

## Acceptance Evidence

- Red test first: `uv run pytest packages/doeff-linter/tests/test_workflow_nondeterminism.py 2>&1 | tee /tmp/c2v-red-tests.log` failed before implementation with 13 banned fixtures undetected and 2 pass-through fixtures passing.
- Required command: `uv run pytest packages/doeff-linter 2>&1 | tee /tmp/c2v-tests.log` passed: 16 passed.
- Rust unit coverage: `cargo test 2>&1 | tee /tmp/c2v-cargo-test.log` passed: 301 passed, 0 failed. Existing unrelated compiler warnings remain.
- Representative diagnostic check: `cargo run --quiet -- --no-config --no-log --enable DOEFF032 --output-format json tests/fixtures/workflow_nondeterminism/random_call.py 2>&1 | tee /tmp/c2v-random-diagnostic.log` reported DOEFF032 with severity `error` and fix guidance including `time!`, `random!`, `gate!`, and `:params`.

## Issue

conductor-c2v-nondeterminism-validator
