### PR TITLE
[codex] Restore cache await spawn regression test

### DIFF
--- a/tests/test_cache_await_spawn_hang.py
+++ b/tests/test_cache_await_spawn_hang.py
@@ -1,76 +1,58 @@
-"""Reproducer: cache() + Await + Spawn+Gather hangs at scale.
+"""Regression coverage for cache() + Await under large Spawn/Gather fan-out.
 
-When many Spawned tasks enter cache compute_and_cache() simultaneously and each
-task does a `yield Await(coroutine)` inside the cached function, the scheduler
-stops dispatching new tasks after the first batch completes.
-
-See: https://github.com/proboscis/doeff/issues/342
+The original issue appeared when many spawned cache misses all entered a cached
+``@do`` function that awaited async work. The scheduler must keep draining
+external promise completions until every spawned task finishes.
 """
 
 from __future__ import annotations
 
 import asyncio
-import signal
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
+from doeff_core_effects.cache import cache
+from doeff_core_effects.memo_handlers import sqlite_memo_handler
 
-from doeff import (
-    Gather,
-    Spawn,
-    WithHandler,
-    cache,
-    do,
-    run,
-    slog,)
-from doeff import Await
+from doeff import Await, Gather, Spawn, WithHandler, do
 from tests._run_helpers import run_with_defaults
-# REMOVED: from doeff_core_effects.handlers import sqlite_cache_handler
-
-TIMEOUT_SECONDS = 30
 
 
-def _timeout_handler(signum: int, frame: Any) -> None:
-    raise TimeoutError(f"Deadlock detected after {TIMEOUT_SECONDS}s")
-
-
-def _run_with_timeout(program):
-    old = signal.signal(signal.SIGALRM, _timeout_handler)
-    signal.alarm(TIMEOUT_SECONDS)
-    try:
-        return run_with_defaults(program)
-    finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, old)
-
-
-def _run_cached_with_timeout(program):
-    wrapped = WithHandler(sqlite_cache_handler(None), program)
-    return _run_with_timeout(wrapped)
-
-
-async def _fake_work(i: int) -> str:
+async def _fake_work(index: int) -> str:
     await asyncio.sleep(0.01)
-    return f"done-{i}"
+    return f"done-{index}"
 
 
+@cache(lifecycle="persistent")
 @do
-def _no_cache_task(i: int):
-    result = yield Await(_fake_work(i))
-    return result
-
-
-# REMOVED: @cache(lifecycle="persistent")
-@do
-def _cached_task(i: int):
-    result = yield Await(_fake_work(i))
+def _cached_task(index: int) -> Any:
+    result: str = yield Await(_fake_work(index))
     return result
 
 
 @do
-def _spawn_gather_n(factory, n: int):
-    tasks = []
-    for i in range(n):
-        t = yield Spawn(factory(i), daemon=False)
-        tasks.append(t)
+def _spawn_gather_n(factory: Callable[[int], Any], total: int) -> Any:
+    tasks: list[Any] = []
+    for index in range(total):
+        task: Any = yield Spawn(factory(index))
+        tasks.append(task)
     return list((yield Gather(*tasks)))
+
+
+def _run_cached_spawn_gather(db_path: Path, total: int) -> list[str]:
+    program: Any = WithHandler(sqlite_memo_handler(db_path), _spawn_gather_n(_cached_task, total))
+    result: Any = run_with_defaults(program)
+    if result.is_err():
+        raise result.error
+    return result.value
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("total", [200, 500])
+def test_cache_await_spawn_gather_completes_at_scale(tmp_path: Path, total: int) -> None:
+    values: list[str] = _run_cached_spawn_gather(tmp_path / "memo.sqlite", total)
+
+    assert len(values) == total
+    assert values == [f"done-{index}" for index in range(total)]


### PR DESCRIPTION
## Summary

Restores the `cache() + Await + Spawn/Gather` regression test for `cache-await-spawn-hang` using the current `doeff_core_effects` cache API.

The previous file no longer collected any tests: it imported the removed `doeff.cache` surface, referenced the removed `sqlite_cache_handler`, and had the cache decorator commented out. This PR rewrites the test to exercise the active implementation path:

- `doeff_core_effects.cache.cache(lifecycle="persistent")`
- `sqlite_memo_handler` backed by a temporary SQLite database
- large `Spawn` + `Gather` fan-out where each cache miss awaits async work
- explicit coverage for `N=200` and `N=500` under a 60s timeout

## Validation

- `uv run pytest tests/test_cache_await_spawn_hang.py -v --timeout=60`
  - 2 passed: `N=200`, `N=500`
- `uv run pytest`
  - 836 passed, 84 skipped
- `uv run pyright tests/test_cache_await_spawn_hang.py`
  - 0 errors, 0 warnings
- `uv run ruff check tests/test_cache_await_spawn_hang.py`
  - all checks passed

Note: full `uv run pyright` still fails on the pre-existing `doeff/cli/discovery.py:57` `Indexer` import issue, unrelated to this change.