### PR TITLE
[codex] Journal random workflow effects

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -77,6 +77,18 @@ rules:
       include:
         - /packages/doeff-agents/**
 
+  - id: conductor-random-effect-no-fixed-seed
+    languages: [python]
+    severity: ERROR
+    message: >
+      conductor-random-true-randomness: random! must draw from OS entropy on
+      first execution and rely on the workflow effect journal for replay.
+      Fixed-seed Random(0) placeholders make separate workflow runs identical.
+    pattern: Random(0)
+    paths:
+      include:
+        - /packages/doeff-conductor/src/doeff_conductor/**
+
   - id: doeff-agents-no-pr-url-session-sniffing
     languages: [generic]
     severity: ERROR

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -599,10 +599,10 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
    no live effect, and no closure verb exists (`gate list` only; no
    proceed/redirect/abort). The overseer contract (§8) is currently
    stub-only; wiring it live is the next major stage.
-10. **`random!` is a placeholder**: `_evaluate_random` uses `Random(0)` —
-   a constant seed shared by every node, so every draw is identical.
-   Per-node seeded randomness recorded for replay is the intended design.
+10. **`random!` true randomness + journal replay fixed `bc48f890`**:
+   `random!` now emits a workflow effect handled through
+   `effect-journal.jsonl`; first execution draws from OS entropy and replay
+   returns the recorded value.
 11. **`doeff-agents` CLI is blind to agentd sessions** (it reads the
    local-handler store) and `doeff-agentd` has no client subcommands;
    session-level monitoring currently requires reading agentd's sqlite.
-

--- a/packages/doeff-conductor/docs/validation-2026-06-11.md
+++ b/packages/doeff-conductor/docs/validation-2026-06-11.md
@@ -109,6 +109,6 @@ daemon (single authority). Candidate follow-up issue.
 | Result channel per-session | ❌→✅ | shared-workspace collision (stale acceptance); fixed 0ad2c7b4 |
 | Loop iteration in node identity | ❌→✅ | round 2 re-adopted round 1's session; fixed 0ad2c7b4 |
 | §8 attention tiers LIVE | ❌ | stub-only: live exhaustion = terminal error, no parked gate, no closure verb, phase-checkpoints inert — NEXT MAJOR STAGE |
-| `random!` true randomness | ❌ | Random(0) constant-seed placeholder (§11-10) |
+| `random!` true randomness | ❌→✅ | fixed `bc48f890`: OS entropy on first run, `effect-journal.jsonl` value on replay (§11-10) |
 | quorum/oks Try-bindings | ⬜ | not yet probed live |
 | merge-conflict structured bounce | ⬜ | not yet probed live |

--- a/packages/doeff-conductor/src/doeff_conductor/__init__.py
+++ b/packages/doeff-conductor/src/doeff_conductor/__init__.py
@@ -81,6 +81,7 @@ from .handlers import (
     GitHandler,
     IssueHandler,
     JournaledAgentHandler,
+    JournaledWorkflowEffectHandler,
     MockConductorRuntime,
     WorkspaceHandler,
     default_scheduled_handlers,
@@ -98,6 +99,7 @@ from .replay_keying import (
     longest_valid_prefix,
     node_identity_fingerprint,
     resolved_identity_fingerprint,
+    workflow_effect_cache_key,
 )
 from .templates import (
     basic_pr,
@@ -168,6 +170,7 @@ __all__ = [
     "IssueStatus",
     "JournalCorruptionError",
     "JournaledAgentHandler",
+    "JournaledWorkflowEffectHandler",
     "ListIssues",
     "MergeCall",
     "MergeConflict",
@@ -227,4 +230,5 @@ __all__ = [
     "reviewed_pr",
     "route_review_item",
     "run_review_routing_demo",
+    "workflow_effect_cache_key",
 ]

--- a/packages/doeff-conductor/src/doeff_conductor/effects/dsl.py
+++ b/packages/doeff-conductor/src/doeff_conductor/effects/dsl.py
@@ -1,7 +1,5 @@
 """L3 workflow DSL effects for doeff-conductor."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -56,6 +54,8 @@ class TimeCall(ConductorEffectBase):
     """Explicit clock effect emitted by ``time!``."""
 
     label: str | None = None
+    run_id: str | None = None
+    node_id: str | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -64,3 +64,5 @@ class RandomCall(ConductorEffectBase):
 
     spec: Any
     label: str | None = None
+    run_id: str | None = None
+    node_id: str | None = None

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/__init__.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/__init__.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from doeff import WithHandler, run
+from doeff_conductor.workflow_effect_journal import JournaledWorkflowEffectHandler
 
 from .agent_handler import (
     AgentBackend,
@@ -90,12 +91,17 @@ def production_handlers(
             state_dir=journal_state_dir,
             run_id=journal_run_id,
         )
+    workflow_effect_handler = JournaledWorkflowEffectHandler(
+        state_dir=journal_state_dir,
+        run_id=journal_run_id,
+    )
     return default_scheduled_handlers(
         workspace_handler=active_workspace_handler,
         issue_handler=issue_handler,
         agent_handler=resolved_agent_handler,
         git_handler=git_handler,
         exec_handler=exec_handler,
+        workflow_effect_handler=workflow_effect_handler,
     )
 
 
@@ -134,6 +140,7 @@ __all__ = [
     "GitHandler",
     "IssueHandler",
     "JournaledAgentHandler",
+    "JournaledWorkflowEffectHandler",
     "MockConductorRuntime",
     "RunSyncResult",
     "WorkspaceHandler",

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/testing.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/testing.py
@@ -19,6 +19,7 @@ from doeff_conductor.effects.agent import (
     AgentValidationErrorKind,
     AgentValidationFailure,
 )
+from doeff_conductor.effects.dsl import RandomCall, TimeCall
 from doeff_conductor.effects.exec import Exec
 from doeff_conductor.effects.git import Commit, CreatePR, MergePR, Push
 from doeff_conductor.effects.issue import CreateIssue, GetIssue, ListIssues, ResolveIssue
@@ -33,6 +34,7 @@ from doeff_conductor.types import (
     PRHandle,
     Workspace,
 )
+from doeff_conductor.workflow_effect_journal import JournaledWorkflowEffectHandler
 
 from .utils import make_scheduled_handler
 
@@ -371,6 +373,9 @@ def mock_handlers(
 ) -> ScheduledHandler:
     """Build a complete mock protocol handler for all conductor effects."""
     active_runtime = runtime or MockConductorRuntime(root=root, workflow_id=workflow_id)
+    workflow_effect_handler = JournaledWorkflowEffectHandler(
+        state_dir=active_runtime.root,
+    )
 
     handlers: list[tuple[type[Any], ScheduledHandler]] = [
         (CreateWorkspace, make_scheduled_handler(active_runtime.handle_create_workspace)),
@@ -382,6 +387,8 @@ def mock_handlers(
         (GetIssue, make_scheduled_handler(active_runtime.handle_get_issue)),
         (ResolveIssue, make_scheduled_handler(active_runtime.handle_resolve_issue)),
         (AgentEffect, make_scheduled_handler(active_runtime.handle_agent)),
+        (TimeCall, make_scheduled_handler(workflow_effect_handler.handle_time)),
+        (RandomCall, make_scheduled_handler(workflow_effect_handler.handle_random)),
         (Commit, make_scheduled_handler(active_runtime.handle_commit)),
         (Push, make_scheduled_handler(active_runtime.handle_push)),
         (CreatePR, make_scheduled_handler(active_runtime.handle_create_pr)),

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/utils.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/utils.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from doeff_conductor.handlers.issue_handler import IssueHandler
     from doeff_conductor.handlers.journaled_agent import JournaledAgentHandler
     from doeff_conductor.handlers.workspace_handler import WorkspaceHandler
+    from doeff_conductor.workflow_effect_journal import JournaledWorkflowEffectHandler
 
 SimpleHandler = Callable[[Any], Any]
 
@@ -61,6 +62,7 @@ def default_scheduled_handlers(
     agent_handler: "AgentHandler | JournaledAgentHandler | None" = None,
     git_handler: "GitHandler | None" = None,
     exec_handler: "ExecHandler | None" = None,
+    workflow_effect_handler: "JournaledWorkflowEffectHandler | None" = None,
 ) -> Callable[..., Any]:
     """Build a complete protocol handler for all conductor effects.
 
@@ -70,11 +72,13 @@ def default_scheduled_handlers(
         agent_handler: Custom AgentHandler, or None to create default
         git_handler: Custom GitHandler, or None to create default
         exec_handler: Custom ExecHandler, or None to create default
+        workflow_effect_handler: Custom time!/random! journal handler, or None for default
 
     Returns:
         Handler-protocol callable for all conductor effects.
     """
     from doeff_conductor.effects.agent import AgentEffect
+    from doeff_conductor.effects.dsl import RandomCall, TimeCall
     from doeff_conductor.effects.exec import Exec
     from doeff_conductor.effects.git import Commit, CreatePR, MergePR, Push
     from doeff_conductor.effects.issue import CreateIssue, GetIssue, ListIssues, ResolveIssue
@@ -84,12 +88,14 @@ def default_scheduled_handlers(
     from doeff_conductor.handlers.git_handler import GitHandler
     from doeff_conductor.handlers.issue_handler import IssueHandler
     from doeff_conductor.handlers.workspace_handler import WorkspaceHandler
+    from doeff_conductor.workflow_effect_journal import JournaledWorkflowEffectHandler
 
     workspace = workspace_handler or WorkspaceHandler()
     iss = issue_handler or IssueHandler()
     agent = agent_handler or AgentHandler(workspace_resolver=workspace.resolve_path)
     git = git_handler or GitHandler(workspace_resolver=workspace.resolve_path)
     exec_gate = exec_handler or ExecHandler(workspace_resolver=workspace.resolve_path)
+    workflow_effect = workflow_effect_handler or JournaledWorkflowEffectHandler()
 
     handlers: tuple[tuple[type[Any], Callable[..., Any]], ...] = (
         (CreateWorkspace, make_blocking_scheduled_handler(workspace.handle_create_workspace)),
@@ -101,6 +107,8 @@ def default_scheduled_handlers(
         (GetIssue, make_blocking_scheduled_handler(iss.handle_get_issue)),
         (ResolveIssue, make_blocking_scheduled_handler(iss.handle_resolve_issue)),
         (AgentEffect, make_blocking_scheduled_handler(agent.handle_agent)),
+        (TimeCall, make_blocking_scheduled_handler(workflow_effect.handle_time)),
+        (RandomCall, make_blocking_scheduled_handler(workflow_effect.handle_random)),
         (Commit, make_blocking_scheduled_handler(git.handle_commit)),
         (Push, make_blocking_scheduled_handler(git.handle_push)),
         (CreatePR, make_blocking_scheduled_handler(git.handle_create_pr)),

--- a/packages/doeff-conductor/src/doeff_conductor/replay_keying.py
+++ b/packages/doeff-conductor/src/doeff_conductor/replay_keying.py
@@ -1,7 +1,5 @@
 """Pure replay identity and cache-key helpers for conductor workflows."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 from dataclasses import asdict, dataclass, is_dataclass
@@ -13,13 +11,15 @@ class ResolvedIdentity:
     """Result-distribution-affecting identity resolved from a profile."""
 
     adapter: str
-    model: str
+    model: str | None
     identity: str | None = None
     effort: str | None = None
 
 
 def _canonical_payload(value: Any) -> Any:
-    canonical_source = asdict(value) if is_dataclass(value) and not isinstance(value, type) else value
+    canonical_source = (
+        asdict(value) if is_dataclass(value) and not isinstance(value, type) else value
+    )
     if isinstance(canonical_source, dict):
         return {
             str(key): _canonical_payload(canonical_source[key])
@@ -84,6 +84,25 @@ def agent_cache_key(
             "prompt": prompt,
             "schema": schema,
             "resolved_identity": resolved_identity_fingerprint(resolved_identity),
+        }
+    )
+
+
+def workflow_effect_cache_key(
+    *,
+    effect_kind: str,
+    node_id: str,
+    label: str | None,
+    spec: Any,
+) -> str:
+    """Return the replay cache key for journaled workflow effects."""
+
+    return _sha256_payload(
+        {
+            "effect_kind": effect_kind,
+            "node_id": node_id,
+            "label": label,
+            "spec": spec,
         }
     )
 

--- a/packages/doeff-conductor/src/doeff_conductor/workflow_effect_journal.py
+++ b/packages/doeff-conductor/src/doeff_conductor/workflow_effect_journal.py
@@ -1,0 +1,415 @@
+"""Durable workflow effect journal for explicit time! and random! replay."""
+
+import json
+import os
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from random import SystemRandom
+from typing import Any
+
+from doeff_conductor.effects.dsl import RandomCall, TimeCall
+from doeff_conductor.exceptions import JournalCorruptionError
+from doeff_conductor.replay_keying import longest_valid_prefix, workflow_effect_cache_key
+
+WORKFLOW_EFFECT_JOURNAL_FILENAME = "effect-journal.jsonl"
+WORKFLOW_EFFECT_JOURNAL_VERSION = 1
+TERMINAL_KIND_SUCCEEDED = "succeeded"
+EFFECT_KIND_RANDOM = "random"
+EFFECT_KIND_TIME = "time"
+
+
+@dataclass(frozen=True, kw_only=True)
+class WorkflowEffectJournalEntry:
+    """One append-only workflow effect journal record."""
+
+    generation: int
+    entry_index: int
+    cache_key: str
+    effect_kind: str
+    node_id: str
+    value: Any
+    terminal_kind: str
+
+    def to_json_line(self) -> str:
+        payload: dict[str, Any] = {
+            "version": WORKFLOW_EFFECT_JOURNAL_VERSION,
+            "generation": self.generation,
+            "entry_index": self.entry_index,
+            "cache_key": self.cache_key,
+            "effect_kind": self.effect_kind,
+            "node_id": self.node_id,
+            "value": self.value,
+            "terminal_kind": self.terminal_kind,
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+    @classmethod
+    def from_json_line(
+        cls,
+        line: str,
+        *,
+        path: Path,
+        line_number: int,
+    ) -> "WorkflowEffectJournalEntry":
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise JournalCorruptionError(
+                path=path,
+                message=f"invalid JSON on line {line_number}: {exc.msg}",
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise JournalCorruptionError(
+                path=path,
+                message=f"line {line_number} is not a JSON object",
+            )
+        version = _require_int(payload, "version", path, line_number)
+        if version != WORKFLOW_EFFECT_JOURNAL_VERSION:
+            raise JournalCorruptionError(
+                path=path,
+                message=f"line {line_number} has unsupported journal version {version}",
+            )
+
+        return cls(
+            generation=_require_int(payload, "generation", path, line_number),
+            entry_index=_require_int(payload, "entry_index", path, line_number),
+            cache_key=_require_str(payload, "cache_key", path, line_number),
+            effect_kind=_require_str(payload, "effect_kind", path, line_number),
+            node_id=_require_str(payload, "node_id", path, line_number),
+            value=_require_field(payload, "value", path, line_number),
+            terminal_kind=_require_str(payload, "terminal_kind", path, line_number),
+        )
+
+
+@dataclass(frozen=True)
+class WorkflowEffectReplayDecision:
+    """Replay identity derived from the current workflow effect invocation."""
+
+    cache_key: str
+    effect_kind: str
+    node_id: str
+
+
+class WorkflowEffectJournal:
+    """Append-only workflow effect journal scoped to a conductor run id."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @classmethod
+    def for_run(
+        cls,
+        run_id: str,
+        *,
+        state_dir: str | Path | None = None,
+    ) -> "WorkflowEffectJournal":
+        run_dir = _state_dir(state_dir) / "workflows" / run_id
+        return cls(run_dir / WORKFLOW_EFFECT_JOURNAL_FILENAME)
+
+    def load_entries(self) -> list[WorkflowEffectJournalEntry]:
+        if not self.path.exists():
+            return []
+
+        entries: list[WorkflowEffectJournalEntry] = []
+        lines = self.path.read_text(encoding="utf-8").splitlines()
+        for line_number, line in enumerate(lines, 1):
+            if not line:
+                raise JournalCorruptionError(
+                    path=self.path,
+                    message=f"blank line at {line_number}",
+                )
+            entries.append(
+                WorkflowEffectJournalEntry.from_json_line(
+                    line,
+                    path=self.path,
+                    line_number=line_number,
+                )
+            )
+        _validate_entry_sequence(entries, self.path)
+        return entries
+
+    def latest_generation_entries(self) -> list[WorkflowEffectJournalEntry]:
+        entries = self.load_entries()
+        if not entries:
+            return []
+        latest_generation = max(entry.generation for entry in entries)
+        latest_entries = [entry for entry in entries if entry.generation == latest_generation]
+        latest_entries.sort(key=lambda entry: entry.entry_index)
+        _validate_contiguous_generation(latest_entries, self.path)
+        return latest_entries
+
+    def append_entry(self, entry: WorkflowEffectJournalEntry) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as journal_file:
+            journal_file.write(entry.to_json_line())
+            journal_file.write("\n")
+
+
+class WorkflowEffectReplaySession:
+    """Stateful replay cursor for one run's workflow effect journal."""
+
+    def __init__(self, journal: WorkflowEffectJournal) -> None:
+        self.journal = journal
+        self.previous_entries = journal.latest_generation_entries()
+        self.previous_keys = [entry.cache_key for entry in self.previous_entries]
+        self.previous_generation = (
+            self.previous_entries[0].generation if self.previous_entries else 0
+        )
+        self.current_generation = self.previous_generation
+        self.current_keys: list[str] = []
+        self.replayed_prefix_entries: list[WorkflowEffectJournalEntry] = []
+        self.started_new_generation = False
+
+    def run_or_replay(
+        self,
+        decision: WorkflowEffectReplayDecision,
+        produce_value: Callable[[], Any],
+    ) -> Any:
+        self.current_keys.append(decision.cache_key)
+        entry_index = len(self.current_keys) - 1
+        valid_prefix = longest_valid_prefix(self.previous_keys, self.current_keys)
+
+        if entry_index < valid_prefix:
+            previous_entry = self.previous_entries[entry_index]
+            self._validate_replay_entry(previous_entry, decision)
+            self.replayed_prefix_entries.append(previous_entry)
+            return previous_entry.value
+
+        if entry_index < len(self.previous_entries):
+            self._start_new_generation()
+
+        value = produce_value()
+        self.journal.append_entry(
+            WorkflowEffectJournalEntry(
+                generation=self.current_generation,
+                entry_index=entry_index,
+                cache_key=decision.cache_key,
+                effect_kind=decision.effect_kind,
+                node_id=decision.node_id,
+                value=value,
+                terminal_kind=TERMINAL_KIND_SUCCEEDED,
+            )
+        )
+        return value
+
+    def _start_new_generation(self) -> None:
+        if self.started_new_generation:
+            return
+        self.current_generation = self.previous_generation + 1
+        for entry_index, previous_entry in enumerate(self.replayed_prefix_entries):
+            self.journal.append_entry(
+                WorkflowEffectJournalEntry(
+                    generation=self.current_generation,
+                    entry_index=entry_index,
+                    cache_key=previous_entry.cache_key,
+                    effect_kind=previous_entry.effect_kind,
+                    node_id=previous_entry.node_id,
+                    value=previous_entry.value,
+                    terminal_kind=previous_entry.terminal_kind,
+                )
+            )
+        self.started_new_generation = True
+
+    def _validate_replay_entry(
+        self,
+        entry: WorkflowEffectJournalEntry,
+        decision: WorkflowEffectReplayDecision,
+    ) -> None:
+        if entry.cache_key != decision.cache_key:
+            raise JournalCorruptionError(
+                path=self.journal.path,
+                message=f"entry {entry.entry_index} cache key does not match replay decision",
+            )
+        if entry.effect_kind != decision.effect_kind:
+            raise JournalCorruptionError(
+                path=self.journal.path,
+                message=f"entry {entry.entry_index} effect kind does not match",
+            )
+        if entry.node_id != decision.node_id:
+            raise JournalCorruptionError(
+                path=self.journal.path,
+                message=f"entry {entry.entry_index} node id does not match",
+            )
+        if entry.terminal_kind != TERMINAL_KIND_SUCCEEDED:
+            raise JournalCorruptionError(
+                path=self.journal.path,
+                message=f"entry {entry.entry_index} has unsupported terminal kind",
+            )
+
+
+class JournaledWorkflowEffectHandler:
+    """Replay cached workflow effect values before producing new values."""
+
+    def __init__(
+        self,
+        *,
+        state_dir: str | Path | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        self.state_dir = Path(state_dir) if state_dir is not None else None
+        self.run_id = run_id
+        self._sessions: dict[str, WorkflowEffectReplaySession] = {}
+
+    def handle_time(self, effect: TimeCall) -> str:
+        return self._run_or_replay(
+            effect,
+            lambda: datetime.now(timezone.utc).isoformat(),
+        )
+
+    def handle_random(self, effect: RandomCall) -> Any:
+        return self._run_or_replay(
+            effect,
+            lambda: evaluate_random_spec(effect.spec),
+        )
+
+    def _run_or_replay(
+        self,
+        effect: TimeCall | RandomCall,
+        produce_value: Callable[[], Any],
+    ) -> Any:
+        run_id = self._resolve_run_id(effect)
+        session = self._sessions.get(run_id)
+        if session is None:
+            session = WorkflowEffectReplaySession(
+                WorkflowEffectJournal.for_run(
+                    run_id,
+                    state_dir=self.state_dir,
+                )
+            )
+            self._sessions[run_id] = session
+        decision = workflow_effect_replay_decision(effect)
+        return session.run_or_replay(decision, produce_value)
+
+    def _resolve_run_id(self, effect: TimeCall | RandomCall) -> str:
+        if self.run_id is not None:
+            return self.run_id
+        if effect.run_id is not None:
+            return effect.run_id
+        raise ValueError("journaled workflow effects require a run_id")
+
+
+def workflow_effect_replay_decision(
+    effect: TimeCall | RandomCall,
+) -> WorkflowEffectReplayDecision:
+    if isinstance(effect, TimeCall):
+        effect_kind = EFFECT_KIND_TIME
+        spec: Any = None
+    elif isinstance(effect, RandomCall):
+        effect_kind = EFFECT_KIND_RANDOM
+        spec = effect.spec
+    else:
+        raise TypeError(f"unsupported workflow effect: {type(effect).__name__}")
+
+    if effect.node_id is None:
+        raise ValueError("journaled workflow effects require a node_id")
+
+    return WorkflowEffectReplayDecision(
+        cache_key=workflow_effect_cache_key(
+            effect_kind=effect_kind,
+            node_id=effect.node_id,
+            label=effect.label,
+            spec=spec,
+        ),
+        effect_kind=effect_kind,
+        node_id=effect.node_id,
+    )
+
+
+def evaluate_random_spec(spec: Any) -> Any:
+    random_source = SystemRandom()
+    if isinstance(spec, Mapping):
+        kind: object | None = spec.get("kind")
+        if kind == "choice":
+            values: object | None = spec.get("values")
+            if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+                raise TypeError("random! choice requires a non-string sequence of values")
+            return random_source.choice(list(values))
+    return random_source.random()
+
+
+def _state_dir(state_dir: str | Path | None) -> Path:
+    if state_dir is not None:
+        return Path(state_dir)
+    xdg_state = os.environ.get("XDG_STATE_HOME")
+    if xdg_state is not None:
+        return Path(xdg_state) / "doeff-conductor"
+    return Path.home() / ".local" / "state" / "doeff-conductor"
+
+
+def _require_field(
+    payload: dict[str, Any],
+    field_name: str,
+    path: Path,
+    line_number: int,
+) -> Any:
+    if field_name not in payload:
+        raise JournalCorruptionError(
+            path=path,
+            message=f"line {line_number} is missing {field_name!r}",
+        )
+    return payload[field_name]
+
+
+def _require_str(
+    payload: dict[str, Any],
+    field_name: str,
+    path: Path,
+    line_number: int,
+) -> str:
+    value = _require_field(payload, field_name, path, line_number)
+    if not isinstance(value, str):
+        raise JournalCorruptionError(
+            path=path,
+            message=f"line {line_number} field {field_name!r} is not a string",
+        )
+    return value
+
+
+def _require_int(
+    payload: dict[str, Any],
+    field_name: str,
+    path: Path,
+    line_number: int,
+) -> int:
+    value = _require_field(payload, field_name, path, line_number)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise JournalCorruptionError(
+            path=path,
+            message=f"line {line_number} field {field_name!r} is not an integer",
+        )
+    if value < 0:
+        raise JournalCorruptionError(
+            path=path,
+            message=f"line {line_number} field {field_name!r} is negative",
+        )
+    return value
+
+
+def _validate_entry_sequence(entries: list[WorkflowEffectJournalEntry], path: Path) -> None:
+    seen: set[tuple[int, int]] = set()
+    for entry in entries:
+        key = (entry.generation, entry.entry_index)
+        if key in seen:
+            raise JournalCorruptionError(
+                path=path,
+                message=f"duplicate generation/index entry {key}",
+            )
+        seen.add(key)
+
+
+def _validate_contiguous_generation(
+    entries: list[WorkflowEffectJournalEntry],
+    path: Path,
+) -> None:
+    for expected_index, entry in enumerate(entries):
+        if entry.entry_index != expected_index:
+            raise JournalCorruptionError(
+                path=path,
+                message=(
+                    f"generation {entry.generation} has non-contiguous index "
+                    f"{entry.entry_index}; expected {expected_index}"
+                ),
+            )

--- a/packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py
+++ b/packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py
@@ -1,14 +1,10 @@
 """Production interpreter for ``WorkflowSpec`` request artifacts."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, is_dataclass
 from dataclasses import field as dataclass_field
-from datetime import datetime, timezone
-from random import Random
 from typing import Any, cast
 
 from doeff import Gather, Spawn, do
@@ -31,7 +27,16 @@ from doeff_conductor.dsl import (
     WorkflowSpec,
     WorkspaceSpec,
 )
-from doeff_conductor.effects import Agent, AgentTask, Commit, CreateWorkspace, Exec, MergeWorkspaces
+from doeff_conductor.effects import (
+    Agent,
+    AgentTask,
+    Commit,
+    CreateWorkspace,
+    Exec,
+    MergeWorkspaces,
+    RandomCall,
+    TimeCall,
+)
 from doeff_conductor.environment import (
     ProfileBinding,
     ProfileRegistry,
@@ -158,9 +163,23 @@ def _execute_expr(  # noqa: PLR0911
     if isinstance(expr, MergeSpec):
         return (yield _execute_merge(expr, context, path=path))
     if isinstance(expr, TimeSpec):
-        return datetime.now(timezone.utc).isoformat()
+        node_id: str = _node_id(context.workflow.name, path, "time")
+        return (yield TimeCall(label=expr.label, run_id=context.run_id, node_id=node_id))
     if isinstance(expr, RandomSpec):
-        return _evaluate_random(expr)
+        node_id = _node_id(context.workflow.name, path, "random")
+        random_spec: Any = yield _evaluate_value(
+            expr.spec,
+            context,
+            path=_path_join(path, "spec"),
+        )
+        return (
+            yield RandomCall(
+                spec=random_spec,
+                label=expr.label,
+                run_id=context.run_id,
+                node_id=node_id,
+            )
+        )
     if isinstance(expr, WorkspaceSpec):
         return (yield _materialize_workspace(expr, context, path=path))
     if isinstance(expr, ParallelSpec):
@@ -538,18 +557,6 @@ def _evaluate_until(predicate: Any, context: _RuntimeContext, *, path: str) -> A
             return _value_passed(binding_value)
         return bool(context.bindings.get(predicate))
     return bool(predicate)
-
-
-def _evaluate_random(spec: RandomSpec) -> Any:
-    random_source = Random(0)
-    if isinstance(spec.spec, Mapping):
-        kind: object | None = spec.spec.get("kind")
-        if kind == "choice":
-            values: object | None = spec.spec.get("values")
-            if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
-                raise TypeError("random! choice requires a non-string sequence of values")
-            return random_source.choice(list(values))
-    return random_source.random()
 
 
 def _bind_runtime_value(target: str | Sequence[str], value: Any, context: _RuntimeContext) -> None:

--- a/packages/doeff-conductor/tests/test_workflow_effect_journal.py
+++ b/packages/doeff-conductor/tests/test_workflow_effect_journal.py
@@ -1,0 +1,43 @@
+"""Workflow effect journal regressions for explicit nondeterministic effects."""
+
+from pathlib import Path
+
+from doeff_conductor.api import ConductorAPI
+from doeff_conductor.types import WorkflowStatus
+
+RANDOM_WORKFLOW_SOURCE = """
+(require doeff-hy.conductor [defworkflow random! <-])
+(import doeff_conductor.dsl [artifact ref])
+
+(defworkflow random-workflow
+  :params {}
+  :roles {}
+  (<- value (random!))
+  (artifact {"value" (ref "value")}))
+
+(setv WORKFLOW random-workflow)
+""".lstrip()
+
+
+def test_random_effect_uses_entropy_for_new_runs_and_journal_for_replay(
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / "random_workflow.hy"
+    workflow_path.write_text(RANDOM_WORKFLOW_SOURCE, encoding="utf-8")
+    state_dir = tmp_path / "state"
+    api = ConductorAPI(state_dir=state_dir)
+
+    first = api.run_workflow(str(workflow_path), run_id="random-run-a")
+    replayed = api.run_workflow(str(workflow_path), run_id="random-run-a")
+    second = api.run_workflow(str(workflow_path), run_id="random-run-b")
+
+    assert first.status == WorkflowStatus.DONE
+    assert replayed.status == WorkflowStatus.DONE
+    assert second.status == WorkflowStatus.DONE
+
+    assert replayed.result_payload == first.result_payload
+    assert second.result_payload != first.result_payload
+
+    journal_path = state_dir / "workflows" / "random-run-a" / "effect-journal.jsonl"
+    assert journal_path.exists()
+    assert '"effect_kind":"random"' in journal_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes `conductor-random-true-randomness` by moving explicit workflow nondeterminism behind a replay journal boundary.

- `random!` and `time!` now emit runtime effects carrying `run_id` and `node_id` instead of being evaluated directly inside the workflow runtime.
- Added `effect-journal.jsonl` replay support for workflow effects, using OS entropy for first `random!` execution and returning recorded values on replay.
- Added a semgrep guard banning the old `Random(0)` placeholder in `doeff-conductor`.
- Updated spec §11-10 and the 2026-06-11 validation table to reference fixed commit `bc48f890`.

## Root Cause

`random!` was evaluated by `_evaluate_random` with `Random(0)`, so every fresh run produced the same value. It also bypassed the effect journal boundary, which meant replacing the seed alone would have broken deterministic replay.

## Acceptance Evidence

- New run randomness and same-run replay reuse: `uv run pytest packages/doeff-conductor/tests/test_workflow_effect_journal.py -q` -> `1 passed`.
- Full conductor package tests: `uv run pytest packages/doeff-conductor/tests -q` -> `298 passed`.
- Changed-file type check: `uv run pyright packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py packages/doeff-conductor/src/doeff_conductor/workflow_effect_journal.py packages/doeff-conductor/src/doeff_conductor/handlers/__init__.py packages/doeff-conductor/src/doeff_conductor/handlers/testing.py packages/doeff-conductor/src/doeff_conductor/handlers/utils.py packages/doeff-conductor/src/doeff_conductor/effects/dsl.py packages/doeff-conductor/src/doeff_conductor/replay_keying.py packages/doeff-conductor/src/doeff_conductor/__init__.py packages/doeff-conductor/tests/test_workflow_effect_journal.py` -> `0 errors`.
- Random fixed-seed guard: `uv run semgrep --config .semgrep.yaml packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py packages/doeff-conductor/src/doeff_conductor/workflow_effect_journal.py --error` -> `0 findings`.
- `make lint` was attempted: ruff and `pyright doeff/` passed, then lint stopped on 84 existing semgrep findings outside this change.

## Issue

Refs `conductor-random-true-randomness`.