### PR TITLE
[codex] Add conductor C6 verbs

### DIFF
--- a/packages/doeff-conductor/src/doeff_conductor/cli.py
+++ b/packages/doeff-conductor/src/doeff_conductor/cli.py
@@ -29,6 +29,12 @@ from rich.text import Text
 from .types import IssueStatus, WorkflowStatus
 
 console = Console()
+_CLI_USER_ERROR_TYPES: tuple[type[BaseException], ...] = (
+    FileNotFoundError,
+    OSError,
+    ValueError,
+    json.JSONDecodeError,
+)
 
 
 def _format_duration(dt: datetime) -> str:
@@ -88,6 +94,129 @@ def cli(ctx: click.Context, state_dir: str | None) -> None:
 # =============================================================================
 
 
+@cli.command("plan")
+@click.argument("workflow_file")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option(
+    "--supervision",
+    type=click.Choice(["autonomous", "phase-checkpoints"]),
+    default="autonomous",
+    show_default=True,
+    help="Run-scoped supervision policy for the approval artifact",
+)
+def plan_cmd(workflow_file: str, output_json: bool, supervision: str) -> None:
+    """Produce the overseer binding plan for a workflow."""
+    from doeff_conductor.verbs import plan_workflow
+    from doeff_conductor.workflow_loader import load_workflow_spec
+
+    try:
+        workflow = load_workflow_spec(workflow_file)
+        plan = plan_workflow(workflow, supervision=supervision)
+        if output_json:
+            click.echo(json.dumps(plan.to_dict(), indent=2))
+            return
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("NODE", style="cyan")
+        table.add_column("PHASE")
+        table.add_column("ROLE")
+        table.add_column("PROFILE")
+        table.add_column("CLASS")
+        table.add_column("BUDGET")
+        table.add_column("FINGERPRINT")
+        for row in plan.rows:
+            table.add_row(
+                row.node_id,
+                row.phase or "-",
+                row.role,
+                row.profile,
+                row.verification_class,
+                str(row.estimated_budget_units),
+                row.fingerprint[:12],
+            )
+        console.print(table)
+        console.print(f"Estimated budget units: {plan.estimated_budget_units}")
+        console.print(f"Capabilities satisfied: {plan.capabilities_satisfied}")
+        if plan.missing_capabilities:
+            console.print(f"Missing capabilities: {', '.join(plan.missing_capabilities)}")
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
+@cli.command("validate")
+@click.argument("workflow_file")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option(
+    "--scenario",
+    "scenarios",
+    multiple=True,
+    help="Scenario to run; defaults to the built-in C6 suite",
+)
+@click.option("--run-id", help="Persist overseer state under this workflow id")
+@click.option(
+    "--supervision",
+    type=click.Choice(["autonomous", "phase-checkpoints"]),
+    default="autonomous",
+    show_default=True,
+    help="Run-scoped supervision policy consumed by validation launch",
+)
+@click.pass_context
+def validate_cmd(
+    ctx: click.Context,
+    workflow_file: str,
+    output_json: bool,
+    scenarios: tuple[str, ...],
+    run_id: str | None,
+    supervision: str,
+) -> None:
+    """Validate workflow control flow under scenario-driven stubs."""
+    from doeff_conductor.verbs import validate_workflow
+    from doeff_conductor.workflow_loader import load_workflow_spec
+
+    try:
+        workflow = load_workflow_spec(workflow_file)
+        state_dir_for_run = None
+        if run_id:
+            from doeff_conductor.api import ConductorAPI
+
+            state_dir_for_run = str(ConductorAPI(ctx.obj.get("state_dir")).state_dir)
+        report = validate_workflow(
+            workflow,
+            scenarios=scenarios or None,
+            supervision=supervision,
+            state_dir=state_dir_for_run,
+            run_id=run_id,
+        )
+        if output_json:
+            click.echo(json.dumps(report.to_dict(), indent=2))
+            return
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("SCENARIO", style="cyan")
+        table.add_column("TERMINALS")
+        table.add_column("OPEN GATES")
+        for scenario_report in report.scenarios:
+            table.add_row(
+                scenario_report.scenario,
+                str(len(scenario_report.terminals)),
+                str(len(scenario_report.open_gates)),
+            )
+        console.print(table)
+        console.print("Closure: ok")
+        if run_id:
+            console.print(f"Persisted overseer state for run: {run_id}")
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
 @cli.command()
 @click.argument("template_or_file")
 @click.option("--issue", "-i", type=click.Path(exists=True), help="Issue file")
@@ -131,7 +260,7 @@ def run(
                 content = issue_path.read_text()
                 from .handlers.issue_handler import _parse_frontmatter
 
-                frontmatter, body = _parse_frontmatter(content)
+                frontmatter, _body = _parse_frontmatter(content)
                 from .effects.issue import GetIssue
 
                 if frontmatter.get("id"):
@@ -154,7 +283,7 @@ def run(
             # Watch workflow
             ctx.invoke(watch_cmd, workflow_id=workflow.id)
 
-    except Exception as e:
+    except _CLI_USER_ERROR_TYPES as e:
         if output_json:
             click.echo(json.dumps({"error": str(e)}))
         else:
@@ -213,16 +342,100 @@ def ps_cmd(
     console.print(table)
 
 
-@cli.command("show")
-@click.argument("workflow_id")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-@click.pass_context
-def show_cmd(
+def _show_progress_since(
+    ctx: click.Context,
+    workflow_id: str,
+    output_json: bool,
+    since: int,
+) -> None:
+    from doeff_conductor.api import ConductorAPI
+    from doeff_conductor.overseer import progress_since
+
+    try:
+        state_dir = ConductorAPI(ctx.obj.get("state_dir")).state_dir
+        events = progress_since(state_dir, workflow_id, since)
+        if output_json:
+            click.echo(json.dumps(events, indent=2))
+            return
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("SEQ", style="cyan")
+        table.add_column("STATUS")
+        table.add_column("PHASE")
+        table.add_column("NODE")
+        table.add_column("MESSAGE")
+        for event in events:
+            table.add_row(
+                str(event["sequence"]),
+                event["status"],
+                event["phase"] or "-",
+                event["node_id"],
+                event["message"],
+            )
+        console.print(table)
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
+def _append_optional_line(lines: list[str], condition: bool, line: str) -> None:
+    if condition:
+        lines.append(line)
+
+
+def _workflow_detail_panel(workflow: object) -> Panel:
+    lines: list[str] = []
+    workflow_vars = vars(workflow)
+    workflow_status = workflow_vars["status"]
+    status_color = _status_color(workflow_status)
+    lines.append(f"[bold]ID:[/bold] {workflow_vars['id']}")
+    lines.append(f"[bold]Name:[/bold] {workflow_vars['name']}")
+    lines.append(
+        f"[bold]Status:[/bold] [{status_color}]{workflow_status.value}[/{status_color}]"
+    )
+    _append_optional_line(
+        lines,
+        workflow_vars["template"] is not None,
+        f"[bold]Template:[/bold] {workflow_vars['template']}",
+    )
+    _append_optional_line(
+        lines,
+        workflow_vars["issue_id"] is not None,
+        f"[bold]Issue:[/bold] {workflow_vars['issue_id']}",
+    )
+    lines.append(f"[bold]Created:[/bold] {workflow_vars['created_at'].isoformat()}")
+    lines.append(f"[bold]Updated:[/bold] {workflow_vars['updated_at'].isoformat()}")
+    _append_optional_line(
+        lines,
+        bool(workflow_vars["workspaces"]),
+        f"\n[bold]Workspaces:[/bold] {', '.join(workflow_vars['workspaces'])}",
+    )
+    _append_optional_line(
+        lines,
+        bool(workflow_vars["agents"]),
+        f"[bold]Agents:[/bold] {', '.join(workflow_vars['agents'])}",
+    )
+    _append_optional_line(
+        lines,
+        workflow_vars["pr_url"] is not None,
+        f"\n[bold]PR:[/bold] {workflow_vars['pr_url']}",
+    )
+    _append_optional_line(
+        lines,
+        workflow_vars["error"] is not None,
+        f"\n[red]Error:[/red] {workflow_vars['error']}",
+    )
+    return Panel("\n".join(lines), title=f"Workflow: {workflow_vars['id']}")
+
+
+def _show_workflow_details(
     ctx: click.Context,
     workflow_id: str,
     output_json: bool,
 ) -> None:
-    """Show workflow details."""
     from .api import ConductorAPI
 
     api = ConductorAPI(ctx.obj.get("state_dir"))
@@ -238,34 +451,31 @@ def show_cmd(
 
         if output_json:
             click.echo(json.dumps(workflow.to_dict(), indent=2))
-        else:
-            lines = []
-            lines.append(f"[bold]ID:[/bold] {workflow.id}")
-            lines.append(f"[bold]Name:[/bold] {workflow.name}")
-            lines.append(
-                f"[bold]Status:[/bold] [{_status_color(workflow.status)}]{workflow.status.value}[/{_status_color(workflow.status)}]"
-            )
-            if workflow.template:
-                lines.append(f"[bold]Template:[/bold] {workflow.template}")
-            if workflow.issue_id:
-                lines.append(f"[bold]Issue:[/bold] {workflow.issue_id}")
-            lines.append(f"[bold]Created:[/bold] {workflow.created_at.isoformat()}")
-            lines.append(f"[bold]Updated:[/bold] {workflow.updated_at.isoformat()}")
+            return
 
-            if workflow.workspaces:
-                lines.append(f"\n[bold]Workspaces:[/bold] {', '.join(workflow.workspaces)}")
-            if workflow.agents:
-                lines.append(f"[bold]Agents:[/bold] {', '.join(workflow.agents)}")
-            if workflow.pr_url:
-                lines.append(f"\n[bold]PR:[/bold] {workflow.pr_url}")
-            if workflow.error:
-                lines.append(f"\n[red]Error:[/red] {workflow.error}")
-
-            console.print(Panel("\n".join(lines), title=f"Workflow: {workflow.id}"))
-
-    except Exception as e:
+        console.print(_workflow_detail_panel(workflow))
+    except _CLI_USER_ERROR_TYPES as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
+
+
+@cli.command("show")
+@click.argument("workflow_id")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--since", type=int, help="Show progress events after this sequence")
+@click.pass_context
+def show_cmd(
+    ctx: click.Context,
+    workflow_id: str,
+    output_json: bool,
+    since: int | None,
+) -> None:
+    """Show workflow details."""
+    if since is not None:
+        _show_progress_since(ctx, workflow_id, output_json, since)
+        return
+
+    _show_workflow_details(ctx, workflow_id, output_json)
 
 
 @cli.command("watch")
@@ -299,7 +509,7 @@ def watch_cmd(
 
     except KeyboardInterrupt:
         console.print("\n[dim]Watch stopped[/dim]")
-    except Exception as e:
+    except _CLI_USER_ERROR_TYPES as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
@@ -330,9 +540,113 @@ def stop_cmd(
         else:
             console.print("[dim]Nothing to stop[/dim]")
 
-    except Exception as e:
+    except _CLI_USER_ERROR_TYPES as e:
         if output_json:
             click.echo(json.dumps({"ok": False, "error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
+# =============================================================================
+# Environment Commands
+# =============================================================================
+
+
+@cli.group("env")
+def env_group() -> None:
+    """Author-facing environment vocabulary."""
+
+
+@env_group.command("describe")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def env_describe(output_json: bool) -> None:
+    """Describe profiles, role conventions, router policy, and capabilities."""
+    from doeff_conductor.verbs import describe_environment
+
+    try:
+        description = describe_environment()
+        if output_json:
+            click.echo(json.dumps(description, indent=2))
+            return
+
+        profile_table = Table(show_header=True, header_style="bold")
+        profile_table.add_column("PROFILE", style="cyan")
+        profile_table.add_column("BUDGET")
+        profile_table.add_column("CAPABILITIES")
+        for profile in description["profiles"]:
+            profile_table.add_row(
+                profile["name"],
+                str(profile["budget_units"]),
+                ", ".join(profile["capabilities"]),
+            )
+        console.print(profile_table)
+
+        router_table = Table(show_header=True, header_style="bold")
+        router_table.add_column("CLASS", style="cyan")
+        router_table.add_column("DEFAULT PROFILE")
+        for verification_class, profile in description["router_default_policy"].items():
+            router_table.add_row(verification_class, profile)
+        console.print(router_table)
+        console.print(
+            f"Available capabilities: {', '.join(description['available_capabilities'])}"
+        )
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
+# =============================================================================
+# Gate Queue Commands
+# =============================================================================
+
+
+@cli.group("gate")
+def gate_group() -> None:
+    """Overseer gate queue commands."""
+
+
+@gate_group.command("list")
+@click.argument("workflow_id", required=False)
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def gate_list(ctx: click.Context, workflow_id: str | None, output_json: bool) -> None:
+    """List open gates with stakes metadata and closure-preserving options."""
+    from doeff_conductor.api import ConductorAPI
+    from doeff_conductor.overseer import list_open_gates
+
+    try:
+        state_dir = ConductorAPI(ctx.obj.get("state_dir")).state_dir
+        gates = list_open_gates(state_dir, workflow_id)
+        if output_json:
+            click.echo(json.dumps(gates, indent=2))
+            return
+
+        if not gates:
+            console.print("[dim]No open gates found[/dim]")
+            return
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("GATE", style="cyan")
+        table.add_column("WORKFLOW")
+        table.add_column("PHASE")
+        table.add_column("REASON")
+        table.add_column("OPTIONS")
+        for gate in gates:
+            table.add_row(
+                gate["gate_id"],
+                gate["workflow_id"],
+                gate["phase"] or "-",
+                gate["reason"],
+                ", ".join(option["name"] for option in gate["options"]),
+            )
+        console.print(table)
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
         else:
             console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
@@ -376,10 +690,7 @@ def issue_create(
     # Handle body from file
     body_text = ""
     if body:
-        if body.startswith("@"):
-            body_text = Path(body[1:]).read_text()
-        else:
-            body_text = body
+        body_text = Path(body[1:]).read_text() if body.startswith("@") else body
 
     try:
         issue_obj = handler.handle_create_issue(

--- a/packages/doeff-conductor/src/doeff_conductor/environment.py
+++ b/packages/doeff-conductor/src/doeff_conductor/environment.py
@@ -1,0 +1,195 @@
+"""Author-facing conductor environment description and profile resolution."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from doeff_conductor.replay_keying import ResolvedIdentity, resolved_identity_fingerprint
+
+DEFAULT_SITE_CAPABILITIES: tuple[str, ...] = (
+    "durable-sessions",
+    "interactive",
+    "schema-validation",
+)
+
+DEFAULT_ROUTER_POLICY: Mapping[str, str] = {
+    "mechanical": "cheap-coder",
+    "test-verifiable": "cheap-coder",
+    "semantic": "frontier-reviewer",
+}
+
+DEFAULT_ROLE_CONVENTIONS: Mapping[str, str] = {
+    "implementer": "writes scoped implementation artifacts; usually cheap-coder",
+    "fixer": "repairs deterministic gate failures; usually cheap-coder",
+    "test-writer": "adds focused verification; usually cheap-coder",
+    "reviewer": "emits structured verdicts; usually cheap-reviewer or frontier-reviewer",
+}
+
+DEFAULT_PROFILE_DATA: Mapping[str, Mapping[str, Any]] = {
+    "cheap-coder": {
+        "adapter": "codex",
+        "model": "default-cheap-coder",
+        "capabilities": ("durable-sessions", "schema-validation"),
+        "budget_units": 1,
+    },
+    "cheap-reviewer": {
+        "adapter": "codex",
+        "model": "default-cheap-reviewer",
+        "capabilities": ("durable-sessions", "schema-validation"),
+        "budget_units": 1,
+    },
+    "frontier-reviewer": {
+        "adapter": "claude",
+        "model": "default-frontier-reviewer",
+        "capabilities": ("durable-sessions", "interactive", "schema-validation"),
+        "budget_units": 3,
+    },
+    "frontier-author": {
+        "adapter": "claude",
+        "model": "default-frontier-author",
+        "capabilities": ("durable-sessions", "interactive", "schema-validation"),
+        "budget_units": 3,
+    },
+}
+
+
+@dataclass(frozen=True)
+class ProfileBinding:
+    """Semantic profile binding without user auth or account contents."""
+
+    name: str
+    adapter: str
+    model: str
+    capabilities: tuple[str, ...]
+    budget_units: int
+
+    @classmethod
+    def from_mapping(cls, name: str, data: Mapping[str, Any]) -> ProfileBinding:
+        adapter: object | None = data.get("adapter")
+        model: object | None = data.get("model")
+        if not isinstance(adapter, str) or not adapter:
+            raise ValueError(f"profile {name!r} requires non-empty adapter")
+        if not isinstance(model, str) or not model:
+            raise ValueError(f"profile {name!r} requires non-empty model")
+
+        raw_capabilities: object = data.get("capabilities", ())
+        if not isinstance(raw_capabilities, (list, tuple)):
+            raise ValueError(f"profile {name!r} capabilities must be a list")
+        capabilities: tuple[str, ...] = tuple(str(item) for item in raw_capabilities)
+
+        raw_budget_units: object = data.get("budget_units", 1)
+        if not isinstance(raw_budget_units, int) or isinstance(raw_budget_units, bool):
+            raise ValueError(f"profile {name!r} budget_units must be an integer")
+        if raw_budget_units < 0:
+            raise ValueError(f"profile {name!r} budget_units must be non-negative")
+
+        return cls(
+            name=name,
+            adapter=adapter,
+            model=model,
+            capabilities=capabilities,
+            budget_units=raw_budget_units,
+        )
+
+    @property
+    def resolved_identity(self) -> ResolvedIdentity:
+        return ResolvedIdentity(adapter=self.adapter, model=self.model, identity=None)
+
+    @property
+    def identity_fingerprint(self) -> str:
+        return resolved_identity_fingerprint(self.resolved_identity)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "capabilities": list(self.capabilities),
+            "budget_units": self.budget_units,
+        }
+
+
+@dataclass(frozen=True)
+class ProfileRegistry:
+    """Resolved project profile registry with an environment default."""
+
+    profiles: Mapping[str, ProfileBinding]
+    default_profile: str = "cheap-coder"
+
+    def resolve(self, profile_name: str) -> ProfileBinding:
+        profile: ProfileBinding | None = self.profiles.get(profile_name)
+        if profile is None:
+            raise ValueError(f"profile {profile_name!r} is not defined")
+        return profile
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "profiles": [
+                profile.to_public_dict()
+                for profile in sorted(self.profiles.values(), key=lambda item: item.name)
+            ],
+            "default_profile": self.default_profile,
+        }
+
+
+def load_profile_registry_from_env() -> ProfileRegistry:
+    """Load minimal semantic profile bindings from env/config, or defaults."""
+
+    raw_json: str | None = os.environ.get("CONDUCTOR_PROFILES_JSON")
+    config_path_text: str | None = os.environ.get("CONDUCTOR_PROFILE_CONFIG")
+    raw_default_profile: str | None = os.environ.get("CONDUCTOR_DEFAULT_PROFILE")
+
+    profile_data: Mapping[str, Any]
+    if raw_json is not None:
+        loaded_json: object = json.loads(raw_json)
+        if not isinstance(loaded_json, dict):
+            raise ValueError("CONDUCTOR_PROFILES_JSON must be a JSON object")
+        profile_data = loaded_json
+    elif config_path_text is not None:
+        config_path: Path = Path(config_path_text)
+        loaded_config: object = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(loaded_config, dict):
+            raise ValueError("CONDUCTOR_PROFILE_CONFIG must contain a JSON object")
+        profile_data = loaded_config
+    else:
+        profile_data = DEFAULT_PROFILE_DATA
+
+    profiles: dict[str, ProfileBinding] = {}
+    for raw_name, raw_profile in profile_data.items():
+        profile_name: str = str(raw_name)
+        if not isinstance(raw_profile, Mapping):
+            raise ValueError(f"profile {profile_name!r} must be an object")
+        profiles[profile_name] = ProfileBinding.from_mapping(profile_name, raw_profile)
+
+    default_profile: str = raw_default_profile or "cheap-coder"
+    if default_profile not in profiles:
+        raise ValueError(f"default profile {default_profile!r} is not defined")
+
+    return ProfileRegistry(profiles=profiles, default_profile=default_profile)
+
+
+def describe_author_environment(
+    *,
+    registry: ProfileRegistry | None = None,
+    site_capabilities: tuple[str, ...] = DEFAULT_SITE_CAPABILITIES,
+) -> dict[str, Any]:
+    """Return machine-readable author-facing vocabulary without auth details."""
+
+    active_registry: ProfileRegistry = registry or load_profile_registry_from_env()
+    return {
+        "profiles": [
+            {
+                "name": profile.name,
+                "capabilities": list(profile.capabilities),
+                "budget_units": profile.budget_units,
+            }
+            for profile in sorted(active_registry.profiles.values(), key=lambda item: item.name)
+        ],
+        "roles": dict(DEFAULT_ROLE_CONVENTIONS),
+        "router_default_policy": dict(DEFAULT_ROUTER_POLICY),
+        "interpreter_env_default": active_registry.default_profile,
+        "available_capabilities": sorted(site_capabilities),
+    }

--- a/packages/doeff-conductor/src/doeff_conductor/interpreters.py
+++ b/packages/doeff-conductor/src/doeff_conductor/interpreters.py
@@ -1,0 +1,35 @@
+"""Named conductor interpreter constants backing public verbs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InterpreterConstant:
+    """System-internal interpreter selection marker.
+
+    Public author and overseer surfaces expose verbs. They do not accept these
+    constants as arguments.
+    """
+
+    name: str
+    purpose: str
+    token_cost: str
+
+
+plan_interpreter = InterpreterConstant(
+    name="plan",
+    purpose="record and estimate agent!/gate!/workspace! without executing them",
+    token_cost="zero",
+)
+validation_interpreter = InterpreterConstant(
+    name="validation",
+    purpose="scenario-driven stub simulation for control flow and closure checks",
+    token_cost="zero",
+)
+production_interpreter = InterpreterConstant(
+    name="production",
+    purpose="journaled production execution through the resolved conductor handlers",
+    token_cost="real",
+)

--- a/packages/doeff-conductor/src/doeff_conductor/overseer.py
+++ b/packages/doeff-conductor/src/doeff_conductor/overseer.py
@@ -1,0 +1,241 @@
+"""Journal-materialized overseer progress and gate queue views."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+RUN_STATE_FILENAME = "run-state.json"
+
+
+@dataclass(frozen=True)
+class GateOption:
+    """One closure-preserving gate option."""
+
+    name: str
+    outcome: str
+    description: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "outcome": self.outcome,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GateOption:
+        return cls(
+            name=str(data["name"]),
+            outcome=str(data["outcome"]),
+            description=str(data["description"]),
+        )
+
+
+@dataclass(frozen=True)
+class OpenGateView:
+    """Open gate exposed to the overseer queue."""
+
+    gate_id: str
+    workflow_id: str
+    node_id: str
+    phase: str | None
+    reason: str
+    stakes: dict[str, Any]
+    options: tuple[GateOption, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gate_id": self.gate_id,
+            "workflow_id": self.workflow_id,
+            "node_id": self.node_id,
+            "phase": self.phase,
+            "reason": self.reason,
+            "stakes": self.stakes,
+            "options": [option.to_dict() for option in self.options],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OpenGateView:
+        raw_options: object = data.get("options", [])
+        if not isinstance(raw_options, list):
+            raise ValueError("gate options must be a list")
+        options: tuple[GateOption, ...] = tuple(
+            GateOption.from_dict(option)
+            for option in raw_options
+            if isinstance(option, dict)
+        )
+        return cls(
+            gate_id=str(data["gate_id"]),
+            workflow_id=str(data["workflow_id"]),
+            node_id=str(data["node_id"]),
+            phase=data.get("phase") if data.get("phase") is None else str(data.get("phase")),
+            reason=str(data["reason"]),
+            stakes=dict(data.get("stakes", {})),
+            options=options,
+        )
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    """One delta-oriented run progress event."""
+
+    sequence: int
+    workflow_id: str
+    node_id: str
+    phase: str | None
+    status: str
+    message: str
+    terminal_kind: str | None = None
+    at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sequence": self.sequence,
+            "workflow_id": self.workflow_id,
+            "node_id": self.node_id,
+            "phase": self.phase,
+            "status": self.status,
+            "message": self.message,
+            "terminal_kind": self.terminal_kind,
+            "at": self.at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProgressEvent:
+        return cls(
+            sequence=int(data["sequence"]),
+            workflow_id=str(data["workflow_id"]),
+            node_id=str(data["node_id"]),
+            phase=data.get("phase") if data.get("phase") is None else str(data.get("phase")),
+            status=str(data["status"]),
+            message=str(data["message"]),
+            terminal_kind=(
+                data.get("terminal_kind")
+                if data.get("terminal_kind") is None
+                else str(data.get("terminal_kind"))
+            ),
+            at=str(data.get("at", "")),
+        )
+
+
+@dataclass(frozen=True)
+class RunStateView:
+    """Persisted overseer-visible run state."""
+
+    workflow_id: str
+    workflow_name: str
+    events: tuple[ProgressEvent, ...]
+    open_gates: tuple[OpenGateView, ...]
+    supervision: str = "autonomous"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workflow_id": self.workflow_id,
+            "workflow_name": self.workflow_name,
+            "supervision": self.supervision,
+            "events": [event.to_dict() for event in self.events],
+            "open_gates": [gate.to_dict() for gate in self.open_gates],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunStateView:
+        raw_events: object = data.get("events", [])
+        raw_gates: object = data.get("open_gates", [])
+        if not isinstance(raw_events, list):
+            raise ValueError("run-state events must be a list")
+        if not isinstance(raw_gates, list):
+            raise ValueError("run-state open_gates must be a list")
+        events: tuple[ProgressEvent, ...] = tuple(
+            ProgressEvent.from_dict(event)
+            for event in raw_events
+            if isinstance(event, dict)
+        )
+        gates: tuple[OpenGateView, ...] = tuple(
+            OpenGateView.from_dict(gate)
+            for gate in raw_gates
+            if isinstance(gate, dict)
+        )
+        return cls(
+            workflow_id=str(data["workflow_id"]),
+            workflow_name=str(data["workflow_name"]),
+            supervision=str(data.get("supervision", "autonomous")),
+            events=events,
+            open_gates=gates,
+        )
+
+
+def run_state_path(state_dir: str | Path, workflow_id: str) -> Path:
+    return Path(state_dir) / "workflows" / workflow_id / RUN_STATE_FILENAME
+
+
+def save_run_state(state_dir: str | Path, run_state: RunStateView) -> None:
+    path: Path = run_state_path(state_dir, run_state.workflow_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(run_state.to_dict(), indent=2, sort_keys=True, ensure_ascii=True),
+        encoding="utf-8",
+    )
+
+
+def load_run_state(state_dir: str | Path, workflow_id: str) -> RunStateView:
+    path: Path = run_state_path(state_dir, workflow_id)
+    if not path.exists():
+        raise FileNotFoundError(f"run state not found for workflow {workflow_id!r}")
+    payload: object = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("run state payload must be an object")
+    return RunStateView.from_dict(payload)
+
+
+def progress_since(state_dir: str | Path, workflow_id: str, since_sequence: int) -> list[dict[str, Any]]:
+    run_state: RunStateView = load_run_state(state_dir, workflow_id)
+    return [
+        event.to_dict()
+        for event in run_state.events
+        if event.sequence > since_sequence
+    ]
+
+
+def list_open_gates(state_dir: str | Path, workflow_id: str | None = None) -> list[dict[str, Any]]:
+    base_dir: Path = Path(state_dir) / "workflows"
+    if workflow_id is not None:
+        return [gate.to_dict() for gate in load_run_state(state_dir, workflow_id).open_gates]
+
+    gates: list[dict[str, Any]] = []
+    if not base_dir.exists():
+        return gates
+    for workflow_dir in sorted(base_dir.iterdir()):
+        if not workflow_dir.is_dir():
+            continue
+        path: Path = workflow_dir / RUN_STATE_FILENAME
+        if not path.exists():
+            continue
+        run_state: RunStateView = load_run_state(state_dir, workflow_dir.name)
+        gates.extend(gate.to_dict() for gate in run_state.open_gates)
+    return gates
+
+
+def make_progress_event(
+    *,
+    sequence: int,
+    workflow_id: str,
+    node_id: str,
+    phase: str | None,
+    status: str,
+    message: str,
+    terminal_kind: str | None = None,
+) -> ProgressEvent:
+    return ProgressEvent(
+        sequence=sequence,
+        workflow_id=workflow_id,
+        node_id=node_id,
+        phase=phase,
+        status=status,
+        message=message,
+        terminal_kind=terminal_kind,
+        at=datetime.now(timezone.utc).isoformat(),
+    )

--- a/packages/doeff-conductor/src/doeff_conductor/replay_keying.py
+++ b/packages/doeff-conductor/src/doeff_conductor/replay_keying.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any
 
 
@@ -18,21 +18,22 @@ class ResolvedIdentity:
 
 
 def _canonical_payload(value: Any) -> Any:
-    if isinstance(value, dict):
+    canonical_source = asdict(value) if is_dataclass(value) and not isinstance(value, type) else value
+    if isinstance(canonical_source, dict):
         return {
-            str(key): _canonical_payload(value[key])
-            for key in sorted(value, key=str)
+            str(key): _canonical_payload(canonical_source[key])
+            for key in sorted(canonical_source, key=str)
         }
-    if isinstance(value, (list, tuple)):
-        return [_canonical_payload(item) for item in value]
-    if isinstance(value, set):
-        return sorted(_canonical_payload(item) for item in value)
-    if isinstance(value, type):
-        return {"python_type": f"{value.__module__}.{value.__qualname__}"}
-    if hasattr(value, "model_json_schema"):
-        model_schema = value.model_json_schema()
+    if isinstance(canonical_source, (list, tuple)):
+        return [_canonical_payload(item) for item in canonical_source]
+    if isinstance(canonical_source, set):
+        return sorted(_canonical_payload(item) for item in canonical_source)
+    if isinstance(canonical_source, type):
+        return {"python_type": f"{canonical_source.__module__}.{canonical_source.__qualname__}"}
+    if hasattr(canonical_source, "model_json_schema"):
+        model_schema = canonical_source.model_json_schema()
         return _canonical_payload(model_schema)
-    return value
+    return canonical_source
 
 
 def _canonical_json(value: Any) -> str:

--- a/packages/doeff-conductor/src/doeff_conductor/verbs.py
+++ b/packages/doeff-conductor/src/doeff_conductor/verbs.py
@@ -1,0 +1,527 @@
+"""C6 public verb implementations for planning and validation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from doeff_conductor.dsl import ExpandedNode, ExpandedWorkflow, WorkflowSpec
+from doeff_conductor.effects.dsl import AgentCall
+from doeff_conductor.environment import (
+    DEFAULT_ROUTER_POLICY,
+    DEFAULT_SITE_CAPABILITIES,
+    ProfileBinding,
+    ProfileRegistry,
+    describe_author_environment,
+    load_profile_registry_from_env,
+)
+from doeff_conductor.interpreters import plan_interpreter, validation_interpreter
+from doeff_conductor.overseer import (
+    GateOption,
+    OpenGateView,
+    ProgressEvent,
+    RunStateView,
+    make_progress_event,
+    save_run_state,
+)
+from doeff_conductor.replay_keying import agent_cache_key
+
+ALLOWED_TERMINAL_KINDS: frozenset[str] = frozenset(
+    {"artifact", "verdict", "escalation", "gate"}
+)
+BUILT_IN_VALIDATION_SCENARIOS: tuple[str, ...] = (
+    "all-pass",
+    "schema-invalid-then-pass",
+    "retry-exhaustion",
+    "quorum-shortfall",
+)
+SUPPORTED_SUPERVISION_POLICIES: tuple[str, ...] = ("autonomous", "phase-checkpoints")
+
+
+@dataclass(frozen=True)
+class BindingPlanRow:
+    """One statically resolved agent binding."""
+
+    node_id: str
+    role: str
+    profile: str
+    fingerprint: str
+    phase: str | None
+    verification_class: str
+    estimated_budget_units: int
+    resolution_source: str
+    label: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "role": self.role,
+            "profile": self.profile,
+            "fingerprint": self.fingerprint,
+            "phase": self.phase,
+            "verification_class": self.verification_class,
+            "estimated_budget_units": self.estimated_budget_units,
+            "resolution_source": self.resolution_source,
+            "label": self.label,
+        }
+
+
+@dataclass(frozen=True)
+class BindingPlan:
+    """Overseer approval artifact for a workflow launch."""
+
+    workflow_name: str
+    interpreter: str
+    rows: tuple[BindingPlanRow, ...]
+    estimated_budget_units: int
+    totals_by_profile: Mapping[str, int]
+    capabilities_satisfied: bool
+    missing_capabilities: tuple[str, ...]
+    supervision: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workflow_name": self.workflow_name,
+            "interpreter": self.interpreter,
+            "rows": [row.to_dict() for row in self.rows],
+            "estimated_budget_units": self.estimated_budget_units,
+            "totals_by_profile": dict(self.totals_by_profile),
+            "capabilities_satisfied": self.capabilities_satisfied,
+            "missing_capabilities": list(self.missing_capabilities),
+            "supervision": self.supervision,
+        }
+
+
+@dataclass(frozen=True)
+class TerminalState:
+    """Terminal state reported by validation scenarios."""
+
+    node_id: str
+    terminal_kind: str
+    status: str
+    phase: str | None = None
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "terminal_kind": self.terminal_kind,
+            "status": self.status,
+            "phase": self.phase,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class ScenarioValidationReport:
+    """Validation result for one scenario."""
+
+    scenario: str
+    workflow_name: str
+    terminals: tuple[TerminalState, ...]
+    open_gates: tuple[OpenGateView, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario": self.scenario,
+            "workflow_name": self.workflow_name,
+            "terminals": [terminal.to_dict() for terminal in self.terminals],
+            "open_gates": [gate.to_dict() for gate in self.open_gates],
+            "closure_ok": True,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationSuiteReport:
+    """Validation report over all requested scenarios."""
+
+    workflow_name: str
+    interpreter: str
+    scenarios: tuple[ScenarioValidationReport, ...]
+    supervision: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workflow_name": self.workflow_name,
+            "interpreter": self.interpreter,
+            "supervision": self.supervision,
+            "scenarios": [scenario.to_dict() for scenario in self.scenarios],
+            "closure_ok": True,
+        }
+
+
+def plan_workflow(
+    workflow: WorkflowSpec | ExpandedWorkflow,
+    *,
+    registry: ProfileRegistry | None = None,
+    site_capabilities: tuple[str, ...] = DEFAULT_SITE_CAPABILITIES,
+    supervision: str = "autonomous",
+) -> BindingPlan:
+    """Resolve the static binding plan without executing workflow effects."""
+
+    _validate_supervision(supervision)
+    expanded: ExpandedWorkflow = _ensure_expanded(workflow)
+    active_registry: ProfileRegistry = registry or load_profile_registry_from_env()
+    rows: list[BindingPlanRow] = []
+    missing_capabilities: set[str] = set()
+    totals_by_profile: dict[str, int] = {}
+
+    for node in expanded.nodes:
+        if node.kind != "agent":
+            continue
+        if not isinstance(node.effect, AgentCall):
+            raise ValueError(f"agent node {node.node_id!r} does not carry AgentCall")
+
+        profile_name, source = resolve_agent_profile(
+            node.effect,
+            roles=expanded.roles,
+            registry=active_registry,
+        )
+        profile: ProfileBinding = active_registry.resolve(profile_name)
+        required_capabilities: tuple[str, ...] = _required_capabilities(
+            node.effect,
+            expanded.roles,
+        )
+        missing_capabilities.update(
+            capability
+            for capability in required_capabilities
+            if capability not in profile.capabilities and capability not in site_capabilities
+        )
+        fingerprint: str = agent_cache_key(
+            prompt=node.effect.prompt,
+            schema=node.effect.schema,
+            resolved_identity=profile.resolved_identity,
+        )
+        estimated_budget_units: int = node.budget_units or profile.budget_units
+        totals_by_profile[profile_name] = (
+            totals_by_profile.get(profile_name, 0) + estimated_budget_units
+        )
+        rows.append(
+            BindingPlanRow(
+                node_id=node.node_id,
+                role=node.effect.role,
+                profile=profile_name,
+                fingerprint=fingerprint,
+                phase=node.phase,
+                verification_class=node.effect.verification_class,
+                estimated_budget_units=estimated_budget_units,
+                resolution_source=source,
+                label=node.effect.label,
+            )
+        )
+
+    return BindingPlan(
+        workflow_name=expanded.name,
+        interpreter=plan_interpreter.name,
+        rows=tuple(rows),
+        estimated_budget_units=sum(row.estimated_budget_units for row in rows),
+        totals_by_profile=totals_by_profile,
+        capabilities_satisfied=not missing_capabilities,
+        missing_capabilities=tuple(sorted(missing_capabilities)),
+        supervision=supervision,
+    )
+
+
+def resolve_agent_profile(
+    effect: AgentCall,
+    *,
+    roles: Mapping[str, Mapping[str, Any]],
+    registry: ProfileRegistry,
+) -> tuple[str, str]:
+    """Resolve the fixed D7 profile cascade in one place."""
+
+    if effect.profile is not None:
+        registry.resolve(effect.profile)
+        return effect.profile, "explicit"
+
+    role_spec: Mapping[str, Any] = roles[effect.role]
+    role_profile: object | None = role_spec.get("profile")
+    if isinstance(role_profile, str) and role_profile:
+        registry.resolve(role_profile)
+        return role_profile, "role"
+
+    routed_profile: str | None = DEFAULT_ROUTER_POLICY.get(effect.verification_class)
+    if routed_profile is not None:
+        registry.resolve(routed_profile)
+        return routed_profile, "router"
+
+    registry.resolve(registry.default_profile)
+    return registry.default_profile, "interpreter-env"
+
+
+def validate_workflow(
+    workflow: WorkflowSpec | ExpandedWorkflow,
+    *,
+    scenarios: Sequence[str] | None = None,
+    supervision: str = "autonomous",
+    state_dir: str | None = None,
+    run_id: str | None = None,
+) -> ValidationSuiteReport:
+    """Run scenario-driven stub validation and assert closure."""
+
+    _validate_supervision(supervision)
+    expanded: ExpandedWorkflow = _ensure_expanded(workflow)
+    reports: list[ScenarioValidationReport] = []
+    active_scenarios: Sequence[str] = scenarios or BUILT_IN_VALIDATION_SCENARIOS
+    for scenario in active_scenarios:
+        if scenario not in BUILT_IN_VALIDATION_SCENARIOS:
+            raise ValueError(f"unknown validation scenario: {scenario}")
+        report: ScenarioValidationReport = _simulate_scenario(
+            expanded,
+            scenario=scenario,
+            supervision=supervision,
+            workflow_id=run_id or expanded.name,
+        )
+        assert_validation_closure(report)
+        reports.append(report)
+
+    suite: ValidationSuiteReport = ValidationSuiteReport(
+        workflow_name=expanded.name,
+        interpreter=validation_interpreter.name,
+        scenarios=tuple(reports),
+        supervision=supervision,
+    )
+
+    if state_dir is not None and run_id is not None:
+        save_run_state(state_dir, _run_state_from_reports(run_id, expanded.name, suite))
+
+    return suite
+
+
+def assert_validation_closure(report: ScenarioValidationReport) -> None:
+    """Fail loudly when a validation terminal violates the closure law."""
+
+    for terminal in report.terminals:
+        if terminal.terminal_kind not in ALLOWED_TERMINAL_KINDS:
+            raise ValueError(
+                f"closure law violation in {report.scenario}: "
+                f"{terminal.node_id} ended as {terminal.terminal_kind!r}"
+            )
+
+
+def describe_environment() -> dict[str, Any]:
+    return describe_author_environment()
+
+
+def _ensure_expanded(workflow: WorkflowSpec | ExpandedWorkflow) -> ExpandedWorkflow:
+    if isinstance(workflow, ExpandedWorkflow):
+        return workflow
+    return workflow.expand()
+
+
+def _required_capabilities(
+    effect: AgentCall,
+    roles: Mapping[str, Mapping[str, Any]],
+) -> tuple[str, ...]:
+    role_spec: Mapping[str, Any] = roles[effect.role]
+    raw_capabilities: object = role_spec.get("requires", ())
+    if raw_capabilities == ():
+        raw_capabilities = role_spec.get("capabilities", ())
+    if not isinstance(raw_capabilities, Iterable) or isinstance(raw_capabilities, (str, bytes)):
+        raise ValueError(f"role {effect.role!r} capabilities must be a sequence")
+    capabilities: tuple[str, ...] = tuple(str(item) for item in raw_capabilities)
+    return ("schema-validation", *capabilities)
+
+
+def _validate_supervision(supervision: str) -> None:
+    if supervision not in SUPPORTED_SUPERVISION_POLICIES:
+        raise ValueError(f"unsupported supervision policy: {supervision}")
+
+
+def _simulate_scenario(
+    expanded: ExpandedWorkflow,
+    *,
+    scenario: str,
+    supervision: str,
+    workflow_id: str,
+) -> ScenarioValidationReport:
+    terminals: list[TerminalState] = []
+    open_gates: list[OpenGateView] = []
+
+    for node in expanded.nodes:
+        terminal: TerminalState = _terminal_for_node(node, scenario)
+        terminals.append(terminal)
+        if terminal.terminal_kind == "gate":
+            open_gates.append(
+                _open_gate_for_terminal(
+                    workflow_id=workflow_id,
+                    terminal=terminal,
+                    reason=terminal.detail or scenario,
+                    expanded=expanded,
+                )
+            )
+
+    if supervision == "phase-checkpoints":
+        for phase_name, phase in expanded.phases.items():
+            checkpoint_terminal: TerminalState = TerminalState(
+                node_id=f"checkpoint:{phase_name}",
+                terminal_kind="gate",
+                status="open",
+                phase=phase_name,
+                detail="phase checkpoint",
+            )
+            terminals.append(checkpoint_terminal)
+            open_gates.append(
+                OpenGateView(
+                    gate_id=f"{workflow_id}:checkpoint:{phase_name}",
+                    workflow_id=workflow_id,
+                    node_id=checkpoint_terminal.node_id,
+                    phase=phase_name,
+                    reason="phase checkpoint",
+                    stakes={
+                        "phase": phase_name,
+                        "level": phase.stakes,
+                        "verification_class": "checkpoint",
+                        "blast_radius": "dependent-subtree",
+                        "reversibility": "abortable",
+                    },
+                    options=_checkpoint_options(),
+                )
+            )
+
+    return ScenarioValidationReport(
+        scenario=scenario,
+        workflow_name=expanded.name,
+        terminals=tuple(terminals),
+        open_gates=tuple(open_gates),
+    )
+
+
+def _terminal_for_node(node: ExpandedNode, scenario: str) -> TerminalState:
+    if scenario == "retry-exhaustion" and node.kind == "agent":
+        return TerminalState(
+            node_id=node.node_id,
+            terminal_kind="gate",
+            status="open",
+            phase=node.phase,
+            detail="agent retry exhaustion",
+        )
+    if scenario == "quorum-shortfall" and node.kind in {"parallel", "parallel-for"}:
+        return TerminalState(
+            node_id=node.node_id,
+            terminal_kind="gate",
+            status="open",
+            phase=node.phase,
+            detail="quorum shortfall",
+        )
+    if node.kind == "agent":
+        detail: str = "schema invalid retry then pass" if scenario == "schema-invalid-then-pass" else scenario
+        return TerminalState(
+            node_id=node.node_id,
+            terminal_kind="artifact",
+            status="passed",
+            phase=node.phase,
+            detail=detail,
+        )
+    if node.kind == "gate":
+        return TerminalState(
+            node_id=node.node_id,
+            terminal_kind="artifact",
+            status="passed",
+            phase=node.phase,
+            detail="deterministic gate passed",
+        )
+    return TerminalState(
+        node_id=node.node_id,
+        terminal_kind="artifact",
+        status="passed",
+        phase=node.phase,
+        detail=f"{node.kind} closed",
+    )
+
+
+def _open_gate_for_terminal(
+    *,
+    workflow_id: str,
+    terminal: TerminalState,
+    reason: str,
+    expanded: ExpandedWorkflow,
+) -> OpenGateView:
+    stakes: dict[str, Any] = {
+        "phase": terminal.phase,
+        "level": _phase_stakes(expanded, terminal.phase),
+        "verification_class": "unknown",
+        "blast_radius": "dependent-subtree",
+        "reversibility": "abortable",
+    }
+    return OpenGateView(
+        gate_id=f"{workflow_id}:{terminal.node_id}",
+        workflow_id=workflow_id,
+        node_id=terminal.node_id,
+        phase=terminal.phase,
+        reason=reason,
+        stakes=stakes,
+        options=_failure_gate_options(),
+    )
+
+
+def _phase_stakes(expanded: ExpandedWorkflow, phase_name: str | None) -> str:
+    if phase_name is None:
+        return "normal"
+    phase = expanded.phases.get(phase_name)
+    if phase is None:
+        return "normal"
+    return phase.stakes
+
+
+def _failure_gate_options() -> tuple[GateOption, ...]:
+    return (
+        GateOption(
+            name="retry-with-feedback",
+            outcome="resume",
+            description="Retry the blocked node with overseer feedback.",
+        ),
+        GateOption(
+            name="abort",
+            outcome="abort",
+            description="Abort the run and preserve the gate as the terminal outcome.",
+        ),
+    )
+
+
+def _checkpoint_options() -> tuple[GateOption, ...]:
+    return (
+        GateOption(
+            name="proceed",
+            outcome="resume",
+            description="Accept the phase artifact summaries and continue.",
+        ),
+        GateOption(
+            name="abort",
+            outcome="abort",
+            description="Abort the run at this checkpoint.",
+        ),
+    )
+
+
+def _run_state_from_reports(
+    workflow_id: str,
+    workflow_name: str,
+    suite: ValidationSuiteReport,
+) -> RunStateView:
+    events: list[ProgressEvent] = []
+    gates: list[OpenGateView] = []
+    sequence: int = 0
+    for report in suite.scenarios:
+        for terminal in report.terminals:
+            sequence += 1
+            events.append(
+                make_progress_event(
+                    sequence=sequence,
+                    workflow_id=workflow_id,
+                    node_id=terminal.node_id,
+                    phase=terminal.phase,
+                    status=terminal.status,
+                    message=f"{report.scenario}: {terminal.detail or terminal.terminal_kind}",
+                    terminal_kind=terminal.terminal_kind,
+                )
+            )
+        gates.extend(report.open_gates)
+    return RunStateView(
+        workflow_id=workflow_id,
+        workflow_name=workflow_name,
+        events=tuple(events),
+        open_gates=tuple(gates),
+        supervision=suite.supervision,
+    )

--- a/packages/doeff-conductor/src/doeff_conductor/workflow_loader.py
+++ b/packages/doeff-conductor/src/doeff_conductor/workflow_loader.py
@@ -1,0 +1,52 @@
+"""Load committed Python workflow fixtures for conductor verbs."""
+
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from doeff_conductor.dsl import WorkflowSpec
+
+
+def load_workflow_spec(workflow_path_text: str) -> WorkflowSpec:
+    """Load a WorkflowSpec from a Python file.
+
+    The module may expose ``workflow``/``WORKFLOW`` directly or a zero-argument
+    ``build_workflow`` function.
+    """
+
+    workflow_path: Path = Path(workflow_path_text)
+    if not workflow_path.exists():
+        raise ValueError(f"workflow file not found: {workflow_path_text}")
+    if workflow_path.suffix != ".py":
+        raise ValueError("C6 workflow verbs currently load Python workflow fixtures")
+
+    spec: ModuleSpec | None = importlib.util.spec_from_file_location(
+        f"doeff_conductor_workflow_{workflow_path.stem}",
+        workflow_path,
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError(f"cannot load workflow: {workflow_path_text}")
+
+    module: ModuleType = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    candidate: Any
+    if "workflow" in module.__dict__:
+        candidate = module.__dict__["workflow"]
+    elif "WORKFLOW" in module.__dict__:
+        candidate = module.__dict__["WORKFLOW"]
+    elif "build_workflow" in module.__dict__:
+        builder: object = module.__dict__["build_workflow"]
+        if not callable(builder):
+            raise ValueError("build_workflow must be callable")
+        candidate = builder()
+    else:
+        raise ValueError("workflow file must define workflow, WORKFLOW, or build_workflow")
+
+    if not isinstance(candidate, WorkflowSpec):
+        raise ValueError("loaded workflow object must be doeff_conductor.dsl.WorkflowSpec")
+    return candidate

--- a/packages/doeff-conductor/tests/fixtures/c6_k2_k3_workflow.py
+++ b/packages/doeff-conductor/tests/fixtures/c6_k2_k3_workflow.py
@@ -1,0 +1,200 @@
+"""C6 k2-k3-shaped workflow fixture for plan/validate CLI tests."""
+
+from __future__ import annotations
+
+from doeff_conductor.dsl import (
+    agent_bang,
+    artifact,
+    bind,
+    defphase,
+    defworkflow,
+    gate_bang,
+    loop,
+    merge_bang,
+    parallel,
+    prompt,
+    ref,
+    workspace_bang,
+)
+
+RESULT_SCHEMA = {
+    "type": "object",
+    "required": ["status"],
+    "properties": {"status": {"type": "string"}},
+}
+VERDICT_SCHEMA = {
+    "type": "object",
+    "required": ["verdict", "findings"],
+    "properties": {
+        "verdict": {"enum": ["PASS", "CHANGES_REQUESTED"]},
+        "findings": {"type": "array"},
+    },
+}
+
+
+def _agent(label: str, role: str, workspace: object, **overrides: object) -> object:
+    fields: dict[str, object] = {
+        "role": role,
+        "verification_class": "test-verifiable",
+        "prompt": prompt("work on ", label),
+        "schema": RESULT_SCHEMA,
+        "workspace": workspace,
+        "files": {f"{label}.py"},
+        "label": label,
+    }
+    fields.update(overrides)
+    return agent_bang(**fields)
+
+
+base = workspace_bang(from_="main")
+impl_workspaces = [workspace_bang(from_=f"main-impl-{index}") for index in range(5)]
+test_workspace = workspace_bang(from_="main-tests")
+gate_workspace = workspace_bang(from_="main-gate")
+
+workflow = defworkflow(
+    "k2_k3_reference_shape",
+    params={"issue": str, "base_ref": str},
+    roles={
+        "implementer": {"profile": "cheap-coder", "retry": 3},
+        "fixer": {"profile": "cheap-coder", "retry": 3},
+        "test_writer": {"profile": "cheap-coder", "retry": 2},
+        "reviewer": {"profile": "cheap-reviewer", "retry": 1},
+    },
+    body=[
+        defphase(
+            "Implement",
+            stakes="normal",
+            body=[
+                bind(
+                    "impls",
+                    parallel(
+                        *[
+                            _agent(
+                                f"impl-{index}",
+                                "implementer",
+                                impl_workspaces[index],
+                                prompt=prompt("implement variant ", index),
+                            )
+                            for index in range(5)
+                        ]
+                    ),
+                )
+            ],
+        ),
+        defphase(
+            "Fix",
+            stakes="high",
+            body=[
+                bind(
+                    "fixed",
+                    loop(
+                        max=3,
+                        until="tests_pass",
+                        body=[
+                            bind("fix_gate", gate_bang(cmd="uv run pytest", workspace=base)),
+                            _agent(
+                                "fixer",
+                                "fixer",
+                                base,
+                                files={"doeff/fix.py"},
+                                prompt=prompt(
+                                    "fix failures after ",
+                                    ref("impls"),
+                                    " from ",
+                                    ref("fix_gate"),
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        ),
+        defphase(
+            "Tests",
+            stakes="normal",
+            body=[
+                bind(
+                    "tests",
+                    parallel(
+                        _agent(
+                            "unit-tests",
+                            "test_writer",
+                            test_workspace,
+                            files={"tests/test_unit.py"},
+                            prompt=prompt("write unit tests for ", ref("fixed")),
+                        ),
+                        _agent(
+                            "integration-tests",
+                            "test_writer",
+                            test_workspace,
+                            files={"tests/test_integration.py"},
+                            prompt=prompt("write integration tests for ", ref("fixed")),
+                        ),
+                    ),
+                )
+            ],
+        ),
+        defphase(
+            "Gate",
+            stakes="high",
+            body=[
+                bind(
+                    "gated",
+                    loop(
+                        max=3,
+                        until="gate_passed",
+                        body=[
+                            bind(
+                                "test_gate",
+                                gate_bang(cmd="uv run pytest", workspace=gate_workspace),
+                            ),
+                            _agent(
+                                "gate-fixer",
+                                "fixer",
+                                gate_workspace,
+                                files={"doeff/gate_fix.py"},
+                                prompt=prompt(
+                                    "repair gate failures after ",
+                                    ref("tests"),
+                                    " ",
+                                    ref("test_gate"),
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        ),
+        defphase(
+            "Review",
+            stakes="high",
+            body=[
+                bind(
+                    "reviews",
+                    parallel(
+                        *[
+                            agent_bang(
+                                role="reviewer",
+                                verification_class="semantic",
+                                prompt=prompt("review axis ", axis, " for ", ref("gated")),
+                                schema=VERDICT_SCHEMA,
+                                workspace=gate_workspace,
+                                files={f"review/{axis}.md"},
+                                label=f"review-{axis}",
+                            )
+                            for axis in ["correctness", "tests", "architecture", "docs"]
+                        ]
+                    ),
+                ),
+                bind(
+                    "merged",
+                    merge_bang(
+                        workspaces=[base, test_workspace, gate_workspace, *impl_workspaces],
+                        strategy="merge",
+                    ),
+                ),
+                artifact(prompt(ref("reviews"), ref("merged"))),
+            ],
+        ),
+    ],
+)

--- a/packages/doeff-conductor/tests/test_c6_verbs_overseer.py
+++ b/packages/doeff-conductor/tests/test_c6_verbs_overseer.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from doeff_conductor.cli import cli
+from doeff_conductor.dsl import agent_bang, defworkflow
+from doeff_conductor.environment import ProfileRegistry, load_profile_registry_from_env
+from doeff_conductor.overseer import list_open_gates, progress_since
+from doeff_conductor.verbs import (
+    BUILT_IN_VALIDATION_SCENARIOS,
+    ScenarioValidationReport,
+    TerminalState,
+    assert_validation_closure,
+    plan_workflow,
+    validate_workflow,
+)
+from doeff_conductor.workflow_loader import load_workflow_spec
+
+RESULT_SCHEMA = {
+    "type": "object",
+    "required": ["status"],
+    "properties": {"status": {"type": "string"}},
+}
+
+
+def _fixture_path() -> Path:
+    return Path(__file__).parent / "fixtures" / "c6_k2_k3_workflow.py"
+
+
+def _cascade_agent(role: str, verification_class: str, **overrides: object) -> object:
+    fields = {
+        "role": role,
+        "verification_class": verification_class,
+        "prompt": f"{role} prompt",
+        "schema": RESULT_SCHEMA,
+        "label": role,
+    }
+    fields.update(overrides)
+    return agent_bang(**fields)
+
+
+def test_plan_resolves_k2_k3_fixture_without_executing_agents() -> None:
+    workflow = load_workflow_spec(str(_fixture_path()))
+
+    plan = plan_workflow(workflow)
+
+    assert plan.interpreter == "plan"
+    assert len(plan.rows) == 13
+    assert plan.estimated_budget_units == 13
+    assert plan.capabilities_satisfied
+    assert plan.totals_by_profile == {"cheap-coder": 9, "cheap-reviewer": 4}
+    assert {row.phase for row in plan.rows} == {
+        "Implement",
+        "Fix",
+        "Tests",
+        "Gate",
+        "Review",
+    }
+    assert all(row.fingerprint for row in plan.rows)
+
+
+def test_plan_profile_resolution_uses_single_cascade() -> None:
+    workflow = defworkflow(
+        "cascade",
+        params={},
+        roles={
+            "explicit": {},
+            "role": {"profile": "cheap-reviewer"},
+            "router": {},
+            "env": {},
+        },
+        body=[
+            _cascade_agent("explicit", "semantic", profile="frontier-author"),
+            _cascade_agent("role", "semantic"),
+            _cascade_agent("router", "test-verifiable"),
+            _cascade_agent("env", "novel"),
+        ],
+    )
+
+    plan = plan_workflow(workflow)
+
+    assert [row.profile for row in plan.rows] == [
+        "frontier-author",
+        "cheap-reviewer",
+        "cheap-coder",
+        "cheap-coder",
+    ]
+    assert [row.resolution_source for row in plan.rows] == [
+        "explicit",
+        "role",
+        "router",
+        "interpreter-env",
+    ]
+
+
+def test_plan_fails_when_profile_does_not_resolve() -> None:
+    workflow = defworkflow(
+        "missing_profile",
+        params={},
+        roles={"implementer": {"profile": "missing-profile"}},
+        body=[_cascade_agent("implementer", "test-verifiable")],
+    )
+
+    with pytest.raises(ValueError, match="profile"):
+        plan_workflow(workflow)
+
+
+def test_env_describe_uses_semantic_profile_surface_only() -> None:
+    registry: ProfileRegistry = load_profile_registry_from_env()
+    description = registry.to_public_dict()
+
+    assert {profile["name"] for profile in description["profiles"]} >= {
+        "cheap-coder",
+        "cheap-reviewer",
+    }
+    assert all("adapter" not in profile for profile in description["profiles"])
+    assert all("model" not in profile for profile in description["profiles"])
+
+
+def test_validate_runs_built_in_scenarios_and_asserts_closure() -> None:
+    workflow = load_workflow_spec(str(_fixture_path()))
+
+    report = validate_workflow(workflow)
+
+    assert report.interpreter == "validation"
+    assert [scenario.scenario for scenario in report.scenarios] == list(
+        BUILT_IN_VALIDATION_SCENARIOS
+    )
+    assert all(scenario.to_dict()["closure_ok"] for scenario in report.scenarios)
+    assert any(
+        gate.reason == "agent retry exhaustion"
+        for scenario in report.scenarios
+        for gate in scenario.open_gates
+    )
+    assert any(
+        terminal.detail == "schema invalid retry then pass"
+        for scenario in report.scenarios
+        for terminal in scenario.terminals
+    )
+
+
+def test_validate_closure_assertion_fails_loudly_for_broken_terminal() -> None:
+    broken = ScenarioValidationReport(
+        scenario="broken",
+        workflow_name="broken",
+        terminals=(
+            TerminalState(
+                node_id="broken/node",
+                terminal_kind="silent-drop",
+                status="done",
+            ),
+        ),
+        open_gates=(),
+    )
+
+    with pytest.raises(ValueError, match="closure law violation"):
+        assert_validation_closure(broken)
+
+
+def test_validate_materializes_gate_queue_and_progress_deltas(tmp_path: Path) -> None:
+    workflow = load_workflow_spec(str(_fixture_path()))
+
+    validate_workflow(
+        workflow,
+        scenarios=("all-pass",),
+        supervision="phase-checkpoints",
+        state_dir=str(tmp_path),
+        run_id="run-c6",
+    )
+
+    gates = list_open_gates(tmp_path, "run-c6")
+    deltas = progress_since(tmp_path, "run-c6", 0)
+
+    assert {gate["reason"] for gate in gates} == {"phase checkpoint"}
+    assert {"proceed", "abort"} <= {
+        option["name"]
+        for gate in gates
+        for option in gate["options"]
+    }
+    assert deltas
+    assert deltas[0]["sequence"] == 1
+
+
+def test_cli_plan_validate_env_gate_and_show_since(tmp_path: Path) -> None:
+    runner = CliRunner()
+    fixture_path = str(_fixture_path())
+
+    plan_result = runner.invoke(cli, ["plan", fixture_path, "--json"])
+    assert plan_result.exit_code == 0
+    plan_payload = json.loads(plan_result.output)
+    assert plan_payload["workflow_name"] == "k2_k3_reference_shape"
+    assert len(plan_payload["rows"]) == 13
+
+    env_result = runner.invoke(cli, ["env", "describe", "--json"])
+    assert env_result.exit_code == 0
+    env_payload = json.loads(env_result.output)
+    assert "router_default_policy" in env_payload
+    assert all("adapter" not in profile for profile in env_payload["profiles"])
+
+    validate_result = runner.invoke(
+        cli,
+        [
+            "--state-dir",
+            str(tmp_path),
+            "validate",
+            fixture_path,
+            "--scenario",
+            "all-pass",
+            "--supervision",
+            "phase-checkpoints",
+            "--run-id",
+            "run-c6",
+            "--json",
+        ],
+    )
+    assert validate_result.exit_code == 0
+    validate_payload = json.loads(validate_result.output)
+    assert validate_payload["closure_ok"]
+
+    gate_result = runner.invoke(
+        cli,
+        ["--state-dir", str(tmp_path), "gate", "list", "run-c6", "--json"],
+    )
+    assert gate_result.exit_code == 0
+    assert json.loads(gate_result.output)
+
+    show_result = runner.invoke(
+        cli,
+        ["--state-dir", str(tmp_path), "show", "run-c6", "--since", "0", "--json"],
+    )
+    assert show_result.exit_code == 0
+    assert json.loads(show_result.output)[0]["sequence"] == 1


### PR DESCRIPTION
## Summary

Implements C6 verb and overseer surfaces for `doeff-conductor`:

- Adds system-internal named interpreter constants: `plan_interpreter`, `validation_interpreter`, and `production_interpreter`.
- Adds semantic profile/environment description and one D7 profile resolver for the fixed cascade: explicit > role > router > interpreter env.
- Adds `conductor plan`, `conductor validate`, `conductor env describe`, `conductor gate list`, and `conductor show --since` surfaces.
- Materializes validation run state into open gate queues and delta progress events.
- Adds phase-checkpoint supervision gates with closure-preserving `proceed` / `abort` options.
- Adds a committed k2-k3-shaped C6 workflow fixture and regression tests, including a deliberately broken closure terminal test.
- Extends replay key canonicalization so DSL dataclass IR can be used safely in agent fingerprints.

Reference: conductor-c6-verbs-overseer

## Acceptance Evidence

- `uv run conductor plan packages/doeff-conductor/tests/fixtures/c6_k2_k3_workflow.py --json 2>&1 | tee /tmp/c6-plan.json`
  - Produced `workflow_name: k2_k3_reference_shape`.
  - Produced 13 resolved agent rows.
  - Totals: `cheap-coder: 9`, `cheap-reviewer: 4`.
  - `capabilities_satisfied: true`.

- `uv run conductor env describe --json 2>&1 | tee /tmp/c6-env.json`
  - Shows semantic profile names, capabilities, budgets, role conventions, router defaults, and available capabilities.
  - Does not emit auth/account contents, adapter names, or model names.

- `uv run conductor --state-dir /tmp/c6-verb-state validate packages/doeff-conductor/tests/fixtures/c6_k2_k3_workflow.py --scenario all-pass --supervision phase-checkpoints --run-id run-c6-final --json 2>&1 | tee /tmp/c6-validate.json`
  - Produced `interpreter: validation` and `closure_ok: true`.
  - Materialized phase checkpoint gates.

- `uv run conductor --state-dir /tmp/c6-verb-state gate list run-c6-final --json 2>&1 | tee /tmp/c6-gates.json`
  - Listed open checkpoint gates with stakes metadata.
  - Gate options are closure-preserving: `proceed` and `abort`.

- `uv run conductor --state-dir /tmp/c6-verb-state show run-c6-final --since 0 --json 2>&1 | tee /tmp/c6-progress.json`
  - Returned delta progress events from persisted run state.

- `packages/doeff-conductor/tests/test_c6_verbs_overseer.py::test_validate_closure_assertion_fails_loudly_for_broken_terminal`
  - Proves the closure assertion rejects a deliberately broken terminal state.

## Checks

- `uv run pytest packages/doeff-conductor 2>&1 | tee /tmp/c6-tests.log`
  - `237 passed, 44 warnings`
- `uv run ruff check packages/doeff-conductor/src/doeff_conductor/environment.py packages/doeff-conductor/src/doeff_conductor/interpreters.py packages/doeff-conductor/src/doeff_conductor/overseer.py packages/doeff-conductor/src/doeff_conductor/workflow_loader.py packages/doeff-conductor/src/doeff_conductor/verbs.py packages/doeff-conductor/src/doeff_conductor/cli.py packages/doeff-conductor/src/doeff_conductor/replay_keying.py packages/doeff-conductor/tests/test_c6_verbs_overseer.py packages/doeff-conductor/tests/fixtures/c6_k2_k3_workflow.py 2>&1 | tee /tmp/c6-ruff.log`
  - `All checks passed!`
- `uv run pyright packages/doeff-conductor/src/doeff_conductor/environment.py packages/doeff-conductor/src/doeff_conductor/interpreters.py packages/doeff-conductor/src/doeff_conductor/overseer.py packages/doeff-conductor/src/doeff_conductor/workflow_loader.py packages/doeff-conductor/src/doeff_conductor/verbs.py packages/doeff-conductor/tests/test_c6_verbs_overseer.py 2>&1 | tee /tmp/c6-pyright.log`
  - `0 errors, 0 warnings, 0 informations`