### PR TITLE
[codex] Exclude conductor runtime state from workspace commits

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -145,6 +145,19 @@ rules:
       exclude:
         - /packages/doeff-conductor/src/doeff_conductor/handlers/exec_handler.py
 
+  - id: conductor-runtime-state-ignores-live-in-workspace-init
+    languages: [generic]
+    severity: ERROR
+    message: >
+      spec §11-6: conductor runtime session-state ignores belong in workspace
+      initialization, not Commit/Git effect staging. Keep git add -A generic so
+      manual git commands and future commit consumers get the same behavior.
+    pattern-regex: '\.agent-home/?'
+    paths:
+      include:
+        - /packages/doeff-conductor/src/doeff_conductor/handlers/git_handler.py
+        - /packages/doeff-conductor/src/doeff_conductor/effects/git.py
+
   - id: http-request-handlers-use-defhandler
     languages: [python]
     severity: ERROR

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -576,12 +576,11 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
 4. **Calibration state store** — cross-run, level-triggered; v1 ships
    manual sampling rates + escape recording only (no autonomous rate
    adjustment).
-5. **Runtime auto-commit captures session state.** The worker's agent
-   home lives inside the worktree as tracked files (`.agent-home/`), so
-   the post-agent-node `Commit` stages session-state mutations into work
-   commits. Either agent homes move outside the worktree or the
-   auto-commit excludes session-state paths (same class as the result
-   file's `info/exclude` treatment).
+5. **Runtime auto-commit captures session state — fixed 913149d1.**
+   Conductor-created workspaces now install workspace-level `.gitignore`
+   entries for in-worktree runtime state (`.agent-home/`). The ignore lives
+   at workspace initialization, so post-agent-node `Commit`, manual
+   `git add -A`, and future workspace consumers all share the same behavior.
 6. **Await budget has no owning axis.** `AgentTask.timeout_seconds`
    exists but nothing sets it; the effective default lives in L1
    (3600s after the 2026-06-11 correction; was 600s, which burned a
@@ -605,4 +604,3 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
 11. **`doeff-agents` CLI is blind to agentd sessions** (it reads the
    local-handler store) and `doeff-agentd` has no client subcommands;
    session-level monitoring currently requires reading agentd's sqlite.
-

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -576,7 +576,7 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
 4. **Calibration state store** — cross-run, level-triggered; v1 ships
    manual sampling rates + escape recording only (no autonomous rate
    adjustment).
-5. **Runtime auto-commit captures session state — fixed 913149d1.**
+5. **Runtime auto-commit captures session state — fixed e206be17.**
    Conductor-created workspaces now install workspace-level `.gitignore`
    entries for in-worktree runtime state (`.agent-home/`). The ignore lives
    at workspace initialization, so post-agent-node `Commit`, manual

--- a/packages/doeff-conductor/docs/validation-2026-06-11.md
+++ b/packages/doeff-conductor/docs/validation-2026-06-11.md
@@ -93,7 +93,7 @@ daemon (single authority). Candidate follow-up issue.
 ## Open defects (spec §11)
 
 5. Workspace resume divergence — ✅ fixed b5854d60 (+ occurrence identity, F1/F2 review fixes)
-6. Auto-commit captures .agent-home session state — ✅ fixed 913149d1
+6. Auto-commit captures .agent-home session state — ✅ fixed e206be17
 7. Await budget owning axis — open
 8. blocked-status cosmetic misread — open
 9. (candidate) doeff-agents CLI blind to agentd sessions — monitoring gap

--- a/packages/doeff-conductor/docs/validation-2026-06-11.md
+++ b/packages/doeff-conductor/docs/validation-2026-06-11.md
@@ -93,7 +93,7 @@ daemon (single authority). Candidate follow-up issue.
 ## Open defects (spec §11)
 
 5. Workspace resume divergence — ✅ fixed b5854d60 (+ occurrence identity, F1/F2 review fixes)
-6. Auto-commit captures .agent-home session state — open
+6. Auto-commit captures .agent-home session state — ✅ fixed 913149d1
 7. Await budget owning axis — open
 8. blocked-status cosmetic misread — open
 9. (candidate) doeff-agents CLI blind to agentd sessions — monitoring gap

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
@@ -43,6 +43,11 @@ class WorkspaceStateError(RuntimeError):
     """Raised when on-disk workspace state contradicts its identity."""
 
 
+WORKSPACE_RUNTIME_STATE_GITIGNORE_ENTRIES: tuple[str, ...] = (
+    ".agent-home/",
+)
+
+
 @dataclass(frozen=True)
 class _WorkspaceMaterialization:
     workspace: Workspace
@@ -58,6 +63,35 @@ def _get_workspace_base_dir() -> Path:
 def _branch_for(workspace_id: str) -> str:
     """Derive the deterministic branch name for a workspace identity."""
     return f"conductor/{workspace_id}"
+
+
+def _ensure_runtime_state_ignored(materialized_path: Path) -> None:
+    """Ensure conductor-created workspaces ignore in-worktree runtime state."""
+    gitignore_path: Path = materialized_path / ".gitignore"
+    try:
+        existing_text: str = gitignore_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        existing_text = ""
+
+    existing_entries: set[str] = {
+        line.strip()
+        for line in existing_text.splitlines()
+        if line.strip()
+    }
+    missing_entries: list[str] = [
+        entry
+        for entry in WORKSPACE_RUNTIME_STATE_GITIGNORE_ENTRIES
+        if entry not in existing_entries and f"/{entry}" not in existing_entries
+    ]
+    if not missing_entries:
+        return
+
+    updated_text: str = existing_text
+    if updated_text and not updated_text.endswith("\n"):
+        updated_text += "\n"
+    for entry in missing_entries:
+        updated_text += f"{entry}\n"
+    gitignore_path.write_text(updated_text, encoding="utf-8")
 
 
 class WorkspaceHandler:
@@ -178,6 +212,8 @@ class WorkspaceHandler:
                 cwd=repo_path,
                 log_path=log_path,
             )
+
+        _ensure_runtime_state_ignored(materialized_path)
 
         workspace = Workspace(
             id=workspace_id,

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
@@ -53,6 +53,7 @@ class _WorkspaceMaterialization:
     workspace: Workspace
     path: Path
     base_commit: str
+    runtime_ignore_snapshot: str | None = None
 
 
 def _get_workspace_base_dir() -> Path:
@@ -65,7 +66,7 @@ def _branch_for(workspace_id: str) -> str:
     return f"conductor/{workspace_id}"
 
 
-def _ensure_runtime_state_ignored(materialized_path: Path) -> None:
+def _ensure_runtime_state_ignored(materialized_path: Path) -> str | None:
     """Ensure conductor-created workspaces ignore in-worktree runtime state."""
     gitignore_path: Path = materialized_path / ".gitignore"
     try:
@@ -84,7 +85,7 @@ def _ensure_runtime_state_ignored(materialized_path: Path) -> None:
         if entry not in existing_entries and f"/{entry}" not in existing_entries
     ]
     if not missing_entries:
-        return
+        return None
 
     updated_text: str = existing_text
     if updated_text and not updated_text.endswith("\n"):
@@ -92,6 +93,45 @@ def _ensure_runtime_state_ignored(materialized_path: Path) -> None:
     for entry in missing_entries:
         updated_text += f"{entry}\n"
     gitignore_path.write_text(updated_text, encoding="utf-8")
+    return updated_text
+
+
+def _status_path_from_porcelain_line(line: str) -> str:
+    """Extract a path from git status porcelain v1 output."""
+    path: str = line[3:]
+    if " -> " in path:
+        return path.split(" -> ", maxsplit=1)[1]
+    return path
+
+
+def _has_only_recorded_runtime_ignore_changes(
+    materialization: _WorkspaceMaterialization,
+) -> bool:
+    """Return true when the only dirty file is our own workspace ignore write."""
+    if materialization.runtime_ignore_snapshot is None:
+        return False
+
+    status_result = run_git(
+        ["git", "status", "--porcelain"],
+        cwd=materialization.path,
+    )
+    status_lines: list[str] = [
+        line
+        for line in status_result.stdout.splitlines()
+        if line
+    ]
+    if not status_lines:
+        return False
+    if any(_status_path_from_porcelain_line(line) != ".gitignore" for line in status_lines):
+        return False
+
+    try:
+        current_gitignore: str = (materialization.path / ".gitignore").read_text(
+            encoding="utf-8"
+        )
+    except FileNotFoundError:
+        return False
+    return current_gitignore == materialization.runtime_ignore_snapshot
 
 
 class WorkspaceHandler:
@@ -213,7 +253,7 @@ class WorkspaceHandler:
                 log_path=log_path,
             )
 
-        _ensure_runtime_state_ignored(materialized_path)
+        runtime_ignore_snapshot: str | None = _ensure_runtime_state_ignored(materialized_path)
 
         workspace = Workspace(
             id=workspace_id,
@@ -227,6 +267,7 @@ class WorkspaceHandler:
             workspace=workspace,
             path=materialized_path,
             base_commit=get_current_commit(materialized_path),
+            runtime_ignore_snapshot=runtime_ignore_snapshot,
         )
         return workspace
 
@@ -325,7 +366,10 @@ class WorkspaceHandler:
             return False
 
         args: list[str] = ["git", "worktree", "remove"]
-        if effect.force:
+        force_remove: bool = effect.force or _has_only_recorded_runtime_ignore_changes(
+            materialization
+        )
+        if force_remove:
             args.append("--force")
         args.append(str(materialization.path))
 

--- a/packages/doeff-conductor/tests/test_workspace_handler.py
+++ b/packages/doeff-conductor/tests/test_workspace_handler.py
@@ -6,7 +6,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from doeff_conductor.effects.git import Commit
 from doeff_conductor.effects.workspace import CreateWorkspace, DeleteWorkspace, MergeWorkspaces
+from doeff_conductor.handlers.git_handler import GitHandler
 from doeff_conductor.handlers.workspace_handler import WorkspaceHandler, WorkspaceStateError
 from doeff_conductor.types import Issue, IssueStatus, MergeStatus, MergeStrategy, Workspace
 
@@ -84,6 +86,60 @@ class TestWorkspaceHandler:
         assert workspace.base_ref in ("master", "main")
         assert "path" not in workspace.to_dict()
         assert handler.resolve_path(workspace).exists()
+
+    def test_create_workspace_installs_runtime_state_gitignore(
+        self,
+        handler: WorkspaceHandler,
+    ) -> None:
+        workspace = handler.handle_create_workspace(CreateWorkspace(workspace_id="ws-ignore"))
+        materialized_path = handler.resolve_path(workspace)
+
+        gitignore_lines = (materialized_path / ".gitignore").read_text().splitlines()
+        assert ".agent-home/" in gitignore_lines
+
+        agent_state_path = materialized_path / ".agent-home" / "session.json"
+        agent_state_path.parent.mkdir()
+        agent_state_path.write_text('{"session": "runtime"}')
+
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=materialized_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert ".agent-home" not in status.stdout
+
+    def test_workspace_auto_commit_excludes_runtime_agent_home(
+        self,
+        handler: WorkspaceHandler,
+    ) -> None:
+        workspace = handler.handle_create_workspace(CreateWorkspace(workspace_id="ws-autocommit"))
+        materialized_path = handler.resolve_path(workspace)
+        git_handler = GitHandler(workspace_resolver=handler.resolve_path)
+
+        (materialized_path / "feature.txt").write_text("user-visible work\n")
+        agent_state_path = materialized_path / ".agent-home" / "session.json"
+        agent_state_path.parent.mkdir()
+        agent_state_path.write_text('{"session": "runtime"}')
+
+        commit_sha = git_handler.handle_commit(
+            Commit(
+                workspace=workspace,
+                message="Commit workspace changes",
+                all=True,
+            )
+        )
+
+        committed_paths = subprocess.run(
+            ["git", "show", "--name-only", "--format=", commit_sha],
+            cwd=materialized_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert "feature.txt" in committed_paths
+        assert ".agent-home/session.json" not in committed_paths
 
     def test_create_workspace_requires_identity(self, handler: WorkspaceHandler) -> None:
         with pytest.raises(ValueError, match="non-empty workspace_id"):

--- a/packages/doeff-conductor/tests/test_workspace_handler.py
+++ b/packages/doeff-conductor/tests/test_workspace_handler.py
@@ -177,6 +177,21 @@ class TestWorkspaceHandler:
         assert result is True
         assert not materialized_path.exists()
 
+    def test_delete_workspace_preserves_uncommitted_user_changes(
+        self,
+        handler: WorkspaceHandler,
+    ) -> None:
+        workspace: Workspace = handler.handle_create_workspace(
+            CreateWorkspace(workspace_id="ws-delete-dirty")
+        )
+        materialized_path: Path = handler.resolve_path(workspace)
+        (materialized_path / "wip.txt").write_text("keep me\n")
+
+        result: bool = handler.handle_delete_workspace(DeleteWorkspace(workspace=workspace))
+
+        assert result is False
+        assert materialized_path.exists()
+
     def test_delete_workspace_nonexistent(self, handler: WorkspaceHandler) -> None:
         workspace = Workspace(id="missing", repo="default", ref="missing", base_ref="main")
 

--- a/packages/doeff-conductor/tests/test_workspace_handler.py
+++ b/packages/doeff-conductor/tests/test_workspace_handler.py
@@ -91,17 +91,19 @@ class TestWorkspaceHandler:
         self,
         handler: WorkspaceHandler,
     ) -> None:
-        workspace = handler.handle_create_workspace(CreateWorkspace(workspace_id="ws-ignore"))
-        materialized_path = handler.resolve_path(workspace)
+        workspace: Workspace = handler.handle_create_workspace(
+            CreateWorkspace(workspace_id="ws-ignore")
+        )
+        materialized_path: Path = handler.resolve_path(workspace)
 
-        gitignore_lines = (materialized_path / ".gitignore").read_text().splitlines()
+        gitignore_lines: list[str] = (materialized_path / ".gitignore").read_text().splitlines()
         assert ".agent-home/" in gitignore_lines
 
-        agent_state_path = materialized_path / ".agent-home" / "session.json"
+        agent_state_path: Path = materialized_path / ".agent-home" / "session.json"
         agent_state_path.parent.mkdir()
         agent_state_path.write_text('{"session": "runtime"}')
 
-        status = subprocess.run(
+        status: subprocess.CompletedProcess[str] = subprocess.run(
             ["git", "status", "--porcelain"],
             cwd=materialized_path,
             check=True,
@@ -114,16 +116,18 @@ class TestWorkspaceHandler:
         self,
         handler: WorkspaceHandler,
     ) -> None:
-        workspace = handler.handle_create_workspace(CreateWorkspace(workspace_id="ws-autocommit"))
-        materialized_path = handler.resolve_path(workspace)
-        git_handler = GitHandler(workspace_resolver=handler.resolve_path)
+        workspace: Workspace = handler.handle_create_workspace(
+            CreateWorkspace(workspace_id="ws-autocommit")
+        )
+        materialized_path: Path = handler.resolve_path(workspace)
+        git_handler: GitHandler = GitHandler(workspace_resolver=handler.resolve_path)
 
         (materialized_path / "feature.txt").write_text("user-visible work\n")
-        agent_state_path = materialized_path / ".agent-home" / "session.json"
+        agent_state_path: Path = materialized_path / ".agent-home" / "session.json"
         agent_state_path.parent.mkdir()
         agent_state_path.write_text('{"session": "runtime"}')
 
-        commit_sha = git_handler.handle_commit(
+        commit_sha: str = git_handler.handle_commit(
             Commit(
                 workspace=workspace,
                 message="Commit workspace changes",
@@ -131,13 +135,14 @@ class TestWorkspaceHandler:
             )
         )
 
-        committed_paths = subprocess.run(
+        show_result: subprocess.CompletedProcess[str] = subprocess.run(
             ["git", "show", "--name-only", "--format=", commit_sha],
             cwd=materialized_path,
             check=True,
             capture_output=True,
             text=True,
-        ).stdout.splitlines()
+        )
+        committed_paths: list[str] = show_result.stdout.splitlines()
         assert "feature.txt" in committed_paths
         assert ".agent-home/session.json" not in committed_paths
 


### PR DESCRIPTION
## Summary

Fixes `conductor-autocommit-exclude-session-state` by moving runtime-state exclusion to the workspace initialization layer.

Conductor-created workspaces now add `.agent-home/` to the workspace `.gitignore` through a centralized runtime-state entry list in `WorkspaceHandler`. This keeps `git add -A` generic while making auto-commit, manual agent git commands, and future workspace consumers share the same ignore behavior.

## Root Cause

The worker's isolated Claude home defaults to `work_dir / ".agent-home"`. Because new conductor workspaces did not install an ignore rule for that in-worktree runtime state, post-agent-node auto-commit delegated to `git add -A` and captured session files into work commits.

## Changes

- Add workspace initialization logic that idempotently installs runtime-state `.gitignore` entries.
- Keep the runtime-state ignore list near workspace materialization as a single constant.
- Add regression tests proving `.agent-home` is hidden from `git status` and absent from auto-commit paths.
- Add a semgrep guard preventing the anti-pattern of hardcoding `.agent-home` exclusions in the conductor Git effect/staging layer.
- Preserve `DeleteWorkspace` behavior by allowing removal of a worktree dirty only from the recorded conductor-created `.gitignore`, while still refusing deletion when user WIP exists.
- Mark spec §11 runtime-state auto-commit defect fixed at `e206be17` and update the validation record.

## Acceptance Evidence

- Failing test phase was verified before implementation:
  - `uv run pytest packages/doeff-conductor/tests/test_workspace_handler.py::TestWorkspaceHandler::test_create_workspace_installs_runtime_state_gitignore packages/doeff-conductor/tests/test_workspace_handler.py::TestWorkspaceHandler::test_workspace_auto_commit_excludes_runtime_agent_home`
  - Result before fix: 2 failed. `.gitignore` was absent and `.agent-home/session.json` appeared in committed paths.
- New workspace ignores `.agent-home` and `git status` does not report it:
  - Covered by `test_create_workspace_installs_runtime_state_gitignore`.
- Auto-commit excludes `.agent-home` paths after creating runtime state:
  - Covered by `test_workspace_auto_commit_excludes_runtime_agent_home`.
  - The test writes `.agent-home/session.json`, commits via `GitHandler(... Commit(all=True))`, then asserts the commit contains `feature.txt` and not `.agent-home/session.json`.
- Existing conductor package tests are green:
  - `uv run pytest packages/doeff-conductor/tests`
  - Result: `300 passed, 76 warnings`.
- Focused lint/type/architecture checks on changed code are green:
  - `uv run ruff check packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py packages/doeff-conductor/tests/test_workspace_handler.py` -> `All checks passed!`
  - `uv run pyright packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py` -> `0 errors, 0 warnings, 0 informations`
  - `uv run semgrep --config .semgrep.yaml packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py packages/doeff-conductor/src/doeff_conductor/handlers/git_handler.py packages/doeff-conductor/src/doeff_conductor/effects/git.py --error` -> `0 findings`.

## Lint Note

`make lint` was run. Ruff and pyright passed, then the command stopped at the repository's existing semgrep baseline with 88 blocking findings outside this change, for example `doeff/cli/code_runner.py`, `doeff/cli/hy_runner.py`, and `packages/doeff-vm-core/src/do_ctrl.rs`. No finding came from the new workspace runtime-state rule or changed files.