### PR TITLE
[codex] Route agents CLI monitoring through agentd

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -145,6 +145,57 @@ rules:
       exclude:
         - /packages/doeff-conductor/src/doeff_conductor/handlers/exec_handler.py
 
+  - id: doeff-agents-cli-monitoring-uses-agentd
+    languages: [python]
+    severity: ERROR
+    message: >
+      agents-cli-query-agentd: doeff-agents ps/watch/output/send/attach must query
+      doeff-agentd as the single authority. Do not fall back to local tmux/session
+      reads for these monitoring commands.
+    pattern-either:
+      - patterns:
+          - pattern-inside: |
+              def ps_command(...):
+                  ...
+          - pattern: list_sessions(...)
+      - patterns:
+          - pattern-inside: |
+              def watch_command(...):
+                  ...
+          - pattern-either:
+              - pattern: monitor_session(...)
+              - pattern: AgentSession(...)
+              - pattern: _resolve_session(...)
+              - pattern: _resolve_tmux_session(...)
+      - patterns:
+          - pattern-inside: |
+              def output(...):
+                  ...
+          - pattern-either:
+              - pattern: capture_output(...)
+              - pattern: AgentSession(...)
+              - pattern: _resolve_session(...)
+              - pattern: _resolve_tmux_session(...)
+      - patterns:
+          - pattern-inside: |
+              def send(...):
+                  ...
+          - pattern-either:
+              - pattern: send_message(...)
+              - pattern: AgentSession(...)
+              - pattern: _resolve_session(...)
+              - pattern: _resolve_tmux_session(...)
+      - patterns:
+          - pattern-inside: |
+              def attach(...):
+                  ...
+          - pattern-either:
+              - pattern: _resolve_session(...)
+              - pattern: _resolve_tmux_session(...)
+    paths:
+      include:
+        - /packages/doeff-agents/src/doeff_agents/cli.py
+
   - id: http-request-handlers-use-defhandler
     languages: [python]
     severity: ERROR

--- a/packages/doeff-agents/src/doeff_agents/cli.py
+++ b/packages/doeff-agents/src/doeff_agents/cli.py
@@ -8,22 +8,35 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from doeff_agents.agentd_client import (
+    AgentdClient,
+    AgentdClientError,
+    AgentdUnavailableError,
+    ensure_agentd,
+)
+from doeff_agents.effects import AgentSessionSnapshot
+
 from .adapters.base import AgentType, LaunchConfig
 from .monitor import SessionStatus
 from .session import (
     AgentSession,
-    capture_output,
     launch_session,
     monitor_session,
-    send_message,
 )
 from .tmux import attach_session as tmux_attach
-from .tmux import has_session, kill_session, list_sessions
+from .tmux import has_session, kill_session
 
 console = Console()
 
 # All doeff-agents sessions are prefixed with this to distinguish from other tmux sessions
 SESSION_PREFIX = "doeff-"
+AGENTD_UNAVAILABLE_HINT = "agentd が起動していません。doeff-agentd serve を実行してください。"
+TERMINAL_STATUSES = {
+    SessionStatus.DONE,
+    SessionStatus.FAILED,
+    SessionStatus.EXITED,
+    SessionStatus.STOPPED,
+}
 
 
 def _to_tmux_name(user_name: str) -> str:
@@ -40,7 +53,96 @@ def _to_display_name(tmux_name: str) -> str:
     return tmux_name
 
 
-def _resolve_session(user_name: str) -> str | None:
+def _agentd_client_or_exit() -> AgentdClient:
+    try:
+        return ensure_agentd()
+    except AgentdUnavailableError as error:
+        _print_agentd_unavailable(error)
+        sys.exit(1)
+
+
+def _print_agentd_unavailable(error: AgentdUnavailableError) -> None:
+    console.print(f"[red]Error:[/red] {AGENTD_UNAVAILABLE_HINT}")
+    console.print(f"[dim]{error}[/dim]")
+
+
+def _print_agentd_request_error(error: AgentdClientError | OSError) -> None:
+    if isinstance(error, OSError):
+        console.print(f"[red]Error:[/red] {AGENTD_UNAVAILABLE_HINT}")
+        console.print(f"[dim]{error}[/dim]")
+        return
+    console.print(f"[red]Error:[/red] {error}")
+
+
+def _resolve_agentd_session(
+    client: AgentdClient,
+    user_name: str,
+) -> AgentSessionSnapshot | None:
+    """Resolve a user-provided session id/name through agentd only."""
+    candidate_ids = _agentd_session_id_candidates(user_name)
+    for session_id in candidate_ids:
+        snapshot = client.get_session(session_id)
+        if snapshot is not None:
+            return snapshot
+
+    snapshots = client.list_sessions()
+    matches = [
+        snapshot
+        for snapshot in snapshots
+        if _agentd_snapshot_matches_name(snapshot, user_name, candidate_ids)
+    ]
+    if len(matches) > 1:
+        names = ", ".join(snapshot.session_id for snapshot in matches)
+        raise AgentdClientError(
+            f"Session name '{user_name}' is ambiguous in agentd: {names}"
+        )
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _agentd_session_id_candidates(user_name: str) -> tuple[str, ...]:
+    prefixed_name = _to_tmux_name(user_name)
+    candidates = [user_name]
+    if prefixed_name != user_name:
+        candidates.append(prefixed_name)
+    return tuple(candidates)
+
+
+def _agentd_snapshot_matches_name(
+    snapshot: AgentSessionSnapshot,
+    user_name: str,
+    candidate_ids: tuple[str, ...],
+) -> bool:
+    return (
+        snapshot.session_id in candidate_ids
+        or snapshot.session_name in candidate_ids
+        or _to_display_name(snapshot.session_name) == user_name
+    )
+
+
+def _agentd_session_or_exit(client: AgentdClient, user_name: str) -> AgentSessionSnapshot:
+    try:
+        snapshot = _resolve_agentd_session(client, user_name)
+    except (AgentdClientError, OSError) as error:
+        _print_agentd_request_error(error)
+        sys.exit(1)
+
+    if snapshot is None:
+        console.print(f"[red]Error:[/red] Session '{user_name}' not found in agentd")
+        sys.exit(1)
+    return snapshot
+
+
+def _agentd_display_name(snapshot: AgentSessionSnapshot) -> str:
+    return _to_display_name(snapshot.session_name)
+
+
+def _is_terminal_snapshot(snapshot: AgentSessionSnapshot) -> bool:
+    return snapshot.status in TERMINAL_STATUSES
+
+
+def _resolve_tmux_session(user_name: str) -> str | None:
     """Resolve user-provided name to actual tmux session name.
 
     Tries prefixed name first, then exact name for backwards compatibility.
@@ -124,40 +226,41 @@ def run(
 
 
 @cli.command("ps")
-@click.option("--all", "-a", "show_all", is_flag=True, help="Show all tmux sessions, not just doeff-agents")
+@click.option(
+    "--all",
+    "-a",
+    "show_all",
+    is_flag=True,
+    help="Show all agentd sessions (kept for CLI compatibility)",
+)
 def ps_command(show_all: bool) -> None:
     """List doeff-agents sessions."""
+    client = _agentd_client_or_exit()
     try:
-        sessions = list_sessions()
-    except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        sessions = client.list_sessions()
+    except (AgentdClientError, OSError) as error:
+        _print_agentd_request_error(error)
         sys.exit(1)
 
-    # Filter to only doeff sessions unless --all is specified
-    if not show_all:
-        sessions = [s for s in sessions if s.startswith(SESSION_PREFIX)]
-
     if not sessions:
-        if show_all:
-            console.print("No tmux sessions found.")
-        else:
-            console.print("No doeff-agents sessions found. Use --all to see all tmux sessions.")
+        console.print("No agentd sessions found.")
         return
 
-    table = Table(title="Agent Sessions" if not show_all else "All Tmux Sessions")
-    table.add_column("Session Name", style="cyan")
-    if show_all:
-        table.add_column("Type", style="green")
+    table = Table(title="Agentd Sessions" if show_all else "Agent Sessions")
+    table.add_column("Session ID", style="cyan")
+    table.add_column("Name", style="cyan")
+    table.add_column("Agent", style="green")
+    table.add_column("Status", style="yellow")
+    table.add_column("Work Dir", style="dim")
 
-    for tmux_name in sessions:
-        if show_all:
-            is_doeff = tmux_name.startswith(SESSION_PREFIX)
-            type_str = "[blue]doeff-agents[/blue]" if is_doeff else "[dim]other[/dim]"
-            display = _to_display_name(tmux_name) if is_doeff else tmux_name
-            table.add_row(display, type_str)
-        else:
-            # Show display name (without prefix)
-            table.add_row(_to_display_name(tmux_name))
+    for snapshot in sessions:
+        table.add_row(
+            snapshot.session_id,
+            _agentd_display_name(snapshot),
+            snapshot.agent_type.value,
+            snapshot.status.value,
+            str(snapshot.work_dir),
+        )
 
     console.print(table)
 
@@ -168,12 +271,17 @@ def attach(session_name: str) -> None:
     """Attach to a tmux session."""
     from .tmux import is_inside_tmux
 
-    tmux_name = _resolve_session(session_name)
-    if tmux_name is None:
-        console.print(f"[red]Error:[/red] Session '{session_name}' not found")
+    client = _agentd_client_or_exit()
+    snapshot = _agentd_session_or_exit(client, session_name)
+    if snapshot.backend_kind != "tmux":
+        console.print(
+            f"[red]Error:[/red] Session '{session_name}' is not backed by tmux "
+            f"(backend: {snapshot.backend_kind})"
+        )
         sys.exit(1)
 
-    display_name = _to_display_name(tmux_name)
+    tmux_name = snapshot.session_name
+    display_name = _agentd_display_name(snapshot)
     if is_inside_tmux():
         console.print(f"Switching to session: {display_name}")
     else:
@@ -186,7 +294,7 @@ def attach(session_name: str) -> None:
 @click.argument("session_name")
 def stop(session_name: str) -> None:
     """Stop (kill) a tmux session."""
-    tmux_name = _resolve_session(session_name)
+    tmux_name = _resolve_tmux_session(session_name)
     if tmux_name is None:
         console.print(f"[red]Error:[/red] Session '{session_name}' not found")
         sys.exit(1)
@@ -200,22 +308,11 @@ def stop(session_name: str) -> None:
 @click.option("--interval", "-i", type=float, default=1.0, help="Poll interval in seconds")
 def watch_command(session_name: str, interval: float) -> None:
     """Monitor a running session."""
-    tmux_name = _resolve_session(session_name)
-    if tmux_name is None:
-        console.print(f"[red]Error:[/red] Session '{session_name}' not found")
-        sys.exit(1)
-
-    # Create a minimal AgentSession for monitoring
-    session = AgentSession(
-        session_name=tmux_name,
-        pane_id=tmux_name,  # Use session name as pane target
-        agent_type=AgentType.CLAUDE,  # Default, will work for monitoring
-        work_dir=Path.cwd(),
-    )
-
-    display_name = _to_display_name(tmux_name)
+    client = _agentd_client_or_exit()
+    snapshot = _agentd_session_or_exit(client, session_name)
+    display_name = _agentd_display_name(snapshot)
     console.print(f"Watching session: {display_name} (Ctrl+C to stop)")
-    _watch_session(session, poll_interval=interval)
+    _watch_agentd_session(client, snapshot, poll_interval=interval)
 
 
 def _watch_session(session: AgentSession, poll_interval: float = 1.0) -> None:
@@ -236,15 +333,11 @@ def _watch_session(session: AgentSession, poll_interval: float = 1.0) -> None:
         color = status_colors.get(new, "white")
         console.print(f"Status: [{color}]{new.value}[/{color}]")
 
-    def on_pr_detected(url: str) -> None:
-        console.print(f"[green]PR Created:[/green] {url}")
-
     try:
         while not session.is_terminal:
             monitor_session(
                 session,
                 on_status_change=on_status_change,
-                on_pr_detected=on_pr_detected,
             )
             time.sleep(poll_interval)
 
@@ -253,25 +346,51 @@ def _watch_session(session: AgentSession, poll_interval: float = 1.0) -> None:
         console.print("\n[dim]Stopped watching (session still running)[/dim]")
 
 
+def _watch_agentd_session(
+    client: AgentdClient,
+    snapshot: AgentSessionSnapshot,
+    *,
+    poll_interval: float = 1.0,
+) -> None:
+    """Watch a session by polling agentd's persisted session snapshot."""
+    current = snapshot
+    last_status = current.status
+
+    try:
+        while not _is_terminal_snapshot(current):
+            time.sleep(poll_interval)
+            refreshed = client.get_session(current.session_id)
+            if refreshed is None:
+                console.print(
+                    f"[red]Error:[/red] Session '{current.session_id}' disappeared from agentd"
+                )
+                sys.exit(1)
+            current = refreshed
+            if current.status != last_status:
+                console.print(f"Status: [bold]{current.status.value}[/bold]")
+                last_status = current.status
+
+        console.print(f"\nSession ended with status: [bold]{current.status.value}[/bold]")
+    except KeyboardInterrupt:
+        console.print("\n[dim]Stopped watching (session still running)[/dim]")
+    except (AgentdClientError, OSError) as error:
+        _print_agentd_request_error(error)
+        sys.exit(1)
+
+
 @cli.command()
 @click.argument("session_name")
 @click.argument("message")
 def send(session_name: str, message: str) -> None:
     """Send a message to a running session."""
-    tmux_name = _resolve_session(session_name)
-    if tmux_name is None:
-        console.print(f"[red]Error:[/red] Session '{session_name}' not found")
+    client = _agentd_client_or_exit()
+    snapshot = _agentd_session_or_exit(client, session_name)
+    try:
+        client.send_session(snapshot.session_id, message)
+    except (AgentdClientError, OSError) as error:
+        _print_agentd_request_error(error)
         sys.exit(1)
-
-    session = AgentSession(
-        session_name=tmux_name,
-        pane_id=tmux_name,
-        agent_type=AgentType.CLAUDE,
-        work_dir=Path.cwd(),
-    )
-
-    send_message(session, message)
-    console.print(f"[green]✓[/green] Sent message to {_to_display_name(tmux_name)}")
+    console.print(f"[green]✓[/green] Sent message to {_agentd_display_name(snapshot)}")
 
 
 @cli.command()
@@ -279,19 +398,13 @@ def send(session_name: str, message: str) -> None:
 @click.option("--lines", "-n", type=int, default=50, help="Number of lines to capture")
 def output(session_name: str, lines: int) -> None:
     """Capture output from a session."""
-    tmux_name = _resolve_session(session_name)
-    if tmux_name is None:
-        console.print(f"[red]Error:[/red] Session '{session_name}' not found")
+    client = _agentd_client_or_exit()
+    snapshot = _agentd_session_or_exit(client, session_name)
+    try:
+        output_text = client.capture_session(snapshot.session_id, lines=lines)
+    except (AgentdClientError, OSError) as error:
+        _print_agentd_request_error(error)
         sys.exit(1)
-
-    session = AgentSession(
-        session_name=tmux_name,
-        pane_id=tmux_name,
-        agent_type=AgentType.CLAUDE,
-        work_dir=Path.cwd(),
-    )
-
-    output_text = capture_output(session, lines)
     console.print(output_text)
 
 

--- a/packages/doeff-agents/tests/test_cli_agentd.py
+++ b/packages/doeff-agents/tests/test_cli_agentd.py
@@ -1,0 +1,201 @@
+"""CLI tests for the agentd-backed monitoring commands."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from doeff_agents import AgentdUnavailableError, AgentSessionSnapshot, AgentType, SessionStatus
+from doeff_agents import cli as cli_module
+from doeff_agents.cli import cli
+
+
+class FakeAgentdClient:
+    def __init__(self, snapshots: list[AgentSessionSnapshot]) -> None:
+        self.snapshots = snapshots
+        self.calls: list[tuple[str, Any]] = []
+        self.sent_messages: list[tuple[str, str]] = []
+        self.captures: list[tuple[str, int]] = []
+
+    def get_session(self, session_id: str) -> AgentSessionSnapshot | None:
+        self.calls.append(("get_session", session_id))
+        for snapshot in self.snapshots:
+            if snapshot.session_id == session_id:
+                return snapshot
+        return None
+
+    def list_sessions(self, query: Any = None) -> tuple[AgentSessionSnapshot, ...]:
+        self.calls.append(("list_sessions", query))
+        return tuple(self.snapshots)
+
+    def capture_session(self, session_id: str, *, lines: int = 100) -> str:
+        self.captures.append((session_id, lines))
+        return f"captured from {session_id}"
+
+    def send_session(
+        self,
+        session_id: str,
+        message: str,
+        *,
+        enter: bool = True,
+        literal: bool = True,
+    ) -> None:
+        self.sent_messages.append((session_id, message))
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_ps_lists_agentd_sessions_not_tmux(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    client = FakeAgentdClient([_snapshot(session_id="agentd-s1", session_name="agentd-tmux")])
+    monkeypatch.setattr(cli_module, "ensure_agentd", lambda: client)
+
+    result = runner.invoke(cli, ["ps"])
+
+    assert result.exit_code == 0
+    assert "agentd-s1" in result.output
+    assert "agentd-tmux" in result.output
+    assert "running" in result.output
+    assert client.calls == [("list_sessions", None)]
+
+
+def test_output_captures_via_agentd(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    client = FakeAgentdClient([_snapshot(session_id="agentd-s1")])
+    monkeypatch.setattr(cli_module, "ensure_agentd", lambda: client)
+
+    result = runner.invoke(cli, ["output", "agentd-s1", "--lines", "12"])
+
+    assert result.exit_code == 0
+    assert "captured from agentd-s1" in result.output
+    assert client.captures == [("agentd-s1", 12)]
+
+
+def test_send_uses_agentd_rpc(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    client = FakeAgentdClient([_snapshot(session_id="agentd-s1")])
+    monkeypatch.setattr(cli_module, "ensure_agentd", lambda: client)
+
+    result = runner.invoke(cli, ["send", "agentd-s1", "hello"])
+
+    assert result.exit_code == 0
+    assert client.sent_messages == [("agentd-s1", "hello")]
+
+
+def test_watch_polls_agentd_snapshot_until_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    running = _snapshot(session_id="agentd-s1", status=SessionStatus.RUNNING)
+    exited = _snapshot(session_id="agentd-s1", status=SessionStatus.EXITED)
+    client = FakeAgentdClient([running])
+    polls = iter([running, exited])
+
+    def get_session(session_id: str) -> AgentSessionSnapshot | None:
+        client.calls.append(("get_session", session_id))
+        return next(polls)
+
+    client.get_session = get_session  # type: ignore[method-assign]
+    monkeypatch.setattr(cli_module, "ensure_agentd", lambda: client)
+    monkeypatch.setattr(cli_module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        cli_module,
+        "monitor_session",
+        lambda *_args, **_kwargs: pytest.fail("watch must poll agentd snapshots"),
+    )
+
+    result = runner.invoke(cli, ["watch", "agentd-s1"])
+
+    assert result.exit_code == 0
+    assert "Watching session: agentd-s1" in result.output
+    assert "exited" in result.output
+
+
+def test_attach_resolves_session_in_agentd(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    client = FakeAgentdClient([_snapshot(session_id="agentd-s1", session_name="agentd-tmux")])
+    attached: list[str] = []
+    monkeypatch.setattr(cli_module, "ensure_agentd", lambda: client)
+    monkeypatch.setattr(cli_module, "tmux_attach", attached.append)
+    monkeypatch.setattr(cli_module, "has_session", lambda *_args: False)
+
+    result = runner.invoke(cli, ["attach", "agentd-s1"])
+
+    assert result.exit_code == 0
+    assert attached == ["agentd-tmux"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["ps"],
+        ["watch", "agentd-s1"],
+        ["output", "agentd-s1"],
+        ["send", "agentd-s1", "hello"],
+        ["attach", "agentd-s1"],
+    ],
+)
+def test_monitoring_commands_fail_loudly_when_agentd_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+    tmp_path: Path,
+    command: list[str],
+) -> None:
+    def unavailable() -> None:
+        raise AgentdUnavailableError(
+            "not reachable",
+            socket_path=tmp_path / "agentd.sock",
+            start_command=("doeff-agentd", "serve"),
+        )
+
+    monkeypatch.setattr(cli_module, "ensure_agentd", unavailable)
+    monkeypatch.setattr(cli_module, "has_session", lambda *_args: pytest.fail("no tmux fallback"))
+
+    result = runner.invoke(cli, command)
+
+    assert result.exit_code == 1
+    assert "agentd が起動していません" in result.output
+    assert "doeff-agentd serve" in result.output
+
+
+def _snapshot(
+    *,
+    session_id: str,
+    session_name: str | None = None,
+    status: SessionStatus = SessionStatus.RUNNING,
+) -> AgentSessionSnapshot:
+    return AgentSessionSnapshot.from_dict(
+        {
+            "session_id": session_id,
+            "session_name": session_name or session_id,
+            "pane_id": "%1",
+            "agent_type": AgentType.CODEX.value,
+            "work_dir": "/tmp/work",
+            "lifecycle": "run_to_completion",
+            "status": status.value,
+            "backend_kind": "tmux",
+            "backend_ref": {"session_name": session_name or session_id, "pane_id": "%1"},
+            "started_at": "2026-05-25T00:00:00+00:00",
+            "last_observed_at": "2026-05-25T00:00:01+00:00",
+            "finished_at": None,
+            "cleaned_at": None,
+            "output_snippet": "running",
+        }
+    )

--- a/packages/doeff-conductor/docs/validation-2026-06-11.md
+++ b/packages/doeff-conductor/docs/validation-2026-06-11.md
@@ -84,11 +84,13 @@ state dirs, pane captures, or plan/validate outputs. ✅ = validated live,
 | Layer | Tool | Status |
 |---|---|---|
 | L3 workflows | `conductor ps / show [--since] / watch / stop / resume` | ✅ works (live-tested ps, show, show --json) |
-| L2 sessions | `doeff-agents ps / watch / output / send / attach` | ❌ reads local-handler store; BLIND to agentd sessions (conductor's only route) |
+| L2 sessions | `doeff-agents ps / watch / output / send / attach` | ❌→✅ now query `doeff-agentd` RPC (`session.list/get/capture/send`) as SSOT; daemon-down path is explicit fail-fast |
 | L1 daemon | `doeff-agentd` | serve only — no client subcommands; session table reachable only via sqlite |
 
-Gap: the L2 CLI predates the agentd-only ruling; it should query the
-daemon (single authority). Candidate follow-up issue.
+Resolved: L2 monitoring commands now query the daemon (single authority)
+instead of local tmux/session state. Follow-up cleanup candidate: decide
+whether legacy local tmux helpers for `run`/`stop` should remain in
+`doeff-agents` CLI scope.
 
 ## Open defects (spec §11)
 


### PR DESCRIPTION
## Summary

- Route `doeff-agents ps/watch/output/send/attach` through `doeff-agentd` RPC instead of local tmux/session reads.
- Add fail-fast daemon-unavailable messaging with the required `doeff-agentd serve` hint.
- Add CLI regression tests plus a semgrep guard for the agentd SSOT invariant.
- Update `packages/doeff-conductor/docs/validation-2026-06-11.md` CLI monitoring inventory.

Issue: `agents-cli-query-agentd`

## Validation

- TDD red check: new CLI tests failed before implementation; new semgrep rule reported 10 findings against the old `cli.py`.
- `uv run pytest packages/doeff-agents/tests/test_cli_agentd.py packages/doeff-agents/tests/test_agentd_client.py -q` -> 22 passed.
- `uv run pytest packages/doeff-agents/tests -q` -> 122 passed, 1 skipped.
- `cargo test --manifest-path packages/doeff-agentd/Cargo.toml` -> 51 passed.
- `uv run pytest packages/doeff-conductor/tests -q` -> 297 passed.
- `uv run ruff check packages/doeff-agents/src/doeff_agents/cli.py packages/doeff-agents/tests/test_cli_agentd.py` -> passed.
- `uv run pyright packages/doeff-agents/src/doeff_agents/cli.py packages/doeff-agents/tests/test_cli_agentd.py` -> 0 errors.
- `uv run semgrep --error --config .semgrep.yaml packages/doeff-agents/src/doeff_agents/cli.py` -> 0 findings.
- Live daemon check: started `doeff-agentd` with temp XDG paths, launched `live-handler-agentd-ps` through `DaemonAgentHandler.handle_launch`, then `XDG_RUNTIME_DIR=... uv run doeff-agents ps` displayed the agentd session with `custom` agent and `exited` status; `doeff-agents output live-handler-agentd-ps --lines 5` captured `live-handler-agentd-session-started` through RPC.
- Daemon-down fail-fast check: with daemon stopped, `XDG_RUNTIME_DIR=... uv run doeff-agents ps` exited 1 and printed `agentd が起動していません。doeff-agentd serve を実行してください。`.
- `make lint` note: ruff and pyright phases passed, then `lint-semgrep` failed on pre-existing repository-wide semgrep findings (88 findings unrelated to this change).