### PR TITLE
fix(agentd-client): blocking RPC read timeouts must cover daemon budgets

### DIFF
--- a/packages/doeff-agents/src/doeff_agents/agentd_client.py
+++ b/packages/doeff-agents/src/doeff_agents/agentd_client.py
@@ -60,6 +60,18 @@ class AgentdPaths:
     log_path: Path
 
 
+# RPC read-timeout contract.  The daemon BLOCKS on these methods by design:
+# `session.launch` waits for agent readiness (daemon LAUNCH_TIMEOUT_SECONDS,
+# 60s) and `session.await_result` waits up to its caller-supplied budget
+# (daemon default 600s, clamp [1, 3600]).  The client socket timeout must
+# therefore cover the daemon-side budget plus a margin — a short default
+# here silently breaks the protocol (observed live: 10s client timeout vs
+# 60s launch budget -> client disconnect, daemon Broken pipe).
+RPC_TIMEOUT_MARGIN_SECONDS: float = 15.0
+LAUNCH_RPC_TIMEOUT_SECONDS: float = 60.0 + RPC_TIMEOUT_MARGIN_SECONDS
+DEFAULT_AWAIT_BUDGET_SECONDS: float = 600.0
+
+
 class AgentdClient:
     """Synchronous client for the long-lived agent supervisor daemon."""
 
@@ -108,7 +120,11 @@ class AgentdClient:
             params["effort"] = effort
         if expected_result is not None:
             params["expected_result"] = dict(expected_result)
-        result = self.request("session.launch", params)
+        result = self.request(
+            "session.launch",
+            params,
+            read_timeout=LAUNCH_RPC_TIMEOUT_SECONDS,
+        )
         return _snapshot_from_result(result)
 
     def await_result(
@@ -120,8 +136,15 @@ class AgentdClient:
         params: dict[str, Any] = {"session_id": session_id}
         if timeout_seconds is not None:
             params["timeout_seconds"] = timeout_seconds
+        await_budget = (
+            timeout_seconds if timeout_seconds is not None else DEFAULT_AWAIT_BUDGET_SECONDS
+        )
         try:
-            result = self.request("session.await_result", params)
+            result = self.request(
+                "session.await_result",
+                params,
+                read_timeout=await_budget + RPC_TIMEOUT_MARGIN_SECONDS,
+            )
         except AgentdClientError as exc:
             if exc.error_code == RPC_ERR_AWAIT_TIMEOUT:
                 return AwaitOutcome(status=AwaitStatus.TIMED_OUT, validation_error=str(exc))
@@ -180,7 +203,13 @@ class AgentdClient:
         result = self.request("session.cleanup", {"session_id": session_id})
         return _snapshot_from_result(result)
 
-    def request(self, method: str, params: Mapping[str, Any] | None = None) -> Any:
+    def request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None = None,
+        *,
+        read_timeout: float | None = None,
+    ) -> Any:
         request = {
             "id": self._next_request_id(),
             "method": method,
@@ -188,9 +217,10 @@ class AgentdClient:
         }
         encoded = json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n"
 
+        effective_timeout = read_timeout if read_timeout is not None else self.timeout
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-            if self.timeout is not None:
-                sock.settimeout(self.timeout)
+            if effective_timeout is not None:
+                sock.settimeout(effective_timeout)
             sock.connect(str(self.socket_path))
             sock.sendall(encoded)
             with sock.makefile("r", encoding="utf-8") as reader:

--- a/packages/doeff-agents/tests/test_agentd_client.py
+++ b/packages/doeff-agents/tests/test_agentd_client.py
@@ -330,3 +330,42 @@ def _snapshot_payload_obj(
     return AgentSessionSnapshot.from_dict(
         _snapshot_payload(session_id=session_id, agent_type=agent_type, work_dir=work_dir)
     )
+
+
+def _spy_client(captured: dict) -> AgentdClient:
+    class _Spy(AgentdClient):
+        def request(self, method, params=None, *, read_timeout=None):
+            captured["method"] = method
+            captured["read_timeout"] = read_timeout
+            if method == "session.launch":
+                return _snapshot_payload()
+            return {"session": _snapshot_payload(), "result": None, "validation_error": None}
+
+    return _Spy("/tmp/unused.sock")
+
+
+def test_launch_read_timeout_covers_daemon_launch_budget() -> None:
+    """session.launch blocks daemon-side up to 60s; the client socket must wait longer."""
+    captured: dict = {}
+    _spy_client(captured).launch_session(
+        session_id="s1",
+        session_name="s1",
+        agent_type="codex",
+        work_dir=Path("/tmp"),
+    )
+    assert captured["method"] == "session.launch"
+    assert captured["read_timeout"] is not None
+    assert captured["read_timeout"] > 60.0
+
+
+def test_await_result_read_timeout_covers_caller_budget() -> None:
+    captured: dict = {}
+    _spy_client(captured).await_result("s1", timeout_seconds=120.0)
+    assert captured["method"] == "session.await_result"
+    assert captured["read_timeout"] > 120.0
+
+
+def test_await_result_read_timeout_covers_default_budget() -> None:
+    captured: dict = {}
+    _spy_client(captured).await_result("s1")
+    assert captured["read_timeout"] > 600.0


### PR DESCRIPTION
Found by the first real end-to-end conductor workflow run (dogfood): the client's 10s socket timeout disconnected mid-launch while the daemon was still within its 60s launch budget (daemon logged Broken pipe). Same hazard on await_result (600s budget). request() gains per-call read_timeout; the two blocking RPCs pass budget+margin. Contract tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)