### PR TITLE
[codex] Make agentd session listing tolerate bad rows

### DIFF
--- a/packages/doeff-agents/src/doeff_agents/__init__.py
+++ b/packages/doeff-agents/src/doeff_agents/__init__.py
@@ -19,6 +19,8 @@ _LAZY_EXPORTS = {
     "AgentdClientError": ".agentd_client",
     "AgentdPaths": ".agentd_client",
     "AgentdProtocolError": ".agentd_client",
+    "AgentdSessionList": ".agentd_client",
+    "AgentdSessionParseWarning": ".agentd_client",
     "AgentdUnavailableError": ".agentd_client",
     "LazyAgentdClient": ".agentd_client",
     "default_agentd_paths": ".agentd_client",

--- a/packages/doeff-agents/src/doeff_agents/adapters/base.py
+++ b/packages/doeff-agents/src/doeff_agents/adapters/base.py
@@ -14,6 +14,7 @@ class AgentType(Enum):
     CLAUDE = "claude"
     CODEX = "codex"
     GEMINI = "gemini"
+    GENERIC = "generic"
     CUSTOM = "custom"
 
 

--- a/packages/doeff-agents/src/doeff_agents/agentd_client.py
+++ b/packages/doeff-agents/src/doeff_agents/agentd_client.py
@@ -7,11 +7,12 @@ import os
 import shlex
 import socket
 import threading
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from doeff_agents.adapters.base import AgentType
 from doeff_agents.effects import (
     AgentSessionLifecycle,
     AgentSessionQuery,
@@ -19,6 +20,7 @@ from doeff_agents.effects import (
     AwaitOutcome,
     AwaitStatus,
 )
+from doeff_agents.monitor import SessionStatus
 
 RPC_ERR_AWAIT_TIMEOUT = -32000
 RPC_ERR_NO_SUCH_SESSION = -32001
@@ -58,6 +60,23 @@ class AgentdPaths:
     db_path: Path
     socket_path: Path
     log_path: Path
+
+
+@dataclass(frozen=True, kw_only=True)
+class AgentdSessionParseWarning:
+    """Details for one agentd session row that could not be parsed."""
+
+    session_name: str
+    field: str
+    raw_value: Any
+
+
+@dataclass(frozen=True)
+class AgentdSessionList:
+    """Parsed session.list result plus recoverable row parse failures."""
+
+    snapshots: tuple[AgentSessionSnapshot, ...]
+    warnings: tuple[AgentdSessionParseWarning, ...] = ()
 
 
 # RPC read-timeout contract.  The daemon BLOCKS on these methods by design:
@@ -172,10 +191,14 @@ class AgentdClient:
         self,
         query: AgentSessionQuery | None = None,
     ) -> tuple[AgentSessionSnapshot, ...]:
+        return self.list_sessions_with_warnings(query).snapshots
+
+    def list_sessions_with_warnings(
+        self,
+        query: AgentSessionQuery | None = None,
+    ) -> AgentdSessionList:
         result = self.request("session.list", _query_to_params(query))
-        if not isinstance(result, list):
-            raise AgentdProtocolError("session.list returned a non-list result")
-        return tuple(_snapshot_from_result(item) for item in result)
+        return _session_list_from_result(result)
 
     def capture_session(self, session_id: str, *, lines: int = 100) -> str:
         result = self.request("session.capture", {"session_id": session_id, "lines": lines})
@@ -342,6 +365,12 @@ class LazyAgentdClient:
     ) -> tuple[AgentSessionSnapshot, ...]:
         return self._resolve().list_sessions(query)
 
+    def list_sessions_with_warnings(
+        self,
+        query: AgentSessionQuery | None = None,
+    ) -> AgentdSessionList:
+        return self._resolve().list_sessions_with_warnings(query)
+
     def capture_session(self, session_id: str, *, lines: int = 100) -> str:
         return self._resolve().capture_session(session_id, lines=lines)
 
@@ -477,6 +506,108 @@ def _snapshot_from_result(result: Any) -> AgentSessionSnapshot:
     return AgentSessionSnapshot.from_dict(dict(result))
 
 
+def _session_list_from_result(result: Any) -> AgentdSessionList:
+    if not isinstance(result, list):
+        raise AgentdProtocolError("session.list returned a non-list result")
+
+    snapshots: list[AgentSessionSnapshot] = []
+    warnings: list[AgentdSessionParseWarning] = []
+    for index, item in enumerate(result):
+        warning = _snapshot_preflight_warning(item, index)
+        if warning is not None:
+            warnings.append(warning)
+            continue
+        try:
+            snapshots.append(_snapshot_from_result(item))
+        except (KeyError, TypeError, ValueError) as error:
+            warnings.append(_snapshot_parse_error_warning(item, index, error))
+    return AgentdSessionList(snapshots=tuple(snapshots), warnings=tuple(warnings))
+
+
+def _snapshot_preflight_warning(
+    item: Any,
+    index: int,
+) -> AgentdSessionParseWarning | None:
+    if not isinstance(item, Mapping):
+        return AgentdSessionParseWarning(
+            session_name=_fallback_session_name(item, index),
+            field="<row>",
+            raw_value=item,
+        )
+
+    for field, enum_value in (
+        ("agent_type", AgentType),
+        ("status", SessionStatus),
+    ):
+        warning = _enum_field_warning(item, index, field, enum_value, required=True)
+        if warning is not None:
+            return warning
+
+    return _enum_field_warning(
+        item,
+        index,
+        "lifecycle",
+        AgentSessionLifecycle,
+        required=False,
+    )
+
+
+def _enum_field_warning(
+    item: Mapping[str, Any],
+    index: int,
+    field: str,
+    enum_value: Callable[[str], object],
+    *,
+    required: bool,
+) -> AgentdSessionParseWarning | None:
+    if field not in item:
+        if required:
+            return AgentdSessionParseWarning(
+                session_name=_fallback_session_name(item, index),
+                field=field,
+                raw_value=None,
+            )
+        return None
+
+    raw_value = item[field]
+    try:
+        enum_value(str(raw_value))
+    except ValueError:
+        return AgentdSessionParseWarning(
+            session_name=_fallback_session_name(item, index),
+            field=field,
+            raw_value=raw_value,
+        )
+    return None
+
+
+def _snapshot_parse_error_warning(
+    item: Any,
+    index: int,
+    error: KeyError | TypeError | ValueError,
+) -> AgentdSessionParseWarning:
+    if isinstance(item, Mapping) and isinstance(error, KeyError):
+        field = str(error).strip("'")
+        return AgentdSessionParseWarning(
+            session_name=_fallback_session_name(item, index),
+            field=field,
+            raw_value=item.get(field),
+        )
+    return AgentdSessionParseWarning(
+        session_name=_fallback_session_name(item, index),
+        field="<snapshot>",
+        raw_value=item,
+    )
+
+
+def _fallback_session_name(item: Any, index: int) -> str:
+    if isinstance(item, Mapping):
+        session_name = item.get("session_name") or item.get("session_id")
+        if session_name is not None:
+            return str(session_name)
+    return f"<row {index}>"
+
+
 def _await_outcome_from_result(result: Mapping[str, Any]) -> AwaitOutcome:
     session = result.get("session")
     status = "exited"
@@ -516,6 +647,8 @@ __all__ = [
     "AgentdClientError",
     "AgentdPaths",
     "AgentdProtocolError",
+    "AgentdSessionList",
+    "AgentdSessionParseWarning",
     "AgentdUnavailableError",
     "LazyAgentdClient",
     "default_agentd_paths",

--- a/packages/doeff-agents/src/doeff_agents/cli.py
+++ b/packages/doeff-agents/src/doeff_agents/cli.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from doeff_agents.agentd_client import (
     AgentdClient,
     AgentdClientError,
+    AgentdSessionParseWarning,
     AgentdUnavailableError,
     ensure_agentd,
 )
@@ -72,6 +73,15 @@ def _print_agentd_request_error(error: AgentdClientError | OSError) -> None:
         console.print(f"[dim]{error}[/dim]")
         return
     console.print(f"[red]Error:[/red] {error}")
+
+
+def _print_agentd_parse_warnings(warnings: tuple[AgentdSessionParseWarning, ...]) -> None:
+    for warning in warnings:
+        click.echo(
+            "Warning: Skipping unparseable agentd session "
+            f"{warning.session_name}: {warning.field}={warning.raw_value!r}",
+            err=True,
+        )
 
 
 def _resolve_agentd_session(
@@ -237,10 +247,13 @@ def ps_command(show_all: bool) -> None:
     """List doeff-agents sessions."""
     client = _agentd_client_or_exit()
     try:
-        sessions = client.list_sessions()
+        session_list = client.list_sessions_with_warnings()
     except (AgentdClientError, OSError) as error:
         _print_agentd_request_error(error)
         sys.exit(1)
+
+    _print_agentd_parse_warnings(session_list.warnings)
+    sessions = session_list.snapshots
 
     if not sessions:
         console.print("No agentd sessions found.")

--- a/packages/doeff-agents/tests/test_agentd_client.py
+++ b/packages/doeff-agents/tests/test_agentd_client.py
@@ -31,6 +31,7 @@ from doeff_agents import (
     default_agentd_paths,
     ensure_agentd,
 )
+from doeff_agents.agentd_client import AgentdSessionList, AgentdSessionParseWarning
 
 
 @pytest.fixture
@@ -131,6 +132,62 @@ def test_agentd_client_launch_sends_interactive_lifecycle(tmp_path: Path) -> Non
     assert snapshot.lifecycle == AgentSessionLifecycle.INTERACTIVE
     assert server.requests[0]["method"] == "session.launch"
     assert server.requests[0]["params"]["lifecycle"] == "interactive"
+
+
+def test_agentd_client_list_sessions_accepts_agentd_generic_rows() -> None:
+    def handle(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "id": request["id"],
+            "ok": True,
+            "result": [
+                _snapshot_payload(session_id="raw-command", agent_type="generic"),
+                _snapshot_payload(session_id="codex-agent", agent_type="codex"),
+            ],
+        }
+
+    with (
+        tempfile.TemporaryDirectory(prefix="agentd-", dir="/tmp") as temp_dir,
+        OneShotAgentdServer(Path(temp_dir) / "agentd.sock", handle) as server,
+    ):
+        client = AgentdClient(server.socket_path, timeout=2.0)
+        snapshots = client.list_sessions()
+
+    assert [snapshot.session_id for snapshot in snapshots] == ["raw-command", "codex-agent"]
+    assert snapshots[0].agent_type == AgentType.GENERIC
+    assert server.requests[0]["method"] == "session.list"
+
+
+def test_agentd_client_list_sessions_with_warnings_skips_unknown_agent_type() -> None:
+    def handle(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "id": request["id"],
+            "ok": True,
+            "result": [
+                _snapshot_payload(session_id="good", agent_type="codex"),
+                _snapshot_payload(
+                    session_id="bad",
+                    agent_type="future-agent",
+                ),
+            ],
+        }
+
+    with (
+        tempfile.TemporaryDirectory(prefix="agentd-", dir="/tmp") as temp_dir,
+        OneShotAgentdServer(Path(temp_dir) / "agentd.sock", handle) as server,
+    ):
+        client = AgentdClient(server.socket_path, timeout=2.0)
+        result = client.list_sessions_with_warnings()
+
+    assert isinstance(result, AgentdSessionList)
+    assert [snapshot.session_id for snapshot in result.snapshots] == ["good"]
+    assert result.warnings == (
+        AgentdSessionParseWarning(
+            session_name="bad",
+            field="agent_type",
+            raw_value="future-agent",
+        ),
+    )
+    assert server.requests[0]["method"] == "session.list"
 
 
 def test_agentd_client_raises_daemon_error() -> None:

--- a/packages/doeff-agents/tests/test_agentd_client.py
+++ b/packages/doeff-agents/tests/test_agentd_client.py
@@ -157,6 +157,13 @@ def test_agentd_client_list_sessions_accepts_agentd_generic_rows() -> None:
     assert server.requests[0]["method"] == "session.list"
 
 
+def test_generic_agent_type_has_no_registered_adapter() -> None:
+    from doeff_agents.session import get_adapter
+
+    with pytest.raises(ValueError, match="No adapter registered"):
+        get_adapter(AgentType.GENERIC)
+
+
 def test_agentd_client_list_sessions_with_warnings_skips_unknown_agent_type() -> None:
     def handle(request: Mapping[str, Any]) -> Mapping[str, Any]:
         return {

--- a/packages/doeff-agents/tests/test_cli_agentd.py
+++ b/packages/doeff-agents/tests/test_cli_agentd.py
@@ -12,13 +12,20 @@ from click.testing import CliRunner
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from doeff_agents import AgentdUnavailableError, AgentSessionSnapshot, AgentType, SessionStatus
+from doeff_agents.agentd_client import AgentdSessionList, AgentdSessionParseWarning
 from doeff_agents import cli as cli_module
 from doeff_agents.cli import cli
 
 
 class FakeAgentdClient:
-    def __init__(self, snapshots: list[AgentSessionSnapshot]) -> None:
+    def __init__(
+        self,
+        snapshots: list[AgentSessionSnapshot],
+        *,
+        warnings: tuple[AgentdSessionParseWarning, ...] = (),
+    ) -> None:
         self.snapshots = snapshots
+        self.warnings = warnings
         self.calls: list[tuple[str, Any]] = []
         self.sent_messages: list[tuple[str, str]] = []
         self.captures: list[tuple[str, int]] = []
@@ -33,6 +40,10 @@ class FakeAgentdClient:
     def list_sessions(self, query: Any = None) -> tuple[AgentSessionSnapshot, ...]:
         self.calls.append(("list_sessions", query))
         return tuple(self.snapshots)
+
+    def list_sessions_with_warnings(self, query: Any = None) -> AgentdSessionList:
+        self.calls.append(("list_sessions_with_warnings", query))
+        return AgentdSessionList(snapshots=tuple(self.snapshots), warnings=self.warnings)
 
     def capture_session(self, session_id: str, *, lines: int = 100) -> str:
         self.captures.append((session_id, lines))
@@ -67,7 +78,32 @@ def test_ps_lists_agentd_sessions_not_tmux(
     assert "agentd-s1" in result.output
     assert "agentd-tmux" in result.output
     assert "running" in result.output
-    assert client.calls == [("list_sessions", None)]
+    assert client.calls == [("list_sessions_with_warnings", None)]
+
+
+def test_ps_warns_about_unparseable_agentd_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    warning = AgentdSessionParseWarning(
+        session_name="raw-session",
+        field="agent_type",
+        raw_value="future-agent",
+    )
+    client = FakeAgentdClient(
+        [_snapshot(session_id="agentd-s1", session_name="agentd-tmux")],
+        warnings=(warning,),
+    )
+    monkeypatch.setattr(cli_module, "ensure_agentd", lambda: client)
+
+    result = runner.invoke(cli, ["ps"])
+
+    assert result.exit_code == 0
+    assert "agentd-s1" in result.output
+    warning_output = result.stderr or result.output
+    assert "raw-session" in warning_output
+    assert "agent_type" in warning_output
+    assert "future-agent" in warning_output
 
 
 def test_output_captures_via_agentd(

--- a/packages/doeff-agents/tests/test_cli_agentd.py
+++ b/packages/doeff-agents/tests/test_cli_agentd.py
@@ -12,8 +12,8 @@ from click.testing import CliRunner
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from doeff_agents import AgentdUnavailableError, AgentSessionSnapshot, AgentType, SessionStatus
-from doeff_agents.agentd_client import AgentdSessionList, AgentdSessionParseWarning
 from doeff_agents import cli as cli_module
+from doeff_agents.agentd_client import AgentdSessionList, AgentdSessionParseWarning
 from doeff_agents.cli import cli
 
 


### PR DESCRIPTION
## Summary

Fixes agents-ps-unknown-agent-type-crash.

`agent_type=generic` is legitimate agentd data, not only legacy corruption: `packages/doeff-agentd/src/main.rs:895` documents `generic` as an explicit-command escape hatch, and `packages/doeff-agentd/src/main.rs:1251` persists `params.agent_type` into the snapshot row.

Changes:
- Add `AgentType.GENERIC` so valid agentd raw-command sessions render in `doeff-agents ps`.
- Add `AgentdSessionList` and `AgentdSessionParseWarning` so `session.list` parsing returns every parseable row plus typed warnings for bad rows.
- Keep single-snapshot parse strict; launch / adapter-required paths still fail fast because `GENERIC` has no registered adapter.
- Print each `ps` parse warning to stderr as one line with session name, offending field, and raw value.

## Verification

TDD red step:
- Added repro tests first and confirmed they failed before implementation with missing `AgentdSessionList` / `AgentdSessionParseWarning` imports.

Checks run:
- `uv run ruff check packages/doeff-agents/src/doeff_agents/agentd_client.py packages/doeff-agents/src/doeff_agents/cli.py packages/doeff-agents/tests/test_agentd_client.py packages/doeff-agents/tests/test_cli_agentd.py` -> passed
- `uv run pyright packages/doeff-agents/src/doeff_agents/agentd_client.py packages/doeff-agents/src/doeff_agents/cli.py` -> 0 errors
- `uv run pytest packages/doeff-agents/tests/test_agentd_client.py::test_generic_agent_type_has_no_registered_adapter packages/doeff-agents/tests/test_agentd_client.py::test_agentd_client_list_sessions_accepts_agentd_generic_rows packages/doeff-agents/tests/test_agentd_client.py::test_agentd_client_list_sessions_with_warnings_skips_unknown_agent_type packages/doeff-agents/tests/test_cli_agentd.py::test_ps_warns_about_unparseable_agentd_rows` -> 4 passed
- `uv run pytest packages/doeff-agents` -> 126 passed, 1 skipped

CLI evidence:
- The default local `uv run doeff-agents ps` could not reach a daemon in this isolated worktree environment (`/run/user/1000/doeff/agentd.sock` absent), so I started a temporary agentd with a temporary state/runtime directory and seeded one valid `generic` row plus one invalid `future-agent` row.
- `XDG_STATE_HOME=/tmp/doeff-agentd-verify-2db994/state XDG_RUNTIME_DIR=/tmp/doeff-agentd-verify-2db994/runtime uv run doeff-agents ps 2>&1` exited 0 and printed:
  - `Warning: Skipping unparseable agentd session doeff-review-verify-unknown: agent_type='future-agent'`
  - an Agent Sessions table containing the parseable `generic` row.

Temporary agentd state and process were removed after verification.