### PR TITLE
[codex] Add VM benchmark baselines

### DIFF
--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Run test suite
         run: uv run --package doeff --python ${{ matrix.python-version }} pytest -q
 
+      - name: Run benchmark smoke checks
+        if: matrix.python-version == '3.12'
+        run: |
+          uv run --package doeff --python ${{ matrix.python-version }} python benchmarks/benchmark_runner.py --smoke --no-output
+          export PYO3_PYTHON="$(uv run --package doeff --python ${{ matrix.python-version }} python -c 'import sys; print(sys.executable)')"
+          cd packages/doeff-vm-core
+          cargo bench --features python_bridge --bench dispatch -- --test
+
   version-probe:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Centralized commands for development, testing, and linting.
 
 .PHONY: help install sync lint lint-ruff lint-pyright lint-semgrep lint-semgrep-docs lint-doeff lint-packages \
-        test test-unit test-e2e test-packages test-all test-spec-audit-sa002 format check pre-commit-install clean \
+        test test-unit test-e2e test-packages test-all test-spec-audit-sa002 bench-smoke format check pre-commit-install clean \
         install-opencode-spec-gap-tdd
 
 # Default target
@@ -32,6 +32,7 @@ help:
 	@echo "  make test-packages     Run tests in all subpackages"
 	@echo "  make test-all          Run ALL tests (core + packages)"
 	@echo "  make test-spec-audit-sa002 Run SA-002 pytest + semgrep checks"
+	@echo "  make bench-smoke       Run benchmark smoke checks without performance gating"
 	@echo ""
 	@echo "Formatting:"
 	@echo "  make format            Format code with ruff"
@@ -127,7 +128,7 @@ PYTEST_MEM_GUARD_POLL_INTERVAL ?= 1.0
 PYTEST_MEMORY_ENV := PYTEST_MEM_GUARD_MB=$(PYTEST_MEM_GUARD_MB) \
 	PYTEST_MEM_GUARD_POLL_INTERVAL=$(PYTEST_MEM_GUARD_POLL_INTERVAL)
 
-test:
+test: bench-smoke
 	$(PYTEST_MEMORY_ENV) uv run pytest
 
 test-unit:
@@ -160,6 +161,10 @@ test-spec-audit-sa002:
 		echo "Warning: semgrep not installed. Install with: uv tool install semgrep"; \
 		exit 1; \
 	fi
+
+bench-smoke:
+	uv run python benchmarks/benchmark_runner.py --smoke --no-output
+	cd packages/doeff-vm-core && PYO3_PYTHON="$$(cd ../.. && uv run python -c 'import sys; print(sys.executable)')" cargo bench --features python_bridge --bench dispatch -- --test
 
 # =============================================================================
 # Formatting

--- a/README.md
+++ b/README.md
@@ -154,6 +154,47 @@ doeff run --program myapp.program --format json
 The CLI supports automatic interpreter/environment discovery via `doeff-indexer`.
 See `docs/14-cli-auto-discovery.md` for marker syntax and hierarchy rules.
 
+## Performance Benchmarks
+
+Rust VM dispatch micro-benchmarks live in `packages/doeff-vm-core/benches/` and
+use Criterion. Run them from the VM core crate with the VM feature enabled:
+
+```bash
+cd packages/doeff-vm-core
+cargo bench --features python_bridge
+```
+
+If PyO3 selects the wrong Python installation on macOS, pin it to the uv
+environment:
+
+```bash
+cd packages/doeff-vm-core
+PYO3_PYTHON="$(cd ../.. && uv run python -c 'import sys; print(sys.executable)')" \
+  cargo bench --features python_bridge
+```
+
+Python end-to-end benchmarks live in `benchmarks/benchmark_runner.py`. A normal
+run writes JSON to `benchmarks/results/<yyyymmdd>-<hostname>.json`:
+
+```bash
+uv run python benchmarks/benchmark_runner.py --runs 20
+```
+
+Compare a fresh run against a committed baseline with:
+
+```bash
+uv run python benchmarks/benchmark_runner.py \
+  --compare benchmarks/results/<baseline>.json
+```
+
+CI uses smoke mode only. It runs one iteration with the smallest N values and
+checks that the benchmark entrypoints still execute; it does not gate on
+performance:
+
+```bash
+make bench-smoke
+```
+
 ## Development
 
 ```bash

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -1,84 +1,498 @@
-"""Micro-benchmarks for the doeff interpreter.
+"""End-to-end benchmarks for the doeff Python runtime.
 
 Usage
 -----
-    uv run python benchmarks/benchmark_runner.py --runs 500
+    uv run python benchmarks/benchmark_runner.py --runs 20
+    uv run python benchmarks/benchmark_runner.py --smoke --no-output
+    uv run python benchmarks/benchmark_runner.py --compare benchmarks/results/baseline.json
 """
 
 from __future__ import annotations
 
 import argparse
+import datetime as dt
+import json
+import platform
+import socket
 import statistics
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
 
-from doeff import default_handlers, do, run
-from doeff.effects import Ask, Put, Tell
+from doeff_core_effects import (
+    Ask,
+    Await,
+    Gather,
+    Get,
+    Put,
+    Spawn,
+    await_handler,
+    reader,
+    scheduled,
+    state,
+)
+from doeff_vm import Callable as VmCallable
+from doeff_vm import EffectBase
+
+from doeff import Apply, Pass, Pure, Resume, do, run
+from doeff.program import WithHandlerType as VMWithHandler
+
+DEFAULT_RUNS = 20
+DEFAULT_LOOP_ITERATIONS = 100
+DEFAULT_AWAIT_ITERATIONS = 100
+DEFAULT_BOUNDARY_ITERATIONS = 1_000
+DEFAULT_SPAWN_SIZES = (100, 1_000)
+RESULTS_DIR = Path("benchmarks/results")
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    runs: int
+    loop_iterations: int
+    await_iterations: int
+    boundary_iterations: int
+    spawn_sizes: tuple[int, ...]
+    smoke: bool = False
+
+    @classmethod
+    def smoke_config(cls) -> BenchmarkConfig:
+        return cls(
+            runs=1,
+            loop_iterations=1,
+            await_iterations=1,
+            boundary_iterations=1,
+            spawn_sizes=(1,),
+            smoke=True,
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkStats:
+    name: str
+    runs: int
+    unit: str
+    units_per_run: int
+    parameters: dict[str, int | str | bool]
+    min_ms: float
+    median_ms: float
+    mean_ms: float
+    max_ms: float
+    mean_unit_us: float
+    throughput_per_s: float
+
+
+class PythonCallableEffect(EffectBase):
+    """Effect carrying a Python callable wrapped for the Rust VM."""
+
+    def __init__(self, callback: VmCallable, value: int) -> None:
+        super().__init__()
+        self.callback = callback
+        self.value = value
 
 
 @do
-def _stateful_workload(iterations: int) -> int:
-    value = yield Ask("seed")
-    total = value
-    for index in range(iterations):
-        yield Tell(f"iteration:{index}")
-        yield Put("counter", index)
-        total += index
+def _state_get_put_loop(iterations: int) -> Any:
+    for _index in range(iterations):
+        counter = yield Get("counter")
+        yield Put("counter", counter + 1)
+    return (yield Get("counter"))
+
+
+@do
+def _reader_ask_loop(iterations: int) -> Any:
+    total = 0
+    for _index in range(iterations):
+        value = yield Ask("value")
+        total += value
     return total
 
 
-def _run_once(workload_iterations: int) -> None:
-    run(
-        _stateful_workload(workload_iterations),
-        handlers=default_handlers(),
-        env={"seed": 1},
+@do
+def _spawn_gather_program(task_count: int) -> Any:
+    tasks = []
+    for _index in range(task_count):
+        task = yield Spawn(_noop_task())
+        tasks.append(task)
+    return (yield Gather(*tasks))
+
+
+@do
+def _noop_task() -> None:
+    return None
+
+
+@do
+def _await_loop(iterations: int) -> Any:
+    import asyncio
+
+    for _index in range(iterations):
+        yield Await(asyncio.sleep(0))
+    return iterations
+
+
+@do
+def _python_callable_effect_handler(effect: Any, k: Any) -> Any:
+    if isinstance(effect, PythonCallableEffect):
+        result = yield Apply(Pure(effect.callback), [Pure(effect.value)])
+        return (yield Resume(k, result))
+    yield Pass(effect, k)
+
+
+@do
+def _python_callable_effect_loop(iterations: int, callback: VmCallable) -> Any:
+    total = 0
+    for index in range(iterations):
+        total += yield PythonCallableEffect(callback, index)
+    return total
+
+
+def _increment(value: int) -> int:
+    return value + 1
+
+
+def _measure(
+    name: str,
+    *,
+    runs: int,
+    unit: str,
+    units_per_run: int,
+    parameters: dict[str, int | str | bool],
+    workload: Callable[[], Any],
+    validate: Callable[[Any], None],
+) -> BenchmarkStats:
+    timings: list[float] = []
+
+    for _index in range(runs):
+        start = time.perf_counter()
+        result = workload()
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        validate(result)
+        timings.append(elapsed_ms)
+
+    mean_ms = statistics.mean(timings)
+    mean_unit_us = (mean_ms * 1_000.0) / max(units_per_run, 1)
+    throughput_per_s = (units_per_run * 1_000.0) / mean_ms if mean_ms > 0.0 else 0.0
+
+    return BenchmarkStats(
+        name=name,
+        runs=runs,
+        unit=unit,
+        units_per_run=units_per_run,
+        parameters=parameters,
+        min_ms=min(timings),
+        median_ms=statistics.median(timings),
+        mean_ms=mean_ms,
+        max_ms=max(timings),
+        mean_unit_us=mean_unit_us,
+        throughput_per_s=throughput_per_s,
     )
 
 
-def benchmark(runs: int, *, workload_iterations: int) -> dict[str, float]:
-    timings: list[float] = []
+def _run_trivial() -> Any:
+    return run(Pure(1))
 
-    for _ in range(runs):
-        start = time.perf_counter()
-        _run_once(workload_iterations)
-        elapsed = (time.perf_counter() - start) * 1000.0
-        timings.append(elapsed)
 
+def _run_state_get_put_loop(iterations: int) -> Any:
+    return run(VMWithHandler(state({"counter": 0}), _state_get_put_loop(iterations)))
+
+
+def _run_reader_ask_loop(iterations: int) -> Any:
+    return run(VMWithHandler(reader({"value": 1}), _reader_ask_loop(iterations)))
+
+
+def _run_spawn_gather(task_count: int) -> Any:
+    return run(scheduled(_spawn_gather_program(task_count)))
+
+
+def _run_await_round_trip(iterations: int, handler: Callable[..., Any]) -> Any:
+    return run(scheduled(VMWithHandler(handler, _await_loop(iterations))))
+
+
+def _run_python_callable_boundary(iterations: int, callback: VmCallable) -> Any:
+    program = VMWithHandler(
+        _python_callable_effect_handler,
+        _python_callable_effect_loop(iterations, callback),
+    )
+    return run(program)
+
+
+def run_benchmarks(config: BenchmarkConfig) -> list[BenchmarkStats]:
+    await_effect_handler = await_handler()
+    boundary_callback = VmCallable(_increment)
+    results: list[BenchmarkStats] = []
+
+    results.append(
+        _measure(
+            "run_trivial",
+            runs=config.runs,
+            unit="run",
+            units_per_run=1,
+            parameters={"program": "Pure(1)"},
+            workload=_run_trivial,
+            validate=lambda result: _assert_equal(result, 1),
+        )
+    )
+    results.append(
+        _measure(
+            "run_state_get_put_loop",
+            runs=config.runs,
+            unit="iteration",
+            units_per_run=config.loop_iterations,
+            parameters={"iterations": config.loop_iterations},
+            workload=lambda: _run_state_get_put_loop(config.loop_iterations),
+            validate=lambda result: _assert_equal(result, config.loop_iterations),
+        )
+    )
+    results.append(
+        _measure(
+            "run_reader_ask_loop",
+            runs=config.runs,
+            unit="iteration",
+            units_per_run=config.loop_iterations,
+            parameters={"iterations": config.loop_iterations},
+            workload=lambda: _run_reader_ask_loop(config.loop_iterations),
+            validate=lambda result: _assert_equal(result, config.loop_iterations),
+        )
+    )
+
+    for task_count in config.spawn_sizes:
+        results.append(
+            _measure(
+                f"spawn_gather_{task_count}",
+                runs=config.runs,
+                unit="task",
+                units_per_run=task_count,
+                parameters={"tasks": task_count},
+                workload=lambda task_count=task_count: _run_spawn_gather(task_count),
+                validate=lambda result, task_count=task_count: _assert_equal(
+                    len(result),
+                    task_count,
+                ),
+            )
+        )
+
+    results.append(
+        _measure(
+            "await_sleep_0_round_trip",
+            runs=config.runs,
+            unit="await",
+            units_per_run=config.await_iterations,
+            parameters={"iterations": config.await_iterations},
+            workload=lambda: _run_await_round_trip(config.await_iterations, await_effect_handler),
+            validate=lambda result: _assert_equal(result, config.await_iterations),
+        )
+    )
+    results.append(
+        _measure(
+            "python_callable_boundary",
+            runs=config.runs,
+            unit="call",
+            units_per_run=config.boundary_iterations,
+            parameters={"iterations": config.boundary_iterations},
+            workload=lambda: _run_python_callable_boundary(
+                config.boundary_iterations,
+                boundary_callback,
+            ),
+            validate=lambda result: _assert_equal(
+                result,
+                config.boundary_iterations * (config.boundary_iterations + 1) // 2,
+            ),
+        )
+    )
+
+    return results
+
+
+def _assert_equal(actual: Any, expected: Any) -> None:
+    if actual != expected:
+        raise AssertionError(f"expected {expected!r}, got {actual!r}")
+
+
+def build_payload(config: BenchmarkConfig, results: Sequence[BenchmarkStats]) -> dict[str, Any]:
     return {
-        "runs": runs,
-        "workload_iterations": workload_iterations,
-        "min_ms": min(timings),
-        "max_ms": max(timings),
-        "mean_ms": statistics.mean(timings),
-        "median_ms": statistics.median(timings),
+        "schema_version": 1,
+        "created_at": dt.datetime.now(dt.UTC).isoformat(),
+        "hostname": socket.gethostname(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "config": asdict(config),
+        "results": [asdict(result) for result in results],
     }
 
 
-def format_report(results: Iterable[tuple[str, dict[str, float]]]) -> str:
+def default_results_path() -> Path:
+    date_label = dt.datetime.now(dt.UTC).strftime("%Y%m%d")
+    host_label = socket.gethostname().split(".", maxsplit=1)[0]
+    return RESULTS_DIR / f"{date_label}-{host_label}.json"
+
+
+def write_results(payload: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def load_results(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def benchmark(runs: int, *, workload_iterations: int) -> dict[str, float]:
+    """Compatibility wrapper for the original stateful benchmark shape."""
+
+    result = _measure(
+        "run_state_get_put_loop",
+        runs=runs,
+        unit="iteration",
+        units_per_run=workload_iterations,
+        parameters={"iterations": workload_iterations},
+        workload=lambda: _run_state_get_put_loop(workload_iterations),
+        validate=lambda actual: _assert_equal(actual, workload_iterations),
+    )
+    return {
+        "runs": float(result.runs),
+        "workload_iterations": float(workload_iterations),
+        "min_ms": result.min_ms,
+        "max_ms": result.max_ms,
+        "mean_ms": result.mean_ms,
+        "median_ms": result.median_ms,
+    }
+
+
+def format_report(results: Iterable[BenchmarkStats | tuple[str, dict[str, float]]]) -> str:
     lines = ["doeff benchmark results:"]
-    for label, stats in results:
-        lines.append(f"  {label}:")
-        lines.append(
-            "    runs={runs} iterations={workload_iterations} | min={min_ms:.2f}ms "
-            "median={median_ms:.2f}ms mean={mean_ms:.2f}ms max={max_ms:.2f}ms".format(**stats)
-        )
+    for item in results:
+        if isinstance(item, BenchmarkStats):
+            lines.append(
+                f"  {item.name}: runs={item.runs} units/run={item.units_per_run} {item.unit} | "
+                f"min={item.min_ms:.2f}ms median={item.median_ms:.2f}ms "
+                f"mean={item.mean_ms:.2f}ms max={item.max_ms:.2f}ms "
+                f"mean_unit={item.mean_unit_us:.2f}us "
+                f"throughput={item.throughput_per_s:.1f}/s"
+            )
+        else:
+            label, stats = item
+            lines.append(f"  {label}:")
+            lines.append(
+                "    runs={runs:.0f} iterations={workload_iterations:.0f} | "
+                "min={min_ms:.2f}ms median={median_ms:.2f}ms "
+                "mean={mean_ms:.2f}ms max={max_ms:.2f}ms".format(**stats)
+            )
     return "\n".join(lines)
 
 
+def format_comparison(current: Sequence[BenchmarkStats], baseline_payload: dict[str, Any]) -> str:
+    baseline_results = {
+        result["name"]: result
+        for result in baseline_payload.get("results", [])
+        if isinstance(result, dict) and "name" in result
+    }
+    lines = ["comparison against baseline:"]
+
+    for result in current:
+        baseline = baseline_results.get(result.name)
+        if baseline is None:
+            lines.append(f"  {result.name}: no baseline")
+            continue
+        baseline_mean = float(baseline["mean_ms"])
+        delta_pct = (
+            ((result.mean_ms - baseline_mean) / baseline_mean) * 100.0
+            if baseline_mean > 0.0
+            else 0.0
+        )
+        lines.append(
+            f"  {result.name}: current={result.mean_ms:.2f}ms "
+            f"baseline={baseline_mean:.2f}ms delta={delta_pct:+.1f}%"
+        )
+
+    return "\n".join(lines)
+
+
+def _parse_spawn_sizes(raw_value: str) -> tuple[int, ...]:
+    values = tuple(int(part.strip()) for part in raw_value.split(",") if part.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("at least one spawn size is required")
+    return values
+
+
+def _config_from_args(args: argparse.Namespace) -> BenchmarkConfig:
+    if args.smoke:
+        return BenchmarkConfig.smoke_config()
+    return BenchmarkConfig(
+        runs=args.runs,
+        loop_iterations=args.iterations,
+        await_iterations=args.await_iterations,
+        boundary_iterations=args.boundary_iterations,
+        spawn_sizes=args.spawn_sizes,
+        smoke=False,
+    )
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark doeff interpreter execution")
-    parser.add_argument("--runs", type=int, default=100, help="Number of interpreter executions")
+    parser = argparse.ArgumentParser(description="Benchmark doeff runtime execution")
+    parser.add_argument("--runs", type=int, default=DEFAULT_RUNS, help="Number of runs per case")
     parser.add_argument(
         "--iterations",
         type=int,
-        default=25,
-        help="Inner loop iterations in the workload",
+        default=DEFAULT_LOOP_ITERATIONS,
+        help="Inner loop iterations for run(), state, and reader cases",
+    )
+    parser.add_argument(
+        "--await-iterations",
+        type=int,
+        default=DEFAULT_AWAIT_ITERATIONS,
+        help="Sequential Await(asyncio.sleep(0)) operations per run",
+    )
+    parser.add_argument(
+        "--boundary-iterations",
+        type=int,
+        default=DEFAULT_BOUNDARY_ITERATIONS,
+        help="Python callable boundary operations per run",
+    )
+    parser.add_argument(
+        "--spawn-sizes",
+        type=_parse_spawn_sizes,
+        default=DEFAULT_SPAWN_SIZES,
+        help="Comma-separated Spawn+Gather task counts",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run one iteration with the smallest N values for CI smoke checks",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="JSON output path; defaults to benchmarks/results/<yyyymmdd>-<hostname>.json",
+    )
+    parser.add_argument(
+        "--no-output",
+        action="store_true",
+        help="Do not write a JSON results file",
+    )
+    parser.add_argument(
+        "--compare",
+        type=Path,
+        default=None,
+        help="Print a mean-time comparison against a baseline JSON file",
     )
     args = parser.parse_args()
 
-    stats = benchmark(args.runs, workload_iterations=args.iterations)
-    print(format_report([("stateful_workload", stats)]))
+    config = _config_from_args(args)
+    results = run_benchmarks(config)
+    payload = build_payload(config, results)
+
+    print(format_report(results))
+
+    if args.compare is not None:
+        print(format_comparison(results, load_results(args.compare)))
+
+    if not args.no_output:
+        output_path = args.output or default_results_path()
+        write_results(payload, output_path)
+        print(f"wrote JSON results: {output_path}")
 
 
-if __name__ == "main":  # pragma: no cover - CLI script
+if __name__ == "__main__":  # pragma: no cover - CLI script
     main()

--- a/benchmarks/results/20260611-CA-20035844.json
+++ b/benchmarks/results/20260611-CA-20035844.json
@@ -1,0 +1,125 @@
+{
+  "config": {
+    "await_iterations": 100,
+    "boundary_iterations": 1000,
+    "loop_iterations": 100,
+    "runs": 20,
+    "smoke": false,
+    "spawn_sizes": [
+      100,
+      1000
+    ]
+  },
+  "created_at": "2026-06-11T10:02:44.656529+00:00",
+  "hostname": "CA-20035844",
+  "platform": "macOS-26.3.2-arm64-arm-64bit-Mach-O",
+  "python": "3.14.3",
+  "results": [
+    {
+      "max_ms": 0.013708136975765228,
+      "mean_ms": 0.0013854354619979858,
+      "mean_unit_us": 1.3854354619979858,
+      "median_ms": 0.0003541354089975357,
+      "min_ms": 0.00024959444999694824,
+      "name": "run_trivial",
+      "parameters": {
+        "program": "Pure(1)"
+      },
+      "runs": 20,
+      "throughput_per_s": 721794.7190104867,
+      "unit": "run",
+      "units_per_run": 1
+    },
+    {
+      "max_ms": 0.6432496011257172,
+      "mean_ms": 0.561389559879899,
+      "mean_unit_us": 5.61389559879899,
+      "median_ms": 0.5423957481980324,
+      "min_ms": 0.520333182066679,
+      "name": "run_state_get_put_loop",
+      "parameters": {
+        "iterations": 100
+      },
+      "runs": 20,
+      "throughput_per_s": 178129.42588635514,
+      "unit": "iteration",
+      "units_per_run": 100
+    },
+    {
+      "max_ms": 0.3870422951877117,
+      "mean_ms": 0.3103602444753051,
+      "mean_unit_us": 3.103602444753051,
+      "median_ms": 0.3039164002984762,
+      "min_ms": 0.2922089770436287,
+      "name": "run_reader_ask_loop",
+      "parameters": {
+        "iterations": 100
+      },
+      "runs": 20,
+      "throughput_per_s": 322206.21609916555,
+      "unit": "iteration",
+      "units_per_run": 100
+    },
+    {
+      "max_ms": 17.500500194728374,
+      "mean_ms": 16.796041559427977,
+      "mean_unit_us": 167.96041559427977,
+      "median_ms": 16.684479312971234,
+      "min_ms": 16.08137506991625,
+      "name": "spawn_gather_100",
+      "parameters": {
+        "tasks": 100
+      },
+      "runs": 20,
+      "throughput_per_s": 5953.783791626061,
+      "unit": "task",
+      "units_per_run": 100
+    },
+    {
+      "max_ms": 151.6007911413908,
+      "mean_ms": 145.45743335038424,
+      "mean_unit_us": 145.45743335038424,
+      "median_ms": 144.30756284855306,
+      "min_ms": 141.23704237863421,
+      "name": "spawn_gather_1000",
+      "parameters": {
+        "tasks": 1000
+      },
+      "runs": 20,
+      "throughput_per_s": 6874.863504508266,
+      "unit": "task",
+      "units_per_run": 1000
+    },
+    {
+      "max_ms": 8.684874977916479,
+      "mean_ms": 7.819481450133026,
+      "mean_unit_us": 78.19481450133026,
+      "median_ms": 7.974062580615282,
+      "min_ms": 6.280125118792057,
+      "name": "await_sleep_0_round_trip",
+      "parameters": {
+        "iterations": 100
+      },
+      "runs": 20,
+      "throughput_per_s": 12788.57180463019,
+      "unit": "await",
+      "units_per_run": 100
+    },
+    {
+      "max_ms": 2.8018751181662083,
+      "mean_ms": 2.5952623458579183,
+      "mean_unit_us": 2.5952623458579183,
+      "median_ms": 2.5914579164236784,
+      "min_ms": 2.3624999448657036,
+      "name": "python_callable_boundary",
+      "parameters": {
+        "iterations": 1000
+      },
+      "runs": 20,
+      "throughput_per_s": 385317.5004045416,
+      "unit": "call",
+      "units_per_run": 1000
+    }
+  ],
+  "schema_version": 1
+}

--- a/packages/doeff-vm-core/Cargo.lock
+++ b/packages/doeff-vm-core/Cargo.lock
@@ -3,10 +3,216 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "doeff-vm-core"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "pyo3",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -16,16 +222,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -110,6 +414,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +544,132 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/packages/doeff-vm-core/Cargo.toml
+++ b/packages/doeff-vm-core/Cargo.toml
@@ -20,4 +20,10 @@ vm_debug_logs = []
 pyo3 = { version = "0.28", features = ["py-clone"], optional = true }
 
 [dev-dependencies]
+criterion = "0.5"
 pyo3 = { version = "0.28", features = ["auto-initialize", "py-clone"] }
+
+[[bench]]
+name = "dispatch"
+harness = false
+required-features = ["python_bridge"]

--- a/packages/doeff-vm-core/benches/dispatch.rs
+++ b/packages/doeff-vm-core/benches/dispatch.rs
@@ -1,0 +1,300 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use doeff_vm_core::{
+    Callable, CallableRef, DoCtrl, Fiber, Frame, IRStream, IRStreamRef, Signal, StepResult,
+    VMError, Value, VM,
+};
+
+const DISPATCH_CYCLES: usize = 100;
+const STEP_CYCLES: usize = 1_000;
+const FIBER_CYCLES: usize = 1_000;
+
+#[derive(Debug)]
+struct PerformLoopStream {
+    cycles: usize,
+    completed: usize,
+    started: bool,
+}
+
+impl PerformLoopStream {
+    fn new(cycles: usize) -> Self {
+        Self {
+            cycles,
+            completed: 0,
+            started: false,
+        }
+    }
+}
+
+impl IRStream for PerformLoopStream {
+    fn resume(&mut self, value: Value) -> doeff_vm_core::ir_stream::StreamStep {
+        if !self.started {
+            self.started = true;
+        } else {
+            black_box(value);
+            self.completed += 1;
+        }
+
+        if self.completed >= self.cycles {
+            return doeff_vm_core::ir_stream::StreamStep::Done(Value::Int(self.completed as i64));
+        }
+
+        doeff_vm_core::ir_stream::StreamStep::Instruction(DoCtrl::Perform {
+            effect: Value::Int(self.completed as i64),
+        })
+    }
+
+    fn throw(&mut self, error: Value) -> doeff_vm_core::ir_stream::StreamStep {
+        doeff_vm_core::ir_stream::StreamStep::Error(error)
+    }
+}
+
+#[derive(Debug)]
+struct StepLoopStream {
+    remaining: usize,
+}
+
+impl StepLoopStream {
+    fn new(remaining: usize) -> Self {
+        Self { remaining }
+    }
+}
+
+impl IRStream for StepLoopStream {
+    fn resume(&mut self, value: Value) -> doeff_vm_core::ir_stream::StreamStep {
+        black_box(value);
+        if self.remaining == 0 {
+            return doeff_vm_core::ir_stream::StreamStep::Done(Value::Unit);
+        }
+        self.remaining -= 1;
+        doeff_vm_core::ir_stream::StreamStep::Instruction(DoCtrl::Pure { value: Value::Unit })
+    }
+
+    fn throw(&mut self, error: Value) -> doeff_vm_core::ir_stream::StreamStep {
+        doeff_vm_core::ir_stream::StreamStep::Error(error)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ResumeMode {
+    Resume,
+    Transfer,
+}
+
+#[derive(Debug)]
+struct ContinueHandler {
+    mode: ResumeMode,
+}
+
+impl ContinueHandler {
+    fn new(mode: ResumeMode) -> Self {
+        Self { mode }
+    }
+}
+
+impl Callable for ContinueHandler {
+    fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
+        Err(VMError::internal(
+            "ContinueHandler must be used as a handler",
+        ))
+    }
+
+    fn call_handler(&self, args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        let mut args_iter = args.into_iter();
+        let _effect = args_iter
+            .next()
+            .ok_or_else(|| VMError::internal("handler missing effect"))?;
+        let k = match args_iter.next() {
+            Some(Value::Continuation(k)) => k,
+            _ => return Err(VMError::internal("handler missing continuation")),
+        };
+
+        match self.mode {
+            ResumeMode::Resume => Ok(DoCtrl::Resume {
+                k,
+                value: Value::Int(1),
+            }),
+            ResumeMode::Transfer => Ok(DoCtrl::Transfer {
+                k,
+                value: Value::Int(1),
+            }),
+        }
+    }
+
+    fn name(&self) -> Option<String> {
+        Some(
+            match self.mode {
+                ResumeMode::Resume => "bench_resume_handler",
+                ResumeMode::Transfer => "bench_transfer_handler",
+            }
+            .to_string(),
+        )
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Debug)]
+struct PassHandler;
+
+impl Callable for PassHandler {
+    fn call(&self, _args: Vec<Value>) -> Result<Value, VMError> {
+        Err(VMError::internal("PassHandler must be used as a handler"))
+    }
+
+    fn call_handler(&self, args: Vec<Value>) -> Result<DoCtrl, VMError> {
+        let mut args_iter = args.into_iter();
+        let effect = args_iter
+            .next()
+            .ok_or_else(|| VMError::internal("pass handler missing effect"))?;
+        let k = match args_iter.next() {
+            Some(Value::Continuation(k)) => k,
+            _ => return Err(VMError::internal("pass handler missing continuation")),
+        };
+        Ok(DoCtrl::Pass { effect, k })
+    }
+
+    fn name(&self) -> Option<String> {
+        Some("bench_pass_handler".to_string())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn callable_value(callable: impl Callable) -> Value {
+    Value::Callable(Arc::new(callable) as CallableRef)
+}
+
+fn expand_stream(stream: impl IRStream + 'static) -> DoCtrl {
+    DoCtrl::Expand {
+        expr: Box::new(DoCtrl::Pure {
+            value: Value::Stream(IRStreamRef::new(Box::new(stream))),
+        }),
+    }
+}
+
+fn handler_program(cycles: usize, depth: usize, mode: ResumeMode) -> DoCtrl {
+    assert!(depth >= 1, "handler depth must be at least 1");
+
+    let mut program = expand_stream(PerformLoopStream::new(cycles));
+    for _ in 1..depth {
+        program = DoCtrl::WithHandler {
+            handler: callable_value(PassHandler),
+            body: Box::new(program),
+        };
+    }
+
+    DoCtrl::WithHandler {
+        handler: callable_value(ContinueHandler::new(mode)),
+        body: Box::new(program),
+    }
+}
+
+fn run_doctrl_to_completion(doctrl: DoCtrl) -> Value {
+    let mut vm = VM::new();
+    let root_fid = vm.alloc_segment(Fiber::new(None));
+    vm.current_segment = Some(root_fid);
+    run_loop(&mut vm, Signal::eval(doctrl))
+}
+
+fn run_stream_to_completion(stream: impl IRStream + 'static) -> Value {
+    let mut vm = VM::new();
+    let stream_ref = IRStreamRef::new(Box::new(stream));
+    let mut root = Fiber::new(None);
+    root.push_frame(Frame::program(stream_ref, None));
+    let root_fid = vm.alloc_segment(root);
+    vm.current_segment = Some(root_fid);
+    run_loop(&mut vm, Signal::send(Value::Unit))
+}
+
+fn run_loop(vm: &mut VM, mut signal: Signal) -> Value {
+    loop {
+        match vm.step(signal) {
+            StepResult::Continue(next_signal) => {
+                signal = next_signal;
+            }
+            StepResult::Done(value) => return value,
+            StepResult::Error { error, .. } => panic!("VM benchmark errored: {error}"),
+            StepResult::External { .. } => {
+                panic!("VM benchmark unexpectedly requested external work")
+            }
+        }
+    }
+}
+
+fn run_fiber_lifecycle(cycles: usize) -> usize {
+    let mut vm = VM::new();
+    let root_fid = vm.alloc_segment(Fiber::new(None));
+
+    for _ in 0..cycles {
+        let child_fid = vm.alloc_segment(Fiber::new(Some(root_fid)));
+        vm.current_segment = Some(child_fid);
+        match vm.fiber_return(Value::Unit) {
+            StepResult::Continue(signal) => {
+                black_box(signal);
+            }
+            other => panic!("fiber_return returned unexpected result: {other:?}"),
+        }
+    }
+
+    vm.segments.len()
+}
+
+fn bench_dispatch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch");
+
+    group.bench_function("perform_resume_depth_1", |b| {
+        b.iter_batched(
+            || handler_program(DISPATCH_CYCLES, 1, ResumeMode::Resume),
+            |program| black_box(run_doctrl_to_completion(program)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("perform_resume_depth_8_reperform", |b| {
+        b.iter_batched(
+            || handler_program(DISPATCH_CYCLES, 8, ResumeMode::Resume),
+            |program| black_box(run_doctrl_to_completion(program)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("continuation_resume_non_tail", |b| {
+        b.iter_batched(
+            || handler_program(DISPATCH_CYCLES, 1, ResumeMode::Resume),
+            |program| black_box(run_doctrl_to_completion(program)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("continuation_transfer_tail", |b| {
+        b.iter_batched(
+            || handler_program(DISPATCH_CYCLES, 1, ResumeMode::Transfer),
+            |program| black_box(run_doctrl_to_completion(program)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("fiber_create_return", |b| {
+        b.iter(|| black_box(run_fiber_lifecycle(FIBER_CYCLES)));
+    });
+
+    group.bench_function("raw_step_trivial_loop", |b| {
+        b.iter_batched(
+            || StepLoopStream::new(STEP_CYCLES),
+            |stream| black_box(run_stream_to_completion(stream)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_dispatch);
+criterion_main!(benches);

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,0 +1,17 @@
+from benchmarks.benchmark_runner import BenchmarkConfig, run_benchmarks
+
+
+def test_benchmark_runner_smoke_cases_execute() -> None:
+    results = run_benchmarks(BenchmarkConfig.smoke_config())
+
+    result_names = {result.name for result in results}
+
+    assert result_names == {
+        "run_trivial",
+        "run_state_get_put_loop",
+        "run_reader_ask_loop",
+        "spawn_gather_1",
+        "await_sleep_0_round_trip",
+        "python_callable_boundary",
+    }
+    assert all(result.runs == 1 for result in results)


### PR DESCRIPTION
## Summary

Adds additive benchmark baselines for `vm-perf-bench-v2` without changing VM runtime code.

- Added Criterion dispatch benches under `packages/doeff-vm-core/benches/` for perform/resume at depth 1 and depth 8 reperform, Resume vs Transfer, fiber create/return, and raw step throughput.
- Expanded `benchmarks/benchmark_runner.py` into Python end-to-end benchmark cases with JSON output, smoke mode, and baseline comparison.
- Committed one baseline JSON from this machine at `benchmarks/results/20260611-CA-20035844.json`.
- Added `make bench-smoke` and a Python 3.12 CI smoke step with no performance gating.
- Documented run and comparison commands in `README.md`.

Reference: `vm-perf-bench-v2`.

## Python Baseline

Machine: `CA-20035844`, macOS arm64, Python 3.14.3, 20 runs.

| Benchmark | Mean ms/run | Unit | Mean us/unit | Throughput/s |
| --- | ---: | --- | ---: | ---: |
| run_trivial | 0.001 | run | 1.385 | 721794.7 |
| run_state_get_put_loop | 0.561 | iteration | 5.614 | 178129.4 |
| run_reader_ask_loop | 0.310 | iteration | 3.104 | 322206.2 |
| spawn_gather_100 | 16.796 | task | 167.960 | 5953.8 |
| spawn_gather_1000 | 145.457 | task | 145.457 | 6874.9 |
| await_sleep_0_round_trip | 7.819 | await | 78.195 | 12788.6 |
| python_callable_boundary | 2.595 | call | 2.595 | 385317.5 |

## Verification

- `make bench-smoke` passed.
- `uv run python benchmarks/benchmark_runner.py --runs 20` passed and wrote `benchmarks/results/20260611-CA-20035844.json`.
- `PYO3_PYTHON=/Users/s22625/.orch/worktrees/vm-perf-bench-v2/6f8ba6_codex_20260611-185233/.venv/bin/python cargo bench --features python_bridge --bench dispatch` passed.
- `uv run python benchmarks/benchmark_runner.py --smoke --no-output --compare benchmarks/results/20260611-CA-20035844.json` passed.
- `uv run ruff check benchmarks/benchmark_runner.py tests/test_benchmark_runner.py` passed.
- `uv run ruff format --check benchmarks/benchmark_runner.py tests/test_benchmark_runner.py` passed.
- `uv run pytest` passed: 838 passed, 84 skipped.

Note: `cargo fmt --check` across `packages/doeff-vm-core` still reports pre-existing formatting diffs in `src/vm/step.rs`; this PR only rustfmt-formatted the new bench file (`rustfmt --check packages/doeff-vm-core/benches/dispatch.rs` passed).