### PR TITLE
fix(conductor): default profiles must not invent model names

### DIFF
--- a/packages/doeff-conductor/src/doeff_conductor/environment.py
+++ b/packages/doeff-conductor/src/doeff_conductor/environment.py
@@ -33,25 +33,25 @@ DEFAULT_ROLE_CONVENTIONS: Mapping[str, str] = {
 DEFAULT_PROFILE_DATA: Mapping[str, Mapping[str, Any]] = {
     "cheap-coder": {
         "adapter": "codex",
-        "model": "default-cheap-coder",
+        "model": None,
         "capabilities": ("durable-sessions", "schema-validation"),
         "budget_units": 1,
     },
     "cheap-reviewer": {
         "adapter": "codex",
-        "model": "default-cheap-reviewer",
+        "model": None,
         "capabilities": ("durable-sessions", "schema-validation"),
         "budget_units": 1,
     },
     "frontier-reviewer": {
         "adapter": "claude",
-        "model": "default-frontier-reviewer",
+        "model": None,
         "capabilities": ("durable-sessions", "interactive", "schema-validation"),
         "budget_units": 3,
     },
     "frontier-author": {
         "adapter": "claude",
-        "model": "default-frontier-author",
+        "model": None,
         "capabilities": ("durable-sessions", "interactive", "schema-validation"),
         "budget_units": 3,
     },
@@ -64,7 +64,7 @@ class ProfileBinding:
 
     name: str
     adapter: str
-    model: str
+    model: str | None
     capabilities: tuple[str, ...]
     budget_units: int
 
@@ -74,8 +74,12 @@ class ProfileBinding:
         model: object | None = data.get("model")
         if not isinstance(adapter, str) or not adapter:
             raise ValueError(f"profile {name!r} requires non-empty adapter")
-        if not isinstance(model, str) or not model:
-            raise ValueError(f"profile {name!r} requires non-empty model")
+        # model=None means "the agent CLI's own default model". Inventing a
+        # placeholder name here is worse than omitting the flag: an unknown
+        # model reaches the worker CLI and every turn fails (observed live:
+        # `codex --model default-cheap-coder` exhausted its retries in 14s).
+        if model is not None and (not isinstance(model, str) or not model):
+            raise ValueError(f"profile {name!r} model must be a non-empty string or None")
 
         raw_capabilities: object = data.get("capabilities", ())
         if not isinstance(raw_capabilities, (list, tuple)):

--- a/packages/doeff-conductor/src/doeff_conductor/replay_keying.py
+++ b/packages/doeff-conductor/src/doeff_conductor/replay_keying.py
@@ -55,7 +55,7 @@ def resolved_identity_fingerprint(identity: ResolvedIdentity) -> str:
     return _sha256_payload(
         {
             "adapter": identity.adapter,
-            "model": identity.model,
+            "model": identity.model if identity.model is not None else "adapter-default",
             "identity": identity.identity,
         }
     )

--- a/packages/doeff-conductor/tests/test_api.py
+++ b/packages/doeff-conductor/tests/test_api.py
@@ -319,9 +319,11 @@ class TestListWorkspaces:
         """Create API with temporary state directory."""
         return ConductorAPI(state_dir=tmp_path / "state")
 
-    def test_list_workspaces_empty(self, api: ConductorAPI):
+    def test_list_workspaces_empty(self, api: ConductorAPI, tmp_path: Path):
         """list_workspaces returns empty list when no workspaces exist."""
-        workspaces = api.list_workspaces()
+        with patch("doeff_conductor.handlers.workspace_handler._get_workspace_base_dir") as mock_base:
+            mock_base.return_value = tmp_path / "empty-workspaces"
+            workspaces = api.list_workspaces()
         assert workspaces == []
 
     def test_list_workspaces_with_mock(self, api: ConductorAPI, tmp_path: Path):
@@ -343,9 +345,11 @@ class TestCleanupWorkspaces:
         """Create API with temporary state directory."""
         return ConductorAPI(state_dir=tmp_path / "state")
 
-    def test_cleanup_workspaces_empty(self, api: ConductorAPI):
+    def test_cleanup_workspaces_empty(self, api: ConductorAPI, tmp_path: Path):
         """cleanup_workspaces returns empty list when no workspaces exist."""
-        cleaned = api.cleanup_workspaces()
+        with patch("doeff_conductor.handlers.workspace_handler._get_workspace_base_dir") as mock_base:
+            mock_base.return_value = tmp_path / "empty-workspaces"
+            cleaned = api.cleanup_workspaces()
         assert cleaned == []
 
     def test_cleanup_workspaces_dry_run(self, api: ConductorAPI, tmp_path: Path):


### PR DESCRIPTION
Found by the live sample-workflow dogfood: profile placeholders (default-cheap-coder) reached `codex --model` and killed every worker turn. model=None = agent CLI default; fingerprint sentinel keeps cache identity stable. Plus: isolate two workspace tests that read real user state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)