### PR TITLE
[codex] Fix gather waiter accounting

### DIFF
--- a/packages/doeff-core-effects/doeff_core_effects/scheduler.py
+++ b/packages/doeff-core-effects/doeff_core_effects/scheduler.py
@@ -230,7 +230,7 @@ def scheduled(body_program):
     tasks = {}           # tid → {status, result, program, priority}
     promises = {}        # pid → {status, result}
     semaphores = {}      # sid → {permits, max_permits, waiters: deque of k}
-    waiters = {}         # waitable_key → [(type, k, ...)]
+    waiters = {}         # waitable_key → [(type, k, ...)] or gather-state refs
     ready = []           # heapq: (-priority, seq, entry)
     cancel_requested = set()  # task ids pending cancellation
     external_queue = queue_mod.Queue()  # thread-safe, blocking get()
@@ -379,6 +379,51 @@ def scheduled(body_program):
         elif status == "cancelled":
             enqueue(("raise", waiter_k, TaskCancelledError()))
 
+    def remove_gather_waiters(gather_state):
+        """Remove unresolved waiter refs for a fail-fast Gather resolution."""
+        for wk in set(gather_state["pending_keys"]):
+            entries = waiters.get(wk)
+            if not entries:
+                continue
+            remaining_entries = [
+                entry
+                for entry in entries
+                if not (entry[0] == "gather" and entry[1] is gather_state)
+            ]
+            if remaining_entries:
+                waiters[wk] = remaining_entries
+            else:
+                waiters.pop(wk, None)
+
+    def resolve_gather_with_error(gather_state, error):
+        if gather_state["resolved"]:
+            return
+        gather_state["resolved"] = True
+        gather_state["failure"] = error
+        remove_gather_waiters(gather_state)
+        enqueue(("raise", gather_state["waiter_k"], error))
+
+    def wake_gather_waiter(gather_state, completed_key):
+        if gather_state["resolved"]:
+            return
+
+        status, result = waitable_status(completed_key)
+        if status == "failed":
+            resolve_gather_with_error(gather_state, result)
+            return
+        if status == "cancelled":
+            resolve_gather_with_error(gather_state, TaskCancelledError())
+            return
+
+        if status != "completed":
+            return
+
+        gather_state["remaining"] -= 1
+        if gather_state["remaining"] == 0:
+            gather_state["resolved"] = True
+            results = [waitable_status(wk)[1] for wk in gather_state["keys"]]
+            enqueue(("resume", gather_state["waiter_k"], results))
+
     def wake_waiters(completed_key):
         ws = waiters.pop(completed_key, [])
         for w in ws:
@@ -386,41 +431,8 @@ def scheduled(body_program):
                 _, waiter_k = w
                 resume_with_waitable_result(waiter_k, completed_key)
             elif w[0] == "gather":
-                _, waiter_k, gather_waitables = w
-                all_done = all(
-                    waitable_status(waitable_key(t))[0] in TERMINAL
-                    for t in gather_waitables
-                )
-                if all_done:
-                    # Fail-fast: check for first error
-                    for t in gather_waitables:
-                        s, r = waitable_status(waitable_key(t))
-                        if s == "failed":
-                            enqueue(("raise", waiter_k, r))
-                            break
-                        if s == "cancelled":
-                            enqueue(("raise", waiter_k, TaskCancelledError()))
-                            break
-                    else:
-                        # All completed successfully
-                        results = [waitable_status(waitable_key(t))[1] for t in gather_waitables]
-                        enqueue(("resume", waiter_k, results))
-                else:
-                    # Fail-fast: check if any already failed/cancelled
-                    for t in gather_waitables:
-                        s, r = waitable_status(waitable_key(t))
-                        if s == "failed":
-                            enqueue(("raise", waiter_k, r))
-                            return
-                        if s == "cancelled":
-                            enqueue(("raise", waiter_k, TaskCancelledError()))
-                            return
-                    # Re-register for next incomplete
-                    for t in gather_waitables:
-                        wk = waitable_key(t)
-                        if waitable_status(wk)[0] not in TERMINAL:
-                            waiters.setdefault(wk, []).append(("gather", waiter_k, gather_waitables))
-                            break
+                _, gather_state = w
+                wake_gather_waiter(gather_state, completed_key)
             elif w[0] == "race":
                 _, waiter_k, _race_waitables = w
                 resume_with_waitable_result(waiter_k, completed_key)
@@ -510,7 +522,7 @@ def scheduled(body_program):
 
         elif isinstance(effect, Gather):
             wks = [waitable_key(t) for t in effect.tasks]
-            # Fail-fast: check for first error/cancelled
+            pending_wks = []
             for wk in wks:
                 s, r = waitable_status(wk)
                 if s == "failed":
@@ -519,17 +531,25 @@ def scheduled(body_program):
                 if s == "cancelled":
                     from doeff.program import ResumeThrow
                     return (yield ResumeThrow(k, TaskCancelledError()))
-            all_done = all(waitable_status(wk)[0] in TERMINAL for wk in wks)
-            if all_done:
+                if s not in TERMINAL:
+                    pending_wks.append(wk)
+
+            if not pending_wks:
                 results = [waitable_status(wk)[1] for wk in wks]
                 r = yield Resume(k, results)
                 return r
-            else:
-                for wk in wks:
-                    if waitable_status(wk)[0] not in TERMINAL:
-                        waiters.setdefault(wk, []).append(("gather", k, effect.tasks))
-                        break
-                yield TailEval(pick_next())
+
+            gather_state = {
+                "waiter_k": k,
+                "keys": wks,
+                "pending_keys": pending_wks,
+                "remaining": len(pending_wks),
+                "failure": None,
+                "resolved": False,
+            }
+            for wk in pending_wks:
+                waiters.setdefault(wk, []).append(("gather", gather_state))
+            yield TailEval(pick_next())
 
         elif isinstance(effect, Race):
             for t in effect.tasks:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,19 +4,21 @@ import sys
 from types import FrameType
 from typing import Any
 
-from doeff import EffectBase, Pass, Resume, do, run as doeff_run
 from doeff_core_effects.scheduler import (
+    PRIORITY_IDLE,
     Cancel,
     CompletePromise,
     CreatePromise,
     Gather,
-    PRIORITY_IDLE,
     Spawn,
     Task,
     TaskCancelledError,
     Wait,
     scheduled,
 )
+
+from doeff import EffectBase, Pass, Resume, do
+from doeff import run as doeff_run
 
 
 def _count_waitable_status_calls_for_gather(total: int) -> int:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,7 +1,67 @@
 """Tests for the cooperative scheduler."""
 
-from doeff import do, run as doeff_run, EffectBase, Resume, Pass
-from doeff_core_effects.scheduler import scheduled, Spawn, Gather, Wait, Task
+import sys
+from types import FrameType
+from typing import Any
+
+from doeff import EffectBase, Pass, Resume, do, run as doeff_run
+from doeff_core_effects.scheduler import (
+    Cancel,
+    CompletePromise,
+    CreatePromise,
+    Gather,
+    PRIORITY_IDLE,
+    Spawn,
+    Task,
+    TaskCancelledError,
+    Wait,
+    scheduled,
+)
+
+
+def _count_waitable_status_calls_for_gather(total: int) -> int:
+    calls = 0
+
+    @do
+    def worker(gate: Any, value: int):
+        _ = yield Wait(gate.future)
+        return value
+
+    @do
+    def release_all(gates: list[Any]):
+        for gate in gates:
+            yield CompletePromise(gate, None)
+
+    @do
+    def body():
+        gates: list[Any] = []
+        tasks: list[Any] = []
+        for value in range(total):
+            gate = yield CreatePromise()
+            gates.append(gate)
+            tasks.append((yield Spawn(worker(gate, value))))
+        _ = yield Spawn(release_all(gates), priority=PRIORITY_IDLE)
+        return (yield Gather(*tasks))
+
+    def profile_waitable_status(frame: FrameType, event: str, arg: object) -> Any:
+        nonlocal calls
+        if (
+            event == "call"
+            and frame.f_code.co_name == "waitable_status"
+            and frame.f_code.co_filename.endswith("scheduler.py")
+        ):
+            calls += 1
+        return profile_waitable_status
+
+    previous_profile = sys.getprofile()
+    sys.setprofile(profile_waitable_status)
+    try:
+        result = doeff_run(scheduled(body()))
+    finally:
+        sys.setprofile(previous_profile)
+
+    assert result == list(range(total))
+    return calls
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +133,83 @@ class TestGather:
             return (yield Gather(t1, t2, t3))
 
         assert doeff_run(scheduled(body())) == [10, 20, 30]
+
+    def test_gather_wake_waiter_status_checks_are_linear(self):
+        """Gather wake-up work should scale linearly with task count."""
+        small_total = 200
+        large_total = 400
+
+        small_calls = _count_waitable_status_calls_for_gather(small_total)
+        large_calls = _count_waitable_status_calls_for_gather(large_total)
+
+        assert small_calls <= small_total * 20
+        assert large_calls <= large_total * 20
+        assert large_calls <= small_calls * 3
+
+    def test_gather_wakes_on_first_failed_pending_task(self):
+        """Gather raises when any pending child fails, not only the first pending child."""
+        events: list[str] = []
+
+        @do
+        def blocked(gate: Any):
+            _ = yield Wait(gate.future)
+            events.append("blocked released")
+            return "blocked"
+
+        @do
+        def failing(gate: Any):
+            _ = yield Wait(gate.future)
+            events.append("failing raised")
+            raise RuntimeError("boom")
+            yield
+
+        @do
+        def release_failure_then_blocker(failure_gate: Any, blocker_gate: Any):
+            events.append("release failure")
+            yield CompletePromise(failure_gate, None)
+            events.append("release blocker")
+            yield CompletePromise(blocker_gate, None)
+
+        @do
+        def body():
+            blocker_gate = yield CreatePromise()
+            failure_gate = yield CreatePromise()
+            blocker_task = yield Spawn(blocked(blocker_gate))
+            failing_task = yield Spawn(failing(failure_gate))
+            _ = yield Spawn(
+                release_failure_then_blocker(failure_gate, blocker_gate),
+                priority=PRIORITY_IDLE,
+            )
+            try:
+                yield Gather(blocker_task, failing_task)
+                return "should not reach"
+            except RuntimeError as error:
+                events.append(f"caught:{error}")
+                return list(events)
+
+        assert doeff_run(scheduled(body())) == [
+            "release failure",
+            "failing raised",
+            "caught:boom",
+        ]
+
+    def test_gather_cancelled_child_raises_task_cancelled_error(self):
+        @do
+        def blocked(gate: Any):
+            return (yield Wait(gate.future))
+
+        @do
+        def body():
+            gate = yield CreatePromise()
+            task = yield Spawn(blocked(gate))
+            yield Cancel(task)
+            try:
+                yield Gather(task)
+                return "should not reach"
+            except TaskCancelledError:
+                return "cancelled"
+
+        assert doeff_run(scheduled(body())) == "cancelled"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `scheduler-gather-quadratic-v2`.

- Replaces Gather wake-up rescans with a single per-Gather countdown state.
- Registers each pending waitable against that state so each completion does O(1) work.
- Preserves result ordering, immediate fail-fast error propagation, and cancellation mapping to `TaskCancelledError`.
- Adds regression coverage for status-call complexity, pending-task fail-fast behavior, and Gather cancellation mapping.

## Root Cause

`wake_waiters(completed_key)` stored Gather waiters as the full waitable list and rescanned that list on each child completion. For `Gather(N)`, that made successful fan-out completion O(N^2) in `waitable_status` calls and delayed fail-fast when a non-front pending child failed first.

## Verification

- TDD proof before fix: `uv run pytest tests/test_scheduler.py::TestGather::test_gather_wake_waiter_status_checks_are_linear tests/test_scheduler.py::TestGather::test_gather_wakes_on_first_failed_pending_task tests/test_scheduler.py::TestGather::test_gather_cancelled_child_raises_task_cancelled_error` failed as expected: complexity test saw `N=200` at `81200` `waitable_status` calls, and pending fail-fast was delayed behind the first pending child.
- After fix: same targeted command passed, `3 passed`.
- `uv run pytest tests/test_scheduler.py tests/test_cache_await_spawn_hang.py tests/core/test_scheduler_transfer.py` passed, `37 passed`.
- `uv run python -W ignore - <<'PY' ... _count_waitable_status_calls_for_gather ... PY` reported `N=200 waitable_status_calls=1000 calls_per_task=5.00` and `N=400 waitable_status_calls=2000 calls_per_task=5.00`.
- `uv run pytest` passed, `840 passed, 84 skipped`.
- `make lint` was run and stopped at an existing unchanged pyright error: `doeff/cli/discovery.py:57:43 - "Indexer" is unknown import symbol`.

## Issue Reference

`scheduler-gather-quadratic-v2`
