### PR TITLE
docs(conductor): authoring surface is Hy-only

### DIFF
--- a/packages/doeff-conductor/docs/adr-0001-workflow-dsl-and-attention-tiers.md
+++ b/packages/doeff-conductor/docs/adr-0001-workflow-dsl-and-attention-tiers.md
@@ -149,6 +149,17 @@ concept: kleisli args → `:params`; effect payloads → form fields;
 `Local` → the flat `:roles` table + call-site overrides; interpreter env →
 system-side verbs; `ask` → name references resolved by the environment.
 
+**The authoring surface is exclusively the Hy macro DSL.** Workflows are
+authored as `.hy` files using the `defworkflow`/`agent!`/... macros. The
+Python spec IR those macros expand into is an internal compilation target
+— it is NEVER written by an author (human or agent), and the loader does
+not accept user-supplied `.py` workflow files. (Amends the C8 stage text,
+which wired and documented `.py` as the runnable surface — that was an
+implementation expedient that leaked into the contract; the snapshot,
+examples, and loader move to `.hy`.) The loader's nondeterminism check is
+unchanged in substance: Hy compiles to Python AST, so the same AST walk
+runs on the compiled module.
+
 **Binding locality (no dynamic scoping):** every `agent!`'s binding is
 derivable from its call site plus the flat top-of-file `:roles` table.
 This is what makes the DSL writable by LLM authors and totally checkable.
@@ -425,8 +436,8 @@ Contract:
   baseline, (c) calibration escape rate. Notes into `docs/pilot-k2-k3.md`.
 - **C8 — single-file run hardening** (from C7's honest deltas + the
   2026-06-10 follow-up design session): (1) native `WorkflowSpec`
-  production interpreter — `conductor run <workflow.py>` executes a
-  DSL-only file; the hand-written `main` Program requirement is deleted;
+  production interpreter — `conductor run <workflow.hy>` executes a
+  DSL-only file (authoring surface amended to Hy-only; see D2); the hand-written `main` Program requirement is deleted;
   (2) loader-enforced nondeterminism check per amended D2 — port the
   DOEFF032 fixtures into conductor tests, delete the doeff-linter rule;
   (3) workflow source snapshot into the run state dir per D10 — resume

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -145,6 +145,10 @@ capabilities satisfied".
 
 ### 4.2 Grammar
 
+The grammar below IS the authoring surface: workflows are `.hy` files
+written in these macros. The Python dataclass IR the macros expand into is
+internal — never authored, never accepted by the loader.
+
 ```hy
 (defworkflow NAME
   :params {param-name schema ...}        ;; supplied at launch, schema-validated
@@ -283,8 +287,8 @@ deleted — single owner, no parallel implementations.)
 A workflow encodes one request; it is kin to a prompt, not to code
 (ADR D10). Lifecycle contract:
 
-- The author (typically an agent) writes the workflow to **any throwaway
-  location** (`/tmp`, a session directory) — never into the target
+- The author (typically an agent) writes the workflow **as a `.hy` DSL
+  file** to **any throwaway location** (`/tmp`, a session directory) — never into the target
   repository. Committing a per-request workflow is an anti-pattern: it
   rots into unowned state referencing branches/issues that no longer
   exist.


### PR DESCRIPTION
Maintainer ruling: Python is never authored by users; only the Hy macro DSL. Loader/.hy wiring tracked in conductor-c10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)