### PR TITLE
docs(conductor): D10 ephemeral workflows + loader-enforced nondeterminism + stage C8

### DIFF
--- a/packages/doeff-conductor/docs/adr-0001-workflow-dsl-and-attention-tiers.md
+++ b/packages/doeff-conductor/docs/adr-0001-workflow-dsl-and-attention-tiers.md
@@ -150,10 +150,18 @@ This is what makes the DSL writable by LLM authors and totally checkable.
 **Glue purity by construction:** glue runs as plain (non-kleisli)
 functions, so it structurally cannot launch agents or touch the
 environment. The residual hole — raw Python nondeterminism that is not an
-effect — is closed by a **validator** (doeff-linter, ERROR severity, no
-baselines) banning `datetime.now`/`random`/`open`/network/subprocess/
-non-allowlisted imports in workflow modules, each diagnostic naming the
-replacement (`time!`, `random!`, `gate!`, a `:params` entry).
+effect — is closed by the **workflow loader itself**: conductor AST-walks
+every workflow module at load time, banning `datetime.now`/`random`/
+`open`/network/subprocess/non-allowlisted imports, each diagnostic naming
+the replacement (`time!`, `random!`, `gate!`, a `:params` entry). Because
+the check lives in the loader, `plan`/`validate`/`run` all inherit it and
+no module marker is needed (the loader knows what it loads). A
+separately-run linter is NOT an acceptable enforcement point: workflows
+are ephemeral request artifacts (D10) that no CI will ever see — a gate
+that depends on a tool the author might run is a prompt promise, not an
+invariant. (This amends the original C2v placement in doeff-linter; the
+rule logic and fixtures move into conductor and the linter rule is
+deleted — no parallel implementations.)
 
 Macros compile to a static DAG of doeff Programs. Expansion-time checks
 (all free, before any token is spent):
@@ -172,7 +180,8 @@ Macros compile to a static DAG of doeff Programs. Expansion-time checks
   tolerated losses are journaled and surfaced, never silent;
 - dataflow well-formedness (references defined; unconsumed results
   flagged); budget annotations parse and sum;
-- the nondeterminism validator passes on the containing module.
+- the loader's nondeterminism check passes on the workflow module
+  (enforced at load time, so `plan`/`validate`/`run` cannot skip it).
 
 Keep the JS tool's load-bearing constraints: static graph skeleton, pure
 metadata, effect-boundary caching for replay resume — with the cache key
@@ -329,6 +338,33 @@ exist to solve, so supervision is a **trust dial**: first runs of a new
 workflow run supervised; the dial relaxes toward `autonomous` as
 calibration escape rates earn it.
 
+### D10 — Workflows are ephemeral request artifacts, never version-controlled code
+
+A workflow encodes ONE request ("implement these four features in
+parallel") — it is kin to a prompt, not to code. It is authored on demand
+(typically by an agent), used once, and discarded. **Committing a
+per-request workflow to a repository is an anti-pattern**: it references
+branches/issues/files that stop existing, becoming exactly the
+unowned-state rot this design bans elsewhere. (The doeff
+"committed Program constants" philosophy deliberately does NOT apply
+here.) The Claude Code Workflow tool being replaced already implements
+the correct lifecycle: scripts persist under the session directory and
+resume by run id — never in the target repo.
+
+Contract:
+- `conductor plan`/`run` **snapshot the workflow source into the run
+  state directory** (next to the journal). Resume — including
+  edit-and-resume — operates on the snapshot; the original path (`/tmp`,
+  a session dir) may vanish freely.
+- Durable workflow-shaped artifacts exist only as **named, parameterized
+  templates** (library code, `:params`-instantiated); the instantiation
+  is still snapshotted per run.
+- What stays version-controlled: ADR/spec, env config (profiles, router
+  policy), templates, and each run's state dir (journal + snapshot) as
+  audit record.
+- Corollary: no CI can ever see these files, which is why the
+  nondeterminism gate must live in the loader (D2) and nowhere else.
+
 ## Implementation plan (stages; each lands with tests)
 
 - **C1 — agent boundary (L2 core + `agent!`)**: implement the D6 algebra
@@ -381,6 +417,18 @@ calibration escape rates earn it.
   workers against a scratch repo. Measure: (a) fraction of items
   terminating at tier ≤1, (b) tier-2 token spend vs an all-Claude
   baseline, (c) calibration escape rate. Notes into `docs/pilot-k2-k3.md`.
+- **C8 — single-file run hardening** (from C7's honest deltas + the
+  2026-06-10 follow-up design session): (1) native `WorkflowSpec`
+  production interpreter — `conductor run <workflow.py>` executes a
+  DSL-only file; the hand-written `main` Program requirement is deleted;
+  (2) loader-enforced nondeterminism check per amended D2 — port the
+  DOEFF032 fixtures into conductor tests, delete the doeff-linter rule;
+  (3) workflow source snapshot into the run state dir per D10 — resume
+  reads the snapshot; (4) run return payload exposure — the `report_path`
+  workaround is deleted. Done: a DSL-only ephemeral file under `/tmp`
+  plans, validates, runs, and resumes with journaled results; a workflow
+  containing `datetime.now()` fails at plan time naming `time!` as the
+  replacement.
 
 ## Condemned existing code — mark-for-fix (delete outright, no deprecation)
 

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -212,14 +212,23 @@ invoked as plain functions** — not kleisli, so they structurally cannot
 yield effects: no agent launches, no `ask`, no `Local`, by construction.
 
 The remaining hole — raw Python calls that are not effects — is closed by
-the **nondeterminism validator** (doeff-linter rule set over workflow
-modules):
+the **workflow loader's nondeterminism check** (an AST walk conductor runs
+on every workflow module at load time, so `plan`, `validate`, and `run`
+all inherit it and cannot skip it):
 
 - ban `datetime.now` / `time.time` / `random.*` / `open` / network and
   subprocess calls / non-allowlisted imports inside workflow modules;
 - each diagnostic names the replacement (`time!`, `random!`, `gate!`,
   a `:params` entry);
-- severity is ERROR; there is no baseline and no allowlist-by-file.
+- load fails hard; there is no baseline, no allowlist-by-file, and no
+  suppression mechanism.
+
+The enforcement point is deliberate: workflows are ephemeral request
+artifacts (§4.7) that no CI or separately-run linter will ever see. No
+module marker is needed — the loader checks exactly what it loads.
+(History: this check first shipped as doeff-linter rule DOEFF032; the
+rule logic and fixtures move into the loader and the linter rule is
+deleted — single owner, no parallel implementations.)
 
 ### 4.5 Expansion-time checks (complete list, all pre-token)
 
@@ -237,7 +246,8 @@ modules):
    the `:roles` table and call-site fields;
 9. dataflow: every reference defined before use; unconsumed results are
    flagged;
-10. nondeterminism validator (§4.4) over the containing module.
+10. the loader's nondeterminism check (§4.4) over the workflow module —
+    enforced at load, so no verb can skip it.
 
 ### 4.6 Example — 4 parallel feature implementations
 
@@ -267,6 +277,27 @@ modules):
                                     (:workspace export) (:workspace i18n)]))
     (gate! :workspace merged :cmd "cargo build && cargo test")))
 ```
+
+### 4.7 Workflow source lifecycle — ephemeral by design
+
+A workflow encodes one request; it is kin to a prompt, not to code
+(ADR D10). Lifecycle contract:
+
+- The author (typically an agent) writes the workflow to **any throwaway
+  location** (`/tmp`, a session directory) — never into the target
+  repository. Committing a per-request workflow is an anti-pattern: it
+  rots into unowned state referencing branches/issues that no longer
+  exist.
+- `conductor plan` / `conductor run` **snapshot the workflow source into
+  the run state directory**, alongside the journal. The snapshot is the
+  authoritative source for that run: resume — including edit-and-resume —
+  reads and modifies the snapshot; the original file may vanish freely.
+- The only durable workflow-shaped artifacts are **named, parameterized
+  templates** (library code instantiated via `:params`); the
+  instantiation is still snapshotted per run.
+- Version-controlled: ADR/spec, environment config (profiles, router
+  policy), templates. Run-state-controlled: journal + workflow snapshot
+  (the audit record). Ephemeral: everything else.
 
 ## 5. L2 — the session algebra
 
@@ -489,7 +520,10 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
 ## 10. Enforcement summary
 
 - expansion-time checks: §4.5 (each rule ships with a failing-case test);
-- nondeterminism validator: §4.4 (doeff-linter, ERROR, no baselines);
+- nondeterminism check: §4.4 — enforced by the workflow loader at load
+  time (no separate linter; no suppression);
+- workflow source snapshot: §4.7 — every `plan`/`run` captures the source
+  into the run state dir; resume reads the snapshot;
 - layer-boundary lint: workflow modules must not import L1 handler modules
   or the profile registry (same enforcement pattern as agent-control-plane
   ADR 0005's semgrep boundary rules);


### PR DESCRIPTION
Design follow-up from the post-pilot session: workflows are ephemeral per-request artifacts (D10) — never committed to target repos; plan/run snapshot the source into the run state dir. Consequently the nondeterminism gate must live in the workflow loader (D2 amended), not in a separately-run linter; DOEFF032 will be ported into conductor and deleted from doeff-linter. Stage C8 defines the implementation scope (native production interpreter, loader check, snapshot, run payload exposure).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)