### PR TITLE
[codex] Add conductor wait command

### DIFF
--- a/packages/doeff-conductor/src/doeff_conductor/cli.py
+++ b/packages/doeff-conductor/src/doeff_conductor/cli.py
@@ -5,6 +5,7 @@ Commands:
     run         Execute a workflow template or file
     ps          List running workflows
     show        Show workflow details
+    wait        Block until a workflow terminates or parks
     watch       Monitor workflow progress
     attach      Attach to agent session
     logs        View session logs
@@ -17,6 +18,7 @@ Commands:
 
 import json
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -63,6 +65,7 @@ def _status_color(status: WorkflowStatus | IssueStatus | str) -> str:
             WorkflowStatus.BLOCKED: "yellow",
             WorkflowStatus.DONE: "blue",
             WorkflowStatus.ERROR: "red",
+            WorkflowStatus.STOPPED: "magenta",
             WorkflowStatus.ABORTED: "magenta",
         }.get(status, "white")
     if isinstance(status, IssueStatus):
@@ -568,6 +571,146 @@ def show_cmd(
         return
 
     _show_workflow_details(ctx, workflow_id, output_json)
+
+
+def _wait_status_value(status: WorkflowStatus) -> str:
+    if status in (WorkflowStatus.STOPPED, WorkflowStatus.ABORTED):
+        return "stopped"
+    return status.value
+
+
+def _wait_gate_payload(gates: list[dict[str, object]]) -> list[dict[str, object]]:
+    payload: list[dict[str, object]] = []
+    for gate in gates:
+        raw_options = gate["options"]
+        if not isinstance(raw_options, list):
+            raise ValueError("open gate options must be a list")
+        option_names: list[str] = []
+        for option in raw_options:
+            if not isinstance(option, dict):
+                raise ValueError("open gate option must be an object")
+            option_names.append(str(option["name"]))
+        payload.append(
+            {
+                "gate_id": str(gate["gate_id"]),
+                "options": option_names,
+            }
+        )
+    return payload
+
+
+def _wait_summary(payload: dict[str, object]) -> str:
+    status = str(payload["status"])
+    raw_waited_seconds = payload["waited_seconds"]
+    if not isinstance(raw_waited_seconds, (int, float)):
+        raise ValueError("wait payload waited_seconds must be numeric")
+    waited_seconds = float(raw_waited_seconds)
+    gates = payload["gates"]
+    if not isinstance(gates, list):
+        raise ValueError("wait payload gates must be a list")
+    if not gates:
+        return f"status={status} waited_seconds={waited_seconds:.3f}"
+
+    gate_parts: list[str] = []
+    for gate in gates:
+        if not isinstance(gate, dict):
+            raise ValueError("wait payload gate must be an object")
+        raw_options = gate["options"]
+        if not isinstance(raw_options, list):
+            raise ValueError("wait payload gate options must be a list")
+        option_text = ", ".join(str(option) for option in raw_options)
+        gate_parts.append(f"{gate['gate_id']}({option_text})")
+    return f"status={status} gates={'; '.join(gate_parts)} waited_seconds={waited_seconds:.3f}"
+
+
+def _wait_for_workflow(
+    *,
+    state_dir: str | None,
+    workflow_id: str,
+    timeout: float | None,
+    poll_interval: float,
+) -> tuple[int, dict[str, object]]:
+    from doeff_conductor.api import ConductorAPI
+    from doeff_conductor.overseer import list_open_gates
+
+    api = ConductorAPI(state_dir)
+    started_at = time.monotonic()
+
+    while True:
+        handle = api.get_workflow(workflow_id)
+        waited_seconds = time.monotonic() - started_at
+        if handle is None:
+            raise ValueError(
+                f"Workflow not found: {workflow_id} (state dir: {api.state_dir})"
+            )
+
+        status_value = _wait_status_value(handle.status)
+        gate_payload = _wait_gate_payload(list_open_gates(api.state_dir, handle.id))
+        payload = {
+            "status": status_value,
+            "gates": gate_payload,
+            "waited_seconds": round(waited_seconds, 3),
+        }
+
+        if handle.status is WorkflowStatus.DONE:
+            return 0, payload
+        if handle.status in (
+            WorkflowStatus.ERROR,
+            WorkflowStatus.STOPPED,
+            WorkflowStatus.ABORTED,
+        ):
+            return 1, payload
+        if gate_payload:
+            return 2, payload
+        if timeout is not None and waited_seconds >= timeout:
+            return 3, payload
+
+        sleep_seconds = poll_interval
+        if timeout is not None:
+            remaining_seconds = timeout - waited_seconds
+            sleep_seconds = min(poll_interval, remaining_seconds)
+        if sleep_seconds > 0:
+            time.sleep(sleep_seconds)
+
+
+@cli.command("wait")
+@click.argument("workflow_id")
+@click.option("--timeout", type=click.FloatRange(min=0.0), help="Maximum seconds to wait")
+@click.option(
+    "--poll-interval",
+    type=click.FloatRange(min=0.001),
+    default=2.0,
+    show_default=True,
+    help="Seconds between state polls",
+)
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def wait_cmd(
+    ctx: click.Context,
+    workflow_id: str,
+    timeout: float | None,
+    poll_interval: float,
+    output_json: bool,
+) -> None:
+    """Wait until a workflow terminates or parks on an open gate."""
+    try:
+        exit_code, payload = _wait_for_workflow(
+            state_dir=ctx.obj.get("state_dir"),
+            workflow_id=workflow_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        if output_json:
+            click.echo(json.dumps(payload))
+        else:
+            click.echo(_wait_summary(payload))
+        sys.exit(exit_code)
+    except _CLI_USER_ERROR_TYPES as e:
+        if output_json:
+            click.echo(json.dumps({"error": str(e)}))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
 
 
 @cli.command("watch")

--- a/packages/doeff-conductor/src/doeff_conductor/cli.py
+++ b/packages/doeff-conductor/src/doeff_conductor/cli.py
@@ -709,7 +709,7 @@ def wait_cmd(
         if output_json:
             click.echo(json.dumps({"error": str(e)}))
         else:
-            console.print(f"[red]Error:[/red] {e}")
+            click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
 

--- a/packages/doeff-conductor/src/doeff_conductor/types.py
+++ b/packages/doeff-conductor/src/doeff_conductor/types.py
@@ -37,6 +37,7 @@ class WorkflowStatus(Enum):
     BLOCKED = "blocked"
     DONE = "done"
     ERROR = "error"
+    STOPPED = "stopped"
     ABORTED = "aborted"
 
     def is_terminal(self) -> bool:
@@ -44,6 +45,7 @@ class WorkflowStatus(Enum):
         return self in (
             WorkflowStatus.DONE,
             WorkflowStatus.ERROR,
+            WorkflowStatus.STOPPED,
             WorkflowStatus.ABORTED,
         )
 

--- a/packages/doeff-conductor/tests/test_api.py
+++ b/packages/doeff-conductor/tests/test_api.py
@@ -263,6 +263,7 @@ class TestStopWorkflow:
         assert "agent-2" in stopped
 
         workflow = api.get_workflow(running_workflow)
+        assert workflow is not None
         assert workflow.status == WorkflowStatus.ABORTED
 
     def test_stop_specific_agent(self, api: ConductorAPI, running_workflow: str):
@@ -528,7 +529,9 @@ class TestRunWorkflow:
 
         assert handle.id == "spawn-run"
         assert handle.status == WorkflowStatus.DONE
-        assert list(handle.result_payload) == ["left", "right"]
+        result_payload = handle.result_payload
+        assert result_payload is not None
+        assert list(result_payload) == ["left", "right"]
 
     def test_run_workflow_does_not_unwrap_non_run_result_value_objects(
         self,
@@ -648,6 +651,10 @@ class TestWorkflowStatusHelpers:
     def test_is_terminal_error(self):
         """ERROR is a terminal status."""
         assert WorkflowStatus.ERROR.is_terminal()
+
+    def test_is_terminal_stopped(self):
+        """STOPPED is a terminal status."""
+        assert WorkflowStatus.STOPPED.is_terminal()
 
     def test_is_terminal_aborted(self):
         """ABORTED is a terminal status."""

--- a/packages/doeff-conductor/tests/test_cli.py
+++ b/packages/doeff-conductor/tests/test_cli.py
@@ -18,6 +18,7 @@ from doeff_conductor.cli import cli
 from doeff_conductor.types import (
     Issue,
     IssueStatus,
+    WorkflowStatus,
     Workspace,
 )
 
@@ -47,6 +48,59 @@ class TestCLIBase:
 
 class TestWorkflowCommands(TestCLIBase):
     """Tests for workflow-related CLI commands."""
+
+    def _write_workflow_meta(
+        self,
+        state_dir: Path,
+        workflow_id: str,
+        status: WorkflowStatus,
+    ) -> None:
+        workflow_dir = state_dir / "workflows" / workflow_id
+        workflow_dir.mkdir(parents=True)
+        now = datetime.now(timezone.utc)
+        workflow_data = {
+            "id": workflow_id,
+            "name": f"{workflow_id}-workflow",
+            "status": status.value,
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "workspaces": [],
+            "agents": [],
+        }
+        (workflow_dir / "meta.json").write_text(json.dumps(workflow_data))
+
+    def _write_open_gate(self, state_dir: Path, workflow_id: str) -> None:
+        run_state = {
+            "workflow_id": workflow_id,
+            "workflow_name": f"{workflow_id}-workflow",
+            "supervision": "autonomous",
+            "events": [],
+            "open_gates": [
+                {
+                    "gate_id": "gate-review",
+                    "workflow_id": workflow_id,
+                    "node_id": "review",
+                    "phase": None,
+                    "reason": "review required",
+                    "stakes": {},
+                    "options": [
+                        {
+                            "name": "proceed",
+                            "outcome": "resume",
+                            "description": "continue the run",
+                        },
+                        {
+                            "name": "abort",
+                            "outcome": "stop",
+                            "description": "stop the run",
+                        },
+                    ],
+                }
+            ],
+            "answered_gates": {},
+        }
+        run_state_path = state_dir / "workflows" / workflow_id / "run-state.json"
+        run_state_path.write_text(json.dumps(run_state))
 
     def test_ps_empty(self, runner: CliRunner, tmp_state_dir: Path):
         """List workflows when none exist."""
@@ -226,6 +280,119 @@ class TestWorkflowCommands(TestCLIBase):
         )
         assert result.exit_code == 0
         assert "abc12345" in result.output
+
+    def test_wait_done_exits_zero_with_json(self, runner: CliRunner, tmp_state_dir: Path):
+        """Wait returns success when the workflow is done."""
+        self._write_workflow_meta(tmp_state_dir, "done1234", WorkflowStatus.DONE)
+
+        result = runner.invoke(
+            cli, ["--state-dir", str(tmp_state_dir), "wait", "done1234", "--json"]
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "done"
+        assert data["gates"] == []
+        assert data["waited_seconds"] >= 0
+
+    def test_wait_error_exits_one_with_json(self, runner: CliRunner, tmp_state_dir: Path):
+        """Wait returns failure when the workflow errors."""
+        self._write_workflow_meta(tmp_state_dir, "err12345", WorkflowStatus.ERROR)
+
+        result = runner.invoke(
+            cli, ["--state-dir", str(tmp_state_dir), "wait", "err12345", "--json"]
+        )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "error"
+        assert data["gates"] == []
+
+    def test_wait_stopped_exits_one_with_json(self, runner: CliRunner, tmp_state_dir: Path):
+        """Wait returns failure when the workflow is stopped."""
+        self._write_workflow_meta(tmp_state_dir, "stop1234", WorkflowStatus.STOPPED)
+
+        result = runner.invoke(
+            cli, ["--state-dir", str(tmp_state_dir), "wait", "stop1234", "--json"]
+        )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "stopped"
+        assert data["gates"] == []
+
+    def test_wait_aborted_exposes_stopped_with_json(
+        self,
+        runner: CliRunner,
+        tmp_state_dir: Path,
+    ):
+        """Wait preserves compatibility with legacy aborted workflow metadata."""
+        self._write_workflow_meta(tmp_state_dir, "abort123", WorkflowStatus.ABORTED)
+
+        result = runner.invoke(
+            cli, ["--state-dir", str(tmp_state_dir), "wait", "abort123", "--json"]
+        )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["status"] == "stopped"
+        assert data["gates"] == []
+
+    def test_wait_parked_exits_two_with_gate_payload(
+        self,
+        runner: CliRunner,
+        tmp_state_dir: Path,
+    ):
+        """Wait returns attention-needed when the workflow has an open gate."""
+        self._write_workflow_meta(tmp_state_dir, "gate1234", WorkflowStatus.BLOCKED)
+        self._write_open_gate(tmp_state_dir, "gate1234")
+
+        result = runner.invoke(
+            cli, ["--state-dir", str(tmp_state_dir), "wait", "gate1234", "--json"]
+        )
+
+        assert result.exit_code == 2
+        data = json.loads(result.output)
+        assert data["status"] == "blocked"
+        assert data["gates"] == [
+            {"gate_id": "gate-review", "options": ["proceed", "abort"]}
+        ]
+
+    def test_wait_timeout_exits_three_with_json(self, runner: CliRunner, tmp_state_dir: Path):
+        """Wait returns timeout when no terminal or parked state arrives in time."""
+        self._write_workflow_meta(tmp_state_dir, "run12345", WorkflowStatus.RUNNING)
+
+        result = runner.invoke(
+            cli,
+            [
+                "--state-dir",
+                str(tmp_state_dir),
+                "wait",
+                "run12345",
+                "--timeout",
+                "0",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 3
+        data = json.loads(result.output)
+        assert data["status"] == "running"
+        assert data["gates"] == []
+
+    def test_wait_unknown_workflow_names_state_dir(
+        self,
+        runner: CliRunner,
+        tmp_state_dir: Path,
+    ):
+        """Wait fails loudly for unknown workflow ids and names the consulted state dir."""
+        result = runner.invoke(
+            cli, ["--state-dir", str(tmp_state_dir), "wait", "missing-workflow"]
+        )
+
+        assert result.exit_code == 1
+        assert "missing-workflow" in result.output
+        assert str(tmp_state_dir) in result.output
 
     def test_stop_workflow(self, runner: CliRunner, tmp_state_dir: Path):
         """Stop a workflow."""

--- a/packages/doeff-conductor/tests/test_types.py
+++ b/packages/doeff-conductor/tests/test_types.py
@@ -125,6 +125,7 @@ class TestWorkflowHandle:
         """Test terminal status detection."""
         assert WorkflowStatus.DONE.is_terminal()
         assert WorkflowStatus.ERROR.is_terminal()
+        assert WorkflowStatus.STOPPED.is_terminal()
         assert WorkflowStatus.ABORTED.is_terminal()
         assert not WorkflowStatus.RUNNING.is_terminal()
         assert not WorkflowStatus.PENDING.is_terminal()


### PR DESCRIPTION
## Summary
- Add `conductor wait WORKFLOW_ID` with `--timeout`, `--poll-interval`, and `--json`.
- Poll only `ConductorAPI.get_workflow()` metadata plus `list_open_gates()`; no runtime, tmux, agentd, or journal writes.
- Add `stopped` as a terminal workflow status while preserving legacy `aborted` metadata as `stopped` in wait output.
- Cover done/error/stopped/parked/timeout/unknown workflow behavior in CLI tests.

## Issue
- conductor-wait-verb

## Validation
- Failing test first: `uv run pytest packages/doeff-conductor/tests/test_cli.py -k wait -q` initially failed because `wait` did not exist.
- `uv run pytest packages/doeff-conductor/tests/test_cli.py -k wait -q` -> 7 passed.
- `uv run ruff check packages/doeff-conductor/src/doeff_conductor/cli.py packages/doeff-conductor/src/doeff_conductor/types.py packages/doeff-conductor/tests/test_cli.py packages/doeff-conductor/tests/test_types.py packages/doeff-conductor/tests/test_api.py` -> passed.
- `uv run pyright packages/doeff-conductor/src/doeff_conductor/cli.py packages/doeff-conductor/src/doeff_conductor/types.py packages/doeff-conductor/tests/test_cli.py packages/doeff-conductor/tests/test_types.py packages/doeff-conductor/tests/test_api.py` -> 0 errors.
- `uv run pytest packages/doeff-conductor/tests` -> 313 passed, 106 warnings.

## CLI acceptance evidence
Using a temp `--state-dir` with fabricated `meta.json` / `run-state.json`:

```text
wait done-cli --json      exit=0 output={"status": "done", "gates": [], "waited_seconds": 0.0}
wait err-cli --json       exit=1 output={"status": "error", "gates": [], "waited_seconds": 0.0}
wait stopped-cli --json   exit=1 output={"status": "stopped", "gates": [], "waited_seconds": 0.0}
wait gate-cli --json      exit=2 output={"status": "blocked", "gates": [{"gate_id": "gate-review", "options": ["proceed", "abort"]}], "waited_seconds": 0.0}
wait run-cli --timeout 0 --json exit=3 output={"status": "running", "gates": [], "waited_seconds": 0.0}
wait missing-workflow     exit=1 output=Error: Workflow not found: missing-workflow (state dir: /tmp/...)
```