### PR TITLE
[codex] Live attention-tier gates

### DIFF
--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -592,17 +592,16 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
    (the `❯` input box is visible mid-work). Cosmetic — contract
    validation, not status labels, decides completion — but operators and
    tooling read it; consider the activity signal for `running`.
-9. **§8 attention-tier machinery is not live (validated 2026-06-11).**
-   Gates exist in the validate interpreter, the run-state schema, and
-   `conductor gate list` — but a live retry exhaustion raises a terminal
-   error instead of parking a gate, `--supervision phase-checkpoints` has
-   no live effect, and no closure verb exists (`gate list` only; no
-   proceed/redirect/abort). The overseer contract (§8) is currently
-   stub-only; wiring it live is the next major stage.
+9. **§8 attention-tier live machinery — resolved 2026-06-11.**
+   Live retry-budget exhaustion parks an open gate with stakes metadata
+   instead of raising a terminal workflow error; `conductor gates` lists
+   open gates; `conductor answer RUN GATE_ID proceed|redirect|abort`
+   records the answer and uses the §9 journal/snapshot resume path; and
+   `--supervision phase-checkpoints` inserts live checkpoint gates with
+   artifact summaries and binding deltas rather than diffs.
 10. **`random!` is a placeholder**: `_evaluate_random` uses `Random(0)` —
    a constant seed shared by every node, so every draw is identical.
    Per-node seeded randomness recorded for replay is the intended design.
 11. **`doeff-agents` CLI is blind to agentd sessions** (it reads the
    local-handler store) and `doeff-agentd` has no client subcommands;
    session-level monitoring currently requires reading agentd's sqlite.
-

--- a/packages/doeff-conductor/docs/validation-2026-06-11.md
+++ b/packages/doeff-conductor/docs/validation-2026-06-11.md
@@ -66,9 +66,9 @@ state dirs, pane captures, or plan/validate outputs. ✅ = validated live,
 | Feature | Status | Evidence |
 |---|---|---|
 | Supervision: autonomous | ✅ | all runs |
-| Supervision: phase-checkpoints + gate adjudication | ⬜ | never exercised live |
-| Parked gate closure options (proceed/redirect/abort) | 🧪 | validate scenarios only |
-| Resume: journal replay of completed agents | ⬜ | blocked on ws-resume fix; then kill-resume E2E |
+| Supervision: phase-checkpoints + gate adjudication | ✅ | live ephemeral Hy probe: `uv run pytest packages/doeff-conductor/tests/test_c9_live_gates.py` |
+| Parked gate closure options (proceed/redirect/abort) | ✅ | `conductor answer RUN GATE_ID proceed` resumes; redirect/abort validated as gate options |
+| Resume: journal replay of completed agents | ✅ | c3 replay tests + live gate proceed keeps completed sibling journal hit |
 | Fingerprint-gated cache invalidation (profile edit) | 🧪 | unit tests only |
 | State dir as audit record | ✅ | journals inspected during incidents |
 
@@ -96,7 +96,8 @@ daemon (single authority). Candidate follow-up issue.
 6. Auto-commit captures .agent-home session state — open
 7. Await budget owning axis — open
 8. blocked-status cosmetic misread — open
-9. (candidate) doeff-agents CLI blind to agentd sessions — monitoring gap
+9. §8 attention tiers live gap — ✅ fixed: open gates, closure verbs, phase-checkpoints live
+10. (candidate) doeff-agents CLI blind to agentd sessions — monitoring gap
 
 
 ## Late-session findings (after the first matrix cut)
@@ -108,7 +109,7 @@ daemon (single authority). Candidate follow-up issue.
 | Fingerprint invalidation END-TO-END | ❌→✅ | two defects: session name lacked identity digest, then digest not threaded to L2 (journal poisoning); fixed 3d765cac + 7th commit; live: same run-id re-launched `…-84716d3a-0` with effort="medium" argv |
 | Result channel per-session | ❌→✅ | shared-workspace collision (stale acceptance); fixed 0ad2c7b4 |
 | Loop iteration in node identity | ❌→✅ | round 2 re-adopted round 1's session; fixed 0ad2c7b4 |
-| §8 attention tiers LIVE | ❌ | stub-only: live exhaustion = terminal error, no parked gate, no closure verb, phase-checkpoints inert — NEXT MAJOR STAGE |
+| §8 attention tiers LIVE | ❌→✅ | live retry-budget exhaustion parks an open gate; `conductor answer ... proceed` resumes via journal; `--supervision phase-checkpoints` inserts checkpoint gates with artifact summaries/binding deltas |
 | `random!` true randomness | ❌ | Random(0) constant-seed placeholder (§11-10) |
 | quorum/oks Try-bindings | ⬜ | not yet probed live |
 | merge-conflict structured bounce | ⬜ | not yet probed live |

--- a/packages/doeff-conductor/src/doeff_conductor/api.py
+++ b/packages/doeff-conductor/src/doeff_conductor/api.py
@@ -38,12 +38,13 @@ class ConductorAPI:
         self.workflows_dir = self.state_dir / "workflows"
         self.workflows_dir.mkdir(parents=True, exist_ok=True)
 
-    def run_workflow(  # noqa: PLR0915
+    def run_workflow(  # noqa: PLR0912, PLR0915
         self,
         template_or_file: str,
         issue: "Issue | None" = None,
         params: dict[str, Any] | None = None,
         run_id: str | None = None,
+        supervision: str = "autonomous",
     ) -> "WorkflowHandle":
         """Run a workflow template or file.
 
@@ -52,6 +53,7 @@ class ConductorAPI:
             issue: Issue to pass to workflow
             params: Additional parameters
             run_id: Optional caller-supplied workflow id for resume/replay runs
+            supervision: Run-scoped overseer supervision policy
 
         Returns:
             WorkflowHandle for the started workflow
@@ -132,6 +134,7 @@ class ConductorAPI:
                     raise ValueError("workflow function was not loaded")
                 program = workflow_func(**kwargs)
             else:
+                from doeff_conductor.overseer import answered_gate_options
                 from doeff_conductor.workflow_runtime import workflow_spec_to_program
 
                 program = workflow_spec_to_program(
@@ -139,6 +142,8 @@ class ConductorAPI:
                     run_id=workflow_id,
                     params=kwargs,
                     issue=issue,
+                    supervision=supervision,
+                    answered_gate_options=answered_gate_options(self.state_dir, workflow_id),
                 )
 
             # Run with conductor handlers
@@ -151,6 +156,37 @@ class ConductorAPI:
 
             result = run(scheduled(WithHandler(conductor_handler, program)))
             result_value = result.value if type(result).__name__ == "RunResult" else result
+            open_gates = ()
+            from doeff_conductor.workflow_runtime import ParkedValue, WorkflowRuntimeResult
+
+            if isinstance(result_value, WorkflowRuntimeResult):
+                open_gates = result_value.open_gates
+                result_value = result_value.value
+            result_payload = None if isinstance(result_value, ParkedValue) else result_value
+
+            if open_gates:
+                from doeff_conductor.overseer import record_open_gates
+
+                record_open_gates(
+                    self.state_dir,
+                    workflow_id=workflow_id,
+                    workflow_name=handle.name,
+                    open_gates=open_gates,
+                    supervision=supervision,
+                )
+                handle = WorkflowHandle(
+                    id=workflow_id,
+                    name=handle.name,
+                    status=WorkflowStatus.BLOCKED,
+                    template=template_name,
+                    issue_id=issue.id if issue else None,
+                    created_at=now,
+                    updated_at=datetime.now(timezone.utc),
+                    result_payload=result_payload,
+                )
+                self._save_workflow(handle)
+                return handle
+
             pr_url = None
             if isinstance(result_value, PRHandle):
                 pr_url = result_value.url
@@ -170,7 +206,7 @@ class ConductorAPI:
                 created_at=now,
                 updated_at=datetime.now(timezone.utc),
                 pr_url=pr_url,
-                result_payload=result_value,
+                result_payload=result_payload,
             )
             self._save_workflow(handle)
 
@@ -195,6 +231,7 @@ class ConductorAPI:
         workflow_id: str,
         *,
         params: dict[str, Any] | None = None,
+        supervision: str | None = None,
     ) -> "WorkflowHandle":
         """Resume a run from its snapshotted workflow source."""
 
@@ -203,11 +240,67 @@ class ConductorAPI:
         snapshot_path: Path = workflow_snapshot_path(self.state_dir, workflow_id)
         if not snapshot_path.exists():
             raise ValueError(f"workflow snapshot not found for run: {workflow_id}")
+        active_supervision = supervision
+        if active_supervision is None:
+            from doeff_conductor.overseer import load_run_state
+
+            try:
+                active_supervision = load_run_state(self.state_dir, workflow_id).supervision
+            except FileNotFoundError:
+                active_supervision = "autonomous"
         return self.run_workflow(
             str(snapshot_path),
             params=params,
             run_id=workflow_id,
+            supervision=active_supervision,
         )
+
+    def answer_gate(
+        self,
+        workflow_id: str,
+        gate_id: str,
+        option: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> "WorkflowHandle":
+        """Record an overseer gate answer and apply its closure-preserving verb."""
+
+        from doeff_conductor.overseer import record_gate_answer
+        from doeff_conductor.types import WorkflowStatus
+
+        run_state = record_gate_answer(
+            self.state_dir,
+            workflow_id=workflow_id,
+            gate_id=gate_id,
+            option=option,
+        )
+        if option == "abort":
+            handle = self.get_workflow(workflow_id)
+            if handle is None:
+                raise ValueError(f"Workflow not found: {workflow_id}")
+            aborted = WorkflowHandle(
+                id=handle.id,
+                name=handle.name,
+                status=WorkflowStatus.ABORTED,
+                template=handle.template,
+                issue_id=handle.issue_id,
+                created_at=handle.created_at,
+                updated_at=datetime.now(timezone.utc),
+                workspaces=handle.workspaces,
+                agents=handle.agents,
+                pr_url=handle.pr_url,
+                error=f"aborted at gate {gate_id}",
+                result_payload=handle.result_payload,
+            )
+            self._save_workflow(aborted)
+            return aborted
+        if option in {"proceed", "redirect"}:
+            return self.resume_workflow(
+                workflow_id,
+                params=params,
+                supervision=run_state.supervision,
+            )
+        raise ValueError(f"unsupported gate answer option: {option}")
 
     def list_workflows(
         self,

--- a/packages/doeff-conductor/src/doeff_conductor/cli.py
+++ b/packages/doeff-conductor/src/doeff_conductor/cli.py
@@ -242,6 +242,13 @@ def validate_cmd(
 @click.option("--issue", "-i", type=click.Path(exists=True), help="Issue file")
 @click.option("--params", "-p", help="Parameters as JSON")
 @click.option("--run-id", help="Use a stable workflow id for replay/resume measurements")
+@click.option(
+    "--supervision",
+    type=click.Choice(["autonomous", "phase-checkpoints"]),
+    default="autonomous",
+    show_default=True,
+    help="Run-scoped supervision policy",
+)
 @click.option("--watch", "-w", is_flag=True, help="Watch workflow progress")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.pass_context
@@ -251,6 +258,7 @@ def run(
     issue: str | None,
     params: str | None,
     run_id: str | None,
+    supervision: str,
     watch: bool,
     output_json: bool,
 ) -> None:
@@ -296,6 +304,7 @@ def run(
             issue=issue_obj,
             params=parsed_params,
             run_id=run_id,
+            supervision=supervision,
         )
 
         if output_json:
@@ -514,10 +523,29 @@ def _show_workflow_details(
             sys.exit(1)
 
         if output_json:
-            click.echo(json.dumps(workflow.to_dict(), indent=2))
+            payload = workflow.to_dict()
+            from doeff_conductor.overseer import list_open_gates
+
+            payload["open_gates"] = list_open_gates(api.state_dir, workflow.id)
+            click.echo(json.dumps(payload, indent=2))
             return
 
         console.print(_workflow_detail_panel(workflow))
+        from doeff_conductor.overseer import list_open_gates
+
+        gates = list_open_gates(api.state_dir, workflow.id)
+        if gates:
+            table = Table(show_header=True, header_style="bold")
+            table.add_column("GATE", style="cyan")
+            table.add_column("REASON")
+            table.add_column("OPTIONS")
+            for gate in gates:
+                table.add_row(
+                    gate["gate_id"],
+                    gate["reason"],
+                    ", ".join(option["name"] for option in gate["options"]),
+                )
+            console.print(table)
     except _CLI_USER_ERROR_TYPES as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
@@ -679,6 +707,61 @@ def gate_group() -> None:
 @click.pass_context
 def gate_list(ctx: click.Context, workflow_id: str | None, output_json: bool) -> None:
     """List open gates with stakes metadata and closure-preserving options."""
+    _list_gates(ctx, workflow_id, output_json)
+
+
+@cli.command("gates")
+@click.argument("workflow_id", required=False)
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def gates_cmd(ctx: click.Context, workflow_id: str | None, output_json: bool) -> None:
+    """List open gates with stakes metadata and closure-preserving options."""
+    _list_gates(ctx, workflow_id, output_json)
+
+
+@cli.command("answer")
+@click.argument("workflow_id")
+@click.argument("gate_id")
+@click.argument("option", type=click.Choice(["proceed", "redirect", "abort"]))
+@click.option("--params", "-p", help="Resume parameters as JSON")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def answer_cmd(
+    ctx: click.Context,
+    workflow_id: str,
+    gate_id: str,
+    option: str,
+    params: str | None,
+    output_json: bool,
+) -> None:
+    """Answer an open gate and apply proceed, redirect, or abort."""
+    from doeff_conductor.api import ConductorAPI
+
+    try:
+        parsed_params = {}
+        if params:
+            parsed_params = json.loads(params)
+        workflow = ConductorAPI(ctx.obj.get("state_dir")).answer_gate(
+            workflow_id,
+            gate_id,
+            option,
+            params=parsed_params,
+        )
+        if output_json:
+            click.echo(json.dumps(workflow.to_dict(), indent=2))
+            return
+        console.print(f"[green]Answered gate:[/green] {gate_id}")
+        console.print(f"  Option: {option}")
+        console.print(f"  Status: {workflow.status.value}")
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+
+def _list_gates(ctx: click.Context, workflow_id: str | None, output_json: bool) -> None:
     from doeff_conductor.api import ConductorAPI
     from doeff_conductor.overseer import list_open_gates
 

--- a/packages/doeff-conductor/src/doeff_conductor/effects/review.py
+++ b/packages/doeff-conductor/src/doeff_conductor/effects/review.py
@@ -780,11 +780,11 @@ def _open_gate_result(
         detail=detail,
         options=(
             GateOption(
-                name="retry-with-feedback",
-                outcome="retry the blocked review step with overseer feedback",
+                name="proceed",
+                outcome="resume the blocked review step after the condition is cleared",
             ),
             GateOption(
-                name="edit-and-resume",
+                name="redirect",
                 outcome="resume after the overseer edits workflow state or budget",
             ),
             GateOption(name="abort", outcome="abort the dependent review subtree"),

--- a/packages/doeff-conductor/src/doeff_conductor/journal.py
+++ b/packages/doeff-conductor/src/doeff_conductor/journal.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from doeff_agents.result_validation import validate_result_payload
 
-from doeff_conductor.effects.agent import AgentEffect, AgentTask
+from doeff_conductor.effects.agent import AgentAttemptExhaustedError, AgentEffect, AgentTask
 from doeff_conductor.exceptions import AgentError, JournalCorruptionError
 from doeff_conductor.replay_keying import (
     ResolvedIdentity,
@@ -24,6 +24,7 @@ from doeff_conductor.replay_keying import (
 JOURNAL_VERSION = 1
 AGENT_JOURNAL_FILENAME = "agent-journal.jsonl"
 TERMINAL_KIND_SUCCEEDED = "succeeded"
+TERMINAL_KIND_OPEN_GATE = "open-gate"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -179,14 +180,48 @@ class AgentReplaySession:
 
         if entry_index < valid_prefix:
             previous_entry = self.previous_entries[entry_index]
+            if previous_entry.terminal_kind != TERMINAL_KIND_SUCCEEDED:
+                self._start_new_generation()
+                return self._run_delegate_and_append(effect, delegate, decision, entry_index)
             self._validate_replay_entry(previous_entry, effect, decision)
             self.replayed_prefix_entries.append(previous_entry)
+            if self.started_new_generation:
+                self._append_replayed_entry(previous_entry)
             return previous_entry.result_artifact
 
         if entry_index < len(self.previous_entries):
             self._start_new_generation()
 
-        result = delegate(effect)
+        return self._run_delegate_and_append(effect, delegate, decision, entry_index)
+
+    def _run_delegate_and_append(
+        self,
+        effect: AgentEffect,
+        delegate: Callable[[AgentEffect], object],
+        decision: AgentReplayDecision,
+        entry_index: int,
+    ) -> object:
+        try:
+            result = delegate(effect)
+        except AgentAttemptExhaustedError as error:
+            self.journal.append_entry(
+                AgentJournalEntry(
+                    generation=self.current_generation,
+                    entry_index=entry_index,
+                    cache_key=decision.cache_key,
+                    resolved_identity_fingerprint=decision.resolved_identity_fingerprint,
+                    node_identity=decision.node_identity,
+                    result_artifact={
+                        "session_id": error.session_id,
+                        "attempts": error.attempts,
+                        "last_error_kind": error.last_error.kind.value,
+                        "last_error_message": error.last_error.message,
+                    },
+                    terminal_kind=TERMINAL_KIND_OPEN_GATE,
+                )
+            )
+            raise
+
         _validate_delegate_result(effect, result)
         self.journal.append_entry(
             AgentJournalEntry(
@@ -206,18 +241,26 @@ class AgentReplaySession:
             return
         self.current_generation = self.previous_generation + 1
         for entry_index, previous_entry in enumerate(self.replayed_prefix_entries):
-            self.journal.append_entry(
-                AgentJournalEntry(
-                    generation=self.current_generation,
-                    entry_index=entry_index,
-                    cache_key=previous_entry.cache_key,
-                    resolved_identity_fingerprint=previous_entry.resolved_identity_fingerprint,
-                    node_identity=previous_entry.node_identity,
-                    result_artifact=previous_entry.result_artifact,
-                    terminal_kind=previous_entry.terminal_kind,
-                )
-            )
+            self._append_replayed_entry(previous_entry, entry_index=entry_index)
         self.started_new_generation = True
+
+    def _append_replayed_entry(
+        self,
+        previous_entry: AgentJournalEntry,
+        *,
+        entry_index: int | None = None,
+    ) -> None:
+        self.journal.append_entry(
+            AgentJournalEntry(
+                generation=self.current_generation,
+                entry_index=previous_entry.entry_index if entry_index is None else entry_index,
+                cache_key=previous_entry.cache_key,
+                resolved_identity_fingerprint=previous_entry.resolved_identity_fingerprint,
+                node_identity=previous_entry.node_identity,
+                result_artifact=previous_entry.result_artifact,
+                terminal_kind=previous_entry.terminal_kind,
+            )
+        )
 
     def _validate_replay_entry(
         self,

--- a/packages/doeff-conductor/src/doeff_conductor/overseer.py
+++ b/packages/doeff-conductor/src/doeff_conductor/overseer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -131,6 +131,7 @@ class RunStateView:
     events: tuple[ProgressEvent, ...]
     open_gates: tuple[OpenGateView, ...]
     supervision: str = "autonomous"
+    answered_gates: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -139,6 +140,7 @@ class RunStateView:
             "supervision": self.supervision,
             "events": [event.to_dict() for event in self.events],
             "open_gates": [gate.to_dict() for gate in self.open_gates],
+            "answered_gates": dict(self.answered_gates),
         }
 
     @classmethod
@@ -149,6 +151,9 @@ class RunStateView:
             raise ValueError("run-state events must be a list")
         if not isinstance(raw_gates, list):
             raise ValueError("run-state open_gates must be a list")
+        raw_answered: object = data.get("answered_gates", {})
+        if not isinstance(raw_answered, dict):
+            raise ValueError("run-state answered_gates must be an object")
         events: tuple[ProgressEvent, ...] = tuple(
             ProgressEvent.from_dict(event)
             for event in raw_events
@@ -165,6 +170,7 @@ class RunStateView:
             supervision=str(data.get("supervision", "autonomous")),
             events=events,
             open_gates=gates,
+            answered_gates={str(key): str(value) for key, value in raw_answered.items()},
         )
 
 
@@ -203,7 +209,11 @@ def progress_since(state_dir: str | Path, workflow_id: str, since_sequence: int)
 def list_open_gates(state_dir: str | Path, workflow_id: str | None = None) -> list[dict[str, Any]]:
     base_dir: Path = Path(state_dir) / "workflows"
     if workflow_id is not None:
-        return [gate.to_dict() for gate in load_run_state(state_dir, workflow_id).open_gates]
+        try:
+            run_state = load_run_state(state_dir, workflow_id)
+        except FileNotFoundError:
+            return []
+        return [gate.to_dict() for gate in run_state.open_gates]
 
     gates: list[dict[str, Any]] = []
     if not base_dir.exists():
@@ -217,6 +227,115 @@ def list_open_gates(state_dir: str | Path, workflow_id: str | None = None) -> li
         run_state: RunStateView = load_run_state(state_dir, workflow_dir.name)
         gates.extend(gate.to_dict() for gate in run_state.open_gates)
     return gates
+
+
+def answered_gate_options(state_dir: str | Path, workflow_id: str) -> dict[str, str]:
+    try:
+        run_state: RunStateView = load_run_state(state_dir, workflow_id)
+    except FileNotFoundError:
+        return {}
+    return dict(run_state.answered_gates)
+
+
+def record_open_gates(
+    state_dir: str | Path,
+    *,
+    workflow_id: str,
+    workflow_name: str,
+    open_gates: tuple[OpenGateView, ...],
+    supervision: str,
+) -> RunStateView:
+    try:
+        existing: RunStateView = load_run_state(state_dir, workflow_id)
+    except FileNotFoundError:
+        existing = RunStateView(
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            events=(),
+            open_gates=(),
+            supervision=supervision,
+        )
+
+    events: list[ProgressEvent] = list(existing.events)
+    gates_by_id: dict[str, OpenGateView] = {
+        gate.gate_id: gate for gate in existing.open_gates
+    }
+    sequence = _last_sequence(existing.events)
+    for gate in open_gates:
+        if gate.gate_id not in gates_by_id:
+            sequence += 1
+            events.append(
+                make_progress_event(
+                    sequence=sequence,
+                    workflow_id=workflow_id,
+                    node_id=gate.node_id,
+                    phase=gate.phase,
+                    status="open",
+                    message=f"{gate.reason}: {gate.gate_id}",
+                    terminal_kind="gate",
+                )
+            )
+        gates_by_id[gate.gate_id] = gate
+
+    updated = RunStateView(
+        workflow_id=workflow_id,
+        workflow_name=workflow_name,
+        events=tuple(events),
+        open_gates=tuple(gates_by_id.values()),
+        supervision=supervision,
+        answered_gates=dict(existing.answered_gates),
+    )
+    save_run_state(state_dir, updated)
+    return updated
+
+
+def record_gate_answer(
+    state_dir: str | Path,
+    *,
+    workflow_id: str,
+    gate_id: str,
+    option: str,
+) -> RunStateView:
+    existing: RunStateView = load_run_state(state_dir, workflow_id)
+    target_gate: OpenGateView | None = None
+    remaining_gates: list[OpenGateView] = []
+    for gate in existing.open_gates:
+        if gate.gate_id == gate_id:
+            target_gate = gate
+        else:
+            remaining_gates.append(gate)
+    if target_gate is None:
+        raise ValueError(f"open gate not found: {gate_id}")
+
+    valid_options = {gate_option.name for gate_option in target_gate.options}
+    if option not in valid_options:
+        raise ValueError(f"gate {gate_id!r} does not support option {option!r}")
+
+    sequence = _last_sequence(existing.events) + 1
+    events = (
+        *existing.events,
+        make_progress_event(
+            sequence=sequence,
+            workflow_id=workflow_id,
+            node_id=target_gate.node_id,
+            phase=target_gate.phase,
+            status="answered",
+            message=f"{gate_id} answered with {option}",
+            terminal_kind="gate-answer",
+        ),
+    )
+    answered_gates = dict(existing.answered_gates)
+    answered_gates[gate_id] = option
+    updated = RunStateView(
+        workflow_id=workflow_id,
+        workflow_name=existing.workflow_name,
+        events=events,
+        open_gates=tuple(remaining_gates),
+        supervision=existing.supervision,
+        answered_gates=answered_gates,
+    )
+    save_run_state(state_dir, updated)
+    return updated
 
 
 def make_progress_event(
@@ -239,3 +358,9 @@ def make_progress_event(
         terminal_kind=terminal_kind,
         at=datetime.now(timezone.utc).isoformat(),
     )
+
+
+def _last_sequence(events: tuple[ProgressEvent, ...]) -> int:
+    if not events:
+        return 0
+    return max(event.sequence for event in events)

--- a/packages/doeff-conductor/src/doeff_conductor/verbs.py
+++ b/packages/doeff-conductor/src/doeff_conductor/verbs.py
@@ -468,9 +468,14 @@ def _phase_stakes(expanded: ExpandedWorkflow, phase_name: str | None) -> str:
 def _failure_gate_options() -> tuple[GateOption, ...]:
     return (
         GateOption(
-            name="retry-with-feedback",
+            name="proceed",
             outcome="resume",
-            description="Retry the blocked node with overseer feedback.",
+            description="Resume the parked subtree after the blocking condition is cleared.",
+        ),
+        GateOption(
+            name="redirect",
+            outcome="resume",
+            description="Edit workflow state or inputs, then resume from the journal prefix.",
         ),
         GateOption(
             name="abort",
@@ -486,6 +491,11 @@ def _checkpoint_options() -> tuple[GateOption, ...]:
             name="proceed",
             outcome="resume",
             description="Accept the phase artifact summaries and continue.",
+        ),
+        GateOption(
+            name="redirect",
+            outcome="resume",
+            description="Edit workflow state or inputs, then resume from the checkpoint.",
         ),
         GateOption(
             name="abort",

--- a/packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py
+++ b/packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, is_dataclass
 from dataclasses import field as dataclass_field
 from datetime import datetime, timezone
@@ -31,12 +31,21 @@ from doeff_conductor.dsl import (
     WorkflowSpec,
     WorkspaceSpec,
 )
-from doeff_conductor.effects import Agent, AgentTask, Commit, CreateWorkspace, Exec, MergeWorkspaces
+from doeff_conductor.effects import (
+    Agent,
+    AgentAttemptExhaustedError,
+    AgentTask,
+    Commit,
+    CreateWorkspace,
+    Exec,
+    MergeWorkspaces,
+)
 from doeff_conductor.environment import (
     ProfileBinding,
     ProfileRegistry,
     load_profile_registry_from_env,
 )
+from doeff_conductor.overseer import GateOption, OpenGateView
 from doeff_conductor.replay_keying import ResolvedIdentity
 from doeff_conductor.types import ExecResult, Issue, MergeStrategy, MergeWorkspacesResult, Workspace
 from doeff_conductor.verbs import resolve_agent_profile
@@ -49,12 +58,31 @@ class _RuntimeContext:
     params: Mapping[str, Any]
     registry: ProfileRegistry
     issue: Issue | None
+    supervision: str
+    answered_gate_options: Mapping[str, str]
     bindings: dict[str, Any] = dataclass_field(default_factory=dict)
+    open_gates: dict[str, OpenGateView] = dataclass_field(default_factory=dict)
     # Keyed by the workspace EXPRESSION's source-order occurrence, NOT by
     # Python object id and NOT by evaluation site — one workspace! value
     # shared by several nodes must bind one workspace, identically across
     # process restarts (resume stability).
     workspace_cache: dict[str, Workspace] = dataclass_field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ParkedValue:
+    """Runtime marker for a subtree parked behind one or more open gates."""
+
+    gates: tuple[OpenGateView, ...]
+    halt_run: bool = False
+
+
+@dataclass(frozen=True)
+class WorkflowRuntimeResult:
+    """Runtime result plus any open overseer gates materialized by live execution."""
+
+    value: Any
+    open_gates: tuple[OpenGateView, ...]
 
 
 def workflow_spec_to_program(
@@ -64,12 +92,16 @@ def workflow_spec_to_program(
     params: Mapping[str, Any] | None = None,
     issue: Issue | None = None,
     registry: ProfileRegistry | None = None,
+    supervision: str = "autonomous",
+    answered_gate_options: Mapping[str, str] | None = None,
 ) -> Any:
     """Compile a ``WorkflowSpec`` into a production doeff Program."""
 
     workflow.expand()
     active_params: Mapping[str, Any] = params or {}
     active_registry: ProfileRegistry = registry or load_profile_registry_from_env()
+    if supervision not in {"autonomous", "phase-checkpoints"}:
+        raise ValueError(f"unsupported supervision policy: {supervision}")
 
     @do
     def program() -> Any:
@@ -79,6 +111,8 @@ def workflow_spec_to_program(
             params=active_params,
             registry=active_registry,
             issue=issue,
+            supervision=supervision,
+            answered_gate_options=answered_gate_options or {},
         )
         result: Any = None
         for index, form in enumerate(workflow.body):
@@ -88,7 +122,12 @@ def workflow_spec_to_program(
                 current_phase=None,
                 path=str(index),
             )
-        return result
+            if isinstance(result, ParkedValue) and result.halt_run:
+                break
+        return WorkflowRuntimeResult(
+            value=result,
+            open_gates=tuple(context.open_gates.values()),
+        )
 
     return program()
 
@@ -102,6 +141,7 @@ def _execute_form(
     path: str,
 ) -> Any:
     if isinstance(form, PhaseSpec):
+        bindings_before_phase: dict[str, Any] = dict(context.bindings)
         result: Any = None
         for index, child_form in enumerate(form.body):
             child_path: str = _path_join(_path_join(path, form.name), str(index))
@@ -111,6 +151,15 @@ def _execute_form(
                 current_phase=form.name,
                 path=child_path,
             )
+            if isinstance(result, ParkedValue):
+                return result
+        checkpoint = _checkpoint_gate_for_phase(
+            context=context,
+            phase=form,
+            bindings_before_phase=bindings_before_phase,
+        )
+        if checkpoint is not None:
+            return _park(context, checkpoint, halt_run=True)
         return result
 
     if isinstance(form, BindSpec):
@@ -120,7 +169,10 @@ def _execute_form(
             current_phase=current_phase,
             path=path,
         )
-        _bind_runtime_value(form.target, value, context)
+        if isinstance(value, ParkedValue):
+            _bind_parked_runtime_value(form.target, value, context)
+        else:
+            _bind_runtime_value(form.target, value, context)
         return value
 
     if isinstance(form, ArtifactSpec):
@@ -219,6 +271,9 @@ def _execute_parallel(
         )
         tasks.append(task)
     results = cast(tuple[Any, ...], (yield Gather(*tasks)))
+    parked = _combine_parked_values(results)
+    if parked is not None:
+        return parked
     return results
 
 
@@ -250,6 +305,9 @@ def _execute_loop(
                 current_phase=current_phase,
                 path=form_path,
             )
+            if isinstance(last_value, ParkedValue):
+                _restore_loop_bindings(context, outer_bindings)
+                return last_value
             predicate_result = cast(
                 bool,
                 (yield _evaluate_until(spec.until, context, path=_path_join(path, "until"))),
@@ -279,9 +337,10 @@ def _execute_agent(
 ) -> Any:
     effect = spec.to_effect(current_phase)
     node_id: str = _node_id(context.workflow.name, path, "agent")
-    prompt_text: str = _stringify_prompt_value(
-        (yield _evaluate_value(effect.prompt, context, path=_path_join(path, "prompt")))
-    )
+    prompt_value = yield _evaluate_value(effect.prompt, context, path=_path_join(path, "prompt"))
+    if isinstance(prompt_value, ParkedValue):
+        return prompt_value
+    prompt_text: str = _stringify_prompt_value(prompt_value)
     schema: dict[str, Any] = _schema_to_dict(effect.schema)
     workspace: Workspace
     if effect.workspace is None:
@@ -304,6 +363,8 @@ def _execute_agent(
             context,
             path=_path_join(path, "workspace"),
         )
+        if isinstance(workspace_value, ParkedValue):
+            return workspace_value
         if not isinstance(workspace_value, Workspace):
             raise TypeError(f"agent workspace for {node_id} did not evaluate to Workspace")
         workspace = workspace_value
@@ -315,31 +376,41 @@ def _execute_agent(
     )
     profile: ProfileBinding = context.registry.resolve(profile_name)
     max_retries: int = _resolve_retry(effect.retry, effect.role, context.workflow.roles)
-    result = yield Agent(
-        AgentTask(
-            run_id=context.run_id,
-            node_id=node_id,
-            attempt=0,
-            env=workspace,
-            prompt=prompt_text,
-            result_schema=schema,
-            verification_class=effect.verification_class,
-            agent_type=profile.adapter,
-            name=effect.label,
-            profile=profile_name,
-            model=profile.model,
-            # Effort is an axis of the profile binding (L0 identity), never a
-            # workflow/run parameter (ADR D7).
+    task = AgentTask(
+        run_id=context.run_id,
+        node_id=node_id,
+        attempt=0,
+        env=workspace,
+        prompt=prompt_text,
+        result_schema=schema,
+        verification_class=effect.verification_class,
+        agent_type=profile.adapter,
+        name=effect.label,
+        profile=profile_name,
+        model=profile.model,
+        # Effort is an axis of the profile binding (L0 identity), never a
+        # workflow/run parameter (ADR D7).
+        effort=profile.effort,
+        resolved_identity=ResolvedIdentity(
+            adapter=profile.adapter,
+            model=profile.model or "",
+            identity=None,
             effort=profile.effort,
-            resolved_identity=ResolvedIdentity(
-                adapter=profile.adapter,
-                model=profile.model,
-                identity=None,
-                effort=profile.effort,
-            ),
-            max_retries=max_retries,
-        )
+        ),
+        max_retries=max_retries,
     )
+    try:
+        result = yield Agent(task)
+    except AgentAttemptExhaustedError as error:
+        return _park(
+            context,
+            _agent_budget_exhausted_gate(
+                context=context,
+                task=task,
+                phase=current_phase,
+                error=error,
+            ),
+        )
     if workspace is not None:
         # D5 mechanized: a worker's output exists only once it is on the
         # workspace branch. Workers cannot be trusted to commit (prompt
@@ -372,6 +443,8 @@ def _execute_gate(spec: GateSpec, context: _RuntimeContext, *, path: str) -> Any
             context,
             path=_path_join(path, "workspace"),
         )
+        if isinstance(workspace_value, ParkedValue):
+            return workspace_value
         if not isinstance(workspace_value, Workspace):
             raise TypeError("gate workspace did not evaluate to Workspace")
         workspace = workspace_value
@@ -388,6 +461,8 @@ def _execute_merge(spec: MergeSpec, context: _RuntimeContext, *, path: str) -> A
             context,
             path=_path_join(path, f"workspaces[{workspace_index}]"),
         )
+        if isinstance(workspace_value, ParkedValue):
+            return workspace_value
         if not isinstance(workspace_value, Workspace):
             raise TypeError("merge! workspaces must evaluate to Workspace values")
         workspaces.append(workspace_value)
@@ -450,7 +525,7 @@ def _materialize_workspace(
 
 
 @do
-def _evaluate_value(  # noqa: PLR0911, PLR0912
+def _evaluate_value(  # noqa: PLR0911, PLR0912, PLR0915
     value: Any,
     context: _RuntimeContext,
     *,
@@ -468,18 +543,27 @@ def _evaluate_value(  # noqa: PLR0911, PLR0912
             context,
             path=_path_join(path, "source"),
         )
+        if isinstance(source_value, ParkedValue):
+            return source_value
         return _read_field(source_value, value.field_name)
     if isinstance(value, OksProjection):
         return (yield _evaluate_value(value.source, context, path=_path_join(path, "source")))
     if isinstance(value, PromptExpr):
         parts: list[str] = []
+        parked_values: list[ParkedValue] = []
         for part_index, part in enumerate(value.parts):
             part_value: Any = yield _evaluate_value(
                 part,
                 context,
                 path=_path_join(path, f"[{part_index}]"),
             )
+            if isinstance(part_value, ParkedValue):
+                parked_values.append(part_value)
+                continue
             parts.append(_stringify_prompt_value(part_value))
+        parked = _combine_parked_values(parked_values)
+        if parked is not None:
+            return parked
         return "".join(parts)
     if isinstance(value, WorkspaceSpec):
         return (yield _materialize_workspace(value, context, path=path))
@@ -489,6 +573,9 @@ def _evaluate_value(  # noqa: PLR0911, PLR0912
             items.append(
                 (yield _evaluate_value(item, context, path=_path_join(path, f"[{item_index}]")))
             )
+        parked = _combine_parked_values(items)
+        if parked is not None:
+            return parked
         return tuple(items)
     if isinstance(value, list):
         items = []
@@ -496,30 +583,50 @@ def _evaluate_value(  # noqa: PLR0911, PLR0912
             items.append(
                 (yield _evaluate_value(item, context, path=_path_join(path, f"[{item_index}]")))
             )
+        parked = _combine_parked_values(items)
+        if parked is not None:
+            return parked
         return items
     if isinstance(value, dict):
         evaluated: dict[Any, Any] = {}
+        parked_values: list[ParkedValue] = []
         for entry_index, (key, item) in enumerate(value.items()):
             evaluated_key: Any = yield _evaluate_value(
                 key,
                 context,
                 path=_path_join(path, f"key[{entry_index}]"),
             )
-            evaluated[evaluated_key] = yield _evaluate_value(
+            evaluated_value: Any = yield _evaluate_value(
                 item,
                 context,
                 path=_path_join(path, f"value[{entry_index}]"),
             )
+            if isinstance(evaluated_key, ParkedValue):
+                parked_values.append(evaluated_key)
+                continue
+            if isinstance(evaluated_value, ParkedValue):
+                parked_values.append(evaluated_value)
+                continue
+            evaluated[evaluated_key] = evaluated_value
+        parked = _combine_parked_values(parked_values)
+        if parked is not None:
+            return parked
         return evaluated
     if isinstance(value, set):
         items = []
         for item in value:
             items.append((yield _evaluate_value(item, context, path=path)))
+        parked = _combine_parked_values(items)
+        if parked is not None:
+            return parked
         return set(items)
     if isinstance(value, frozenset):
         items = []
         for item in value:
             items.append((yield _evaluate_value(item, context, path=path)))
+        parked = _combine_parked_values(items)
+        if parked is not None:
+            return parked
         return frozenset(items)
     return value
 
@@ -564,12 +671,153 @@ def _bind_runtime_value(target: str | Sequence[str], value: Any, context: _Runti
         context.bindings[str(name)] = value[index]
 
 
+def _bind_parked_runtime_value(
+    target: str | Sequence[str],
+    value: ParkedValue,
+    context: _RuntimeContext,
+) -> None:
+    if isinstance(target, str):
+        context.bindings[target] = value
+        return
+    for name in target:
+        context.bindings[str(name)] = value
+
+
 def _restore_loop_bindings(
     context: _RuntimeContext,
     outer_bindings: Mapping[str, Any],
 ) -> None:
     context.bindings.clear()
     context.bindings.update(outer_bindings)
+
+
+def _park(
+    context: _RuntimeContext,
+    gate: OpenGateView,
+    *,
+    halt_run: bool = False,
+) -> ParkedValue:
+    context.open_gates[gate.gate_id] = gate
+    return ParkedValue(gates=(gate,), halt_run=halt_run)
+
+
+def _combine_parked_values(values: Iterable[Any]) -> ParkedValue | None:
+    gates_by_id: dict[str, OpenGateView] = {}
+    halt_run = False
+    for value in values:
+        if not isinstance(value, ParkedValue):
+            continue
+        halt_run = halt_run or value.halt_run
+        for gate in value.gates:
+            gates_by_id[gate.gate_id] = gate
+    if not gates_by_id:
+        return None
+    return ParkedValue(gates=tuple(gates_by_id.values()), halt_run=halt_run)
+
+
+def _agent_budget_exhausted_gate(
+    *,
+    context: _RuntimeContext,
+    task: AgentTask,
+    phase: str | None,
+    error: AgentAttemptExhaustedError,
+) -> OpenGateView:
+    return OpenGateView(
+        gate_id=f"{context.run_id}:{task.node_id}:budget-exhausted",
+        workflow_id=context.run_id,
+        node_id=task.node_id,
+        phase=phase,
+        reason="budget exhausted",
+        stakes={
+            "verification_class": task.verification_class,
+            "blast_radius": "dependent-subtree",
+            "reversibility": "retryable",
+            "profile": task.profile,
+            "attempts": error.attempts,
+            "session_id": task.session_id,
+        },
+        options=_gate_options(),
+    )
+
+
+def _checkpoint_gate_for_phase(
+    *,
+    context: _RuntimeContext,
+    phase: PhaseSpec,
+    bindings_before_phase: Mapping[str, Any],
+) -> OpenGateView | None:
+    if context.supervision != "phase-checkpoints":
+        return None
+    gate_id = f"{context.run_id}:checkpoint:{phase.name}"
+    if context.answered_gate_options.get(gate_id) in {"proceed", "redirect"}:
+        return None
+
+    binding_deltas = _binding_deltas(bindings_before_phase, context.bindings)
+    artifact_summaries = {
+        name: _summarize_artifact(context.bindings[name])
+        for name in binding_deltas
+        if name in context.bindings
+    }
+    return OpenGateView(
+        gate_id=gate_id,
+        workflow_id=context.run_id,
+        node_id=f"checkpoint:{phase.name}",
+        phase=phase.name,
+        reason="phase checkpoint",
+        stakes={
+            "phase": phase.name,
+            "level": phase.stakes,
+            "verification_class": "checkpoint",
+            "blast_radius": "dependent-subtree",
+            "reversibility": "abortable",
+            "binding_deltas": binding_deltas,
+            "artifact_summaries": artifact_summaries,
+        },
+        options=_gate_options(),
+    )
+
+
+def _binding_deltas(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+) -> list[str]:
+    changed: list[str] = []
+    for name in sorted(after):
+        if name not in before:
+            changed.append(name)
+            continue
+        if _jsonable(before[name]) != _jsonable(after[name]):
+            changed.append(name)
+    return changed
+
+
+def _summarize_artifact(value: Any) -> str:
+    if isinstance(value, ParkedValue):
+        return "parked behind open gate"
+    encoded = json.dumps(_jsonable(value), sort_keys=True, ensure_ascii=True)
+    if len(encoded) <= 160:
+        return encoded
+    return f"{encoded[:157]}..."
+
+
+def _gate_options() -> tuple[GateOption, ...]:
+    return (
+        GateOption(
+            name="proceed",
+            outcome="resume",
+            description="Resume the parked subtree after the blocking condition is cleared.",
+        ),
+        GateOption(
+            name="redirect",
+            outcome="resume",
+            description="Edit workflow state or inputs, then resume from the journal prefix.",
+        ),
+        GateOption(
+            name="abort",
+            outcome="abort",
+            description="Abort the dependent subtree and preserve the gate outcome.",
+        ),
+    )
 
 
 def _resolve_retry(
@@ -613,6 +861,8 @@ def _read_field(source_value: Any, field_name: str) -> Any:
 
 
 def _value_passed(value: Any) -> bool:
+    if isinstance(value, ParkedValue):
+        return False
     if isinstance(value, ExecResult):
         return value.passed
     if isinstance(value, Mapping):

--- a/packages/doeff-conductor/tests/test_c8_single_file_run.py
+++ b/packages/doeff-conductor/tests/test_c8_single_file_run.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from click.testing import CliRunner
-from doeff_agents.effects.agent import AgentAttemptExhaustedError
 from doeff_conductor.api import ConductorAPI
 from doeff_conductor.cli import cli
 from doeff_conductor.effects import AgentEffect, AgentTask
 from doeff_conductor.handlers.journaled_agent import JournaledAgentHandler
 from doeff_conductor.handlers.testing import MockConductorRuntime, mock_handlers
+from doeff_conductor.overseer import list_open_gates
 from doeff_conductor.replay_keying import ResolvedIdentity
 from doeff_conductor.types import WorkflowStatus
 from doeff_conductor.workflow_loader import (
@@ -30,13 +30,13 @@ def _cheap_session_id(run_id: str, node_id: str) -> str:
         run_id=run_id,
         node_id=node_id,
         attempt=0,
-        env=None,
+        env=cast(Any, None),
         prompt="",
         result_schema={},
         verification_class="mechanical",
         agent_type="codex",
         resolved_identity=ResolvedIdentity(
-            adapter="codex", model=None, identity=None, effort="xhigh"
+            adapter="codex", model="", identity=None, effort="xhigh"
         ),
     ).session_id
 
@@ -223,17 +223,16 @@ def test_single_file_dsl_run_returns_payload_and_resumes_from_snapshot(
     _install_mock_production_handlers(monkeypatch=monkeypatch, runtime=runtime)
 
     api = ConductorAPI(state_dir=state_dir)
-    with pytest.raises(AgentAttemptExhaustedError):
-        api.run_workflow(str(workflow_path), run_id=run_id)
+    blocked_handle = api.run_workflow(str(workflow_path), run_id=run_id)
 
-    failed_handle = api.get_workflow(run_id)
-    assert failed_handle is not None
-    assert failed_handle.status == WorkflowStatus.ERROR
+    assert blocked_handle.status == WorkflowStatus.BLOCKED
+    assert list_open_gates(state_dir, run_id)
     assert (state_dir / "workflows" / run_id / "workflow.hy").exists()
 
     workflow_path.unlink()
     runtime.configure_agent_script(second_session_id, [{"summary": "second"}])
-    resumed_handle = api.resume_workflow(run_id)
+    gate_id = list_open_gates(state_dir, run_id)[0]["gate_id"]
+    resumed_handle = api.answer_gate(run_id, gate_id, "proceed")
 
     assert resumed_handle.status == WorkflowStatus.DONE
     assert resumed_handle.result_payload == {"summary": "second"}

--- a/packages/doeff-conductor/tests/test_c9_live_gates.py
+++ b/packages/doeff-conductor/tests/test_c9_live_gates.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from click.testing import CliRunner
@@ -21,14 +21,14 @@ def _cheap_session_id(run_id: str, node_id: str) -> str:
         run_id=run_id,
         node_id=node_id,
         attempt=0,
-        env=None,
+        env=cast(Any, None),
         prompt="",
         result_schema={},
         verification_class="test-verifiable",
         agent_type="codex",
         resolved_identity=ResolvedIdentity(
             adapter="codex",
-            model=None,
+            model="",
             identity=None,
             effort="xhigh",
         ),
@@ -94,14 +94,14 @@ def _write_checkpoint_workflow(path: Path) -> None:
     path.write_text(
         """
 (require doeff-hy.conductor [defworkflow defphase <-])
-(import doeff_conductor.dsl [artifact ref])
+(import doeff_conductor.dsl [artifact prompt ref])
 
 (defworkflow checkpoint-live
   :params {}
   :roles {}
   (defphase Build
-    :stakes high
-    (<- built (artifact "built")))
+    :stakes "high"
+    (<- built (prompt "built")))
   (artifact (ref "built")))
 
 (setv WORKFLOW checkpoint-live)

--- a/packages/doeff-conductor/tests/test_c9_live_gates.py
+++ b/packages/doeff-conductor/tests/test_c9_live_gates.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+from click.testing import CliRunner
+from doeff_conductor.api import ConductorAPI
+from doeff_conductor.cli import cli
+from doeff_conductor.effects import AgentEffect, AgentTask
+from doeff_conductor.handlers.journaled_agent import JournaledAgentHandler
+from doeff_conductor.handlers.testing import MockConductorRuntime, mock_handlers
+from doeff_conductor.overseer import list_open_gates, progress_since
+from doeff_conductor.replay_keying import ResolvedIdentity
+from doeff_conductor.types import WorkflowStatus
+
+
+def _cheap_session_id(run_id: str, node_id: str) -> str:
+    return AgentTask(
+        run_id=run_id,
+        node_id=node_id,
+        attempt=0,
+        env=None,
+        prompt="",
+        result_schema={},
+        verification_class="test-verifiable",
+        agent_type="codex",
+        resolved_identity=ResolvedIdentity(
+            adapter="codex",
+            model=None,
+            identity=None,
+            effort="xhigh",
+        ),
+    ).session_id
+
+
+def _install_mock_production_handlers(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime: MockConductorRuntime,
+) -> None:
+    import doeff_conductor.handlers as handlers_module
+
+    def production_handlers(**kwargs: object):
+        journaled_handler = JournaledAgentHandler(
+            runtime.handle_agent,
+            state_dir=cast(str | Path | None, kwargs["journal_state_dir"]),
+            run_id=str(kwargs["journal_run_id"]),
+        )
+        return mock_handlers(
+            runtime=runtime,
+            overrides={AgentEffect: journaled_handler.handle_agent},
+        )
+
+    monkeypatch.setattr(handlers_module, "production_handlers", production_handlers)
+
+
+def _write_parallel_gate_workflow(path: Path) -> None:
+    path.write_text(
+        """
+(require doeff-hy.conductor [defworkflow agent! parallel <-])
+(import doeff_conductor.dsl [artifact prompt ref])
+
+(setv RESULT-SCHEMA {"type" "object"
+                     "required" ["summary"]
+                     "properties" {"summary" {"type" "string"}}
+                     "additionalProperties" False})
+
+(defworkflow live-gate
+  :params {}
+  :roles {"implementer" {"profile" "cheap-coder" "retry" 0}}
+  (<- branches
+      (parallel
+        (agent! :role "implementer"
+                :class "test-verifiable"
+                :prompt (prompt "blocked branch")
+                :schema RESULT-SCHEMA
+                :label "blocked")
+        (agent! :role "implementer"
+                :class "test-verifiable"
+                :prompt (prompt "independent branch")
+                :schema RESULT-SCHEMA
+                :label "independent")))
+  (artifact (ref "branches")))
+
+(setv WORKFLOW live-gate)
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _write_checkpoint_workflow(path: Path) -> None:
+    path.write_text(
+        """
+(require doeff-hy.conductor [defworkflow defphase <-])
+(import doeff_conductor.dsl [artifact ref])
+
+(defworkflow checkpoint-live
+  :params {}
+  :roles {}
+  (defphase Build
+    :stakes high
+    (<- built (artifact "built")))
+  (artifact (ref "built")))
+
+(setv WORKFLOW checkpoint-live)
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_live_retry_budget_exhaustion_opens_gate_and_parallel_sibling_continues(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_path = tmp_path / "live_gate.hy"
+    state_dir = tmp_path / "state"
+    run_id = "live-budget"
+    _write_parallel_gate_workflow(workflow_path)
+
+    runtime = MockConductorRuntime(tmp_path / "runtime")
+    blocked_session_id = _cheap_session_id(run_id, "live-gate/0/parallel[0]/agent")
+    independent_session_id = _cheap_session_id(run_id, "live-gate/0/parallel[1]/agent")
+    runtime.configure_agent_script(blocked_session_id, [None])
+    runtime.configure_agent_script(independent_session_id, [{"summary": "independent done"}])
+    _install_mock_production_handlers(monkeypatch=monkeypatch, runtime=runtime)
+
+    handle = ConductorAPI(state_dir=state_dir).run_workflow(
+        str(workflow_path),
+        run_id=run_id,
+    )
+
+    assert handle.status is WorkflowStatus.BLOCKED
+    assert runtime.agent_invocation_count(blocked_session_id) == 1
+    assert runtime.agent_invocation_count(independent_session_id) == 1
+
+    gates = list_open_gates(state_dir, run_id)
+    assert len(gates) == 1
+    assert gates[0]["reason"] == "budget exhausted"
+    assert gates[0]["stakes"]["verification_class"] == "test-verifiable"
+    assert gates[0]["stakes"]["blast_radius"] == "dependent-subtree"
+    assert {"proceed", "redirect", "abort"} <= {
+        option["name"] for option in gates[0]["options"]
+    }
+
+
+def test_answer_proceed_records_journal_event_and_resumes_parked_subtree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_path = tmp_path / "live_gate.hy"
+    state_dir = tmp_path / "state"
+    run_id = "answer-proceed"
+    _write_parallel_gate_workflow(workflow_path)
+
+    runtime = MockConductorRuntime(tmp_path / "runtime")
+    blocked_session_id = _cheap_session_id(run_id, "live-gate/0/parallel[0]/agent")
+    independent_session_id = _cheap_session_id(run_id, "live-gate/0/parallel[1]/agent")
+    runtime.configure_agent_script(blocked_session_id, [None])
+    runtime.configure_agent_script(independent_session_id, [{"summary": "independent done"}])
+    _install_mock_production_handlers(monkeypatch=monkeypatch, runtime=runtime)
+
+    first_handle = ConductorAPI(state_dir=state_dir).run_workflow(
+        str(workflow_path),
+        run_id=run_id,
+    )
+    assert first_handle.status is WorkflowStatus.BLOCKED
+    gate_id = list_open_gates(state_dir, run_id)[0]["gate_id"]
+
+    runtime.configure_agent_script(blocked_session_id, [{"summary": "blocked recovered"}])
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--state-dir",
+            str(state_dir),
+            "answer",
+            run_id,
+            gate_id,
+            "proceed",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "done"
+    assert list_open_gates(state_dir, run_id) == []
+    assert runtime.agent_invocation_count(blocked_session_id) == 2
+    assert runtime.agent_invocation_count(independent_session_id) == 1
+    assert any(
+        event["status"] == "answered" and event["message"].endswith("proceed")
+        for event in progress_since(state_dir, run_id, 0)
+    )
+
+
+def test_live_phase_checkpoint_blocks_until_proceed(
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / "checkpoint_live.hy"
+    state_dir = tmp_path / "state"
+    run_id = "checkpoint-live"
+    _write_checkpoint_workflow(workflow_path)
+    api = ConductorAPI(state_dir=state_dir)
+
+    first_handle = api.run_workflow(
+        str(workflow_path),
+        run_id=run_id,
+        supervision="phase-checkpoints",
+    )
+
+    assert first_handle.status is WorkflowStatus.BLOCKED
+    gates = list_open_gates(state_dir, run_id)
+    assert len(gates) == 1
+    assert gates[0]["reason"] == "phase checkpoint"
+    assert gates[0]["stakes"]["binding_deltas"] == ["built"]
+    assert "built" in gates[0]["stakes"]["artifact_summaries"]
+    assert {"proceed", "redirect", "abort"} <= {
+        option["name"] for option in gates[0]["options"]
+    }
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--state-dir",
+            str(state_dir),
+            "answer",
+            run_id,
+            gates[0]["gate_id"],
+            "proceed",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "done"
+    assert payload["result_payload"] == "built"
+    assert list_open_gates(state_dir, run_id) == []


### PR DESCRIPTION
## Summary

Implements live §8 attention-tier gates for `doeff-conductor`.

- Converts live agent retry-budget exhaustion into an open overseer gate instead of a terminal workflow error.
- Propagates parked values through dependent runtime expressions while allowing independent parallel siblings to complete and journal successfully.
- Adds persisted gate answers, `conductor gates`, and `conductor answer RUN GATE_ID proceed|redirect|abort` backed by the existing §9 snapshot/journal resume path.
- Enables live `--supervision phase-checkpoints` gates with artifact summaries and binding deltas, not diffs.
- Updates validation/spec docs for `conductor-attention-tiers-live`.

## Acceptance evidence

- Budget exhaustion → open gate: `uv run pytest packages/doeff-conductor/tests/test_c9_live_gates.py::test_live_retry_budget_exhaustion_opens_gate_and_parallel_sibling_continues`
- `answer proceed` journal event + resume: `uv run pytest packages/doeff-conductor/tests/test_c9_live_gates.py::test_answer_proceed_records_journal_event_and_resumes_parked_subtree`
- Phase checkpoint gate + proceed: `uv run pytest packages/doeff-conductor/tests/test_c9_live_gates.py::test_live_phase_checkpoint_blocks_until_proceed`
- Full conductor package: `uv run pytest packages/doeff-conductor` → 300 passed
- Targeted lint: `uv run ruff check packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py packages/doeff-conductor/src/doeff_conductor/api.py packages/doeff-conductor/src/doeff_conductor/overseer.py packages/doeff-conductor/src/doeff_conductor/journal.py packages/doeff-conductor/src/doeff_conductor/cli.py packages/doeff-conductor/src/doeff_conductor/verbs.py packages/doeff-conductor/src/doeff_conductor/effects/review.py packages/doeff-conductor/tests/test_c9_live_gates.py packages/doeff-conductor/tests/test_c8_single_file_run.py`
- Targeted type check: `uv run pyright packages/doeff-conductor/src/doeff_conductor/workflow_runtime.py packages/doeff-conductor/src/doeff_conductor/api.py packages/doeff-conductor/src/doeff_conductor/overseer.py packages/doeff-conductor/src/doeff_conductor/journal.py packages/doeff-conductor/tests/test_c9_live_gates.py packages/doeff-conductor/tests/test_c8_single_file_run.py`

Reference: `conductor-attention-tiers-live`