### PR TITLE
[codex] Fix conductor workspace runtime excludes

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -221,6 +221,18 @@ rules:
         - /packages/doeff-conductor/src/doeff_conductor/handlers/git_handler.py
         - /packages/doeff-conductor/src/doeff_conductor/effects/git.py
 
+  - id: conductor-workspace-runtime-exclude-not-gitignore
+    languages: [generic]
+    severity: ERROR
+    message: >
+      conductor-workspace-exclude-not-gitignore: workspace runtime state must be
+      excluded via `git rev-parse --git-path info/exclude` from the worktree.
+      Never mutate the tracked workspace .gitignore during materialization.
+    pattern-regex: '\.gitignore'
+    paths:
+      include:
+        - /packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
+
   - id: http-request-handlers-use-defhandler
     languages: [python]
     severity: ERROR

--- a/packages/doeff-conductor/docs/spec-workflow-orchestration.md
+++ b/packages/doeff-conductor/docs/spec-workflow-orchestration.md
@@ -576,11 +576,12 @@ because where to pause is a trust/stakes judgment extrinsic to the task:
 4. **Calibration state store** — cross-run, level-triggered; v1 ships
    manual sampling rates + escape recording only (no autonomous rate
    adjustment).
-5. **Runtime auto-commit captures session state — fixed e206be17.**
-   Conductor-created workspaces now install workspace-level `.gitignore`
-   entries for in-worktree runtime state (`.agent-home/`). The ignore lives
-   at workspace initialization, so post-agent-node `Commit`, manual
-   `git add -A`, and future workspace consumers all share the same behavior.
+5. **Runtime auto-commit captures session state — fixed e206be17 and
+   conductor-workspace-exclude-not-gitignore.** Conductor-created workspaces
+   now install repository-local `info/exclude` entries for in-worktree runtime
+   state (`.agent-home/`). The exclude lives at workspace initialization, so
+   post-agent-node `Commit`, manual `git add -A`, and future workspace
+   consumers all share the same behavior without dirtying tracked files.
 6. **Await budget has no owning axis.** `AgentTask.timeout_seconds`
    exists but nothing sets it; the effective default lives in L1
    (3600s after the 2026-06-11 correction; was 600s, which burned a

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py
@@ -43,7 +43,7 @@ class WorkspaceStateError(RuntimeError):
     """Raised when on-disk workspace state contradicts its identity."""
 
 
-WORKSPACE_RUNTIME_STATE_GITIGNORE_ENTRIES: tuple[str, ...] = (
+WORKSPACE_RUNTIME_STATE_EXCLUDE_ENTRIES: tuple[str, ...] = (
     ".agent-home/",
 )
 
@@ -53,7 +53,6 @@ class _WorkspaceMaterialization:
     workspace: Workspace
     path: Path
     base_commit: str
-    runtime_ignore_snapshot: str | None = None
 
 
 def _get_workspace_base_dir() -> Path:
@@ -66,11 +65,24 @@ def _branch_for(workspace_id: str) -> str:
     return f"conductor/{workspace_id}"
 
 
-def _ensure_runtime_state_ignored(materialized_path: Path) -> str | None:
+def _git_metadata_path(materialized_path: Path, pathspec: str) -> Path:
+    """Resolve a git metadata path from the worktree that owns it."""
+    result = run_git(
+        ["git", "rev-parse", "--git-path", pathspec],
+        cwd=materialized_path,
+    )
+    metadata_path = Path(result.stdout.strip())
+    if metadata_path.is_absolute():
+        return metadata_path
+    return materialized_path / metadata_path
+
+
+def _ensure_runtime_state_ignored(materialized_path: Path) -> None:
     """Ensure conductor-created workspaces ignore in-worktree runtime state."""
-    gitignore_path: Path = materialized_path / ".gitignore"
+    exclude_path: Path = _git_metadata_path(materialized_path, "info/exclude")
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        existing_text: str = gitignore_path.read_text(encoding="utf-8")
+        existing_text: str = exclude_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         existing_text = ""
 
@@ -81,19 +93,18 @@ def _ensure_runtime_state_ignored(materialized_path: Path) -> str | None:
     }
     missing_entries: list[str] = [
         entry
-        for entry in WORKSPACE_RUNTIME_STATE_GITIGNORE_ENTRIES
+        for entry in WORKSPACE_RUNTIME_STATE_EXCLUDE_ENTRIES
         if entry not in existing_entries and f"/{entry}" not in existing_entries
     ]
     if not missing_entries:
-        return None
+        return
 
     updated_text: str = existing_text
     if updated_text and not updated_text.endswith("\n"):
         updated_text += "\n"
     for entry in missing_entries:
         updated_text += f"{entry}\n"
-    gitignore_path.write_text(updated_text, encoding="utf-8")
-    return updated_text
+    exclude_path.write_text(updated_text, encoding="utf-8")
 
 
 def _status_path_from_porcelain_line(line: str) -> str:
@@ -104,34 +115,29 @@ def _status_path_from_porcelain_line(line: str) -> str:
     return path
 
 
-def _has_only_recorded_runtime_ignore_changes(
-    materialization: _WorkspaceMaterialization,
-) -> bool:
-    """Return true when the only dirty file is our own workspace ignore write."""
-    if materialization.runtime_ignore_snapshot is None:
-        return False
+def _is_runtime_state_path(path: str) -> bool:
+    """Return true when a git status path belongs to conductor runtime state."""
+    return any(
+        path == entry.rstrip("/") or path.startswith(entry)
+        for entry in WORKSPACE_RUNTIME_STATE_EXCLUDE_ENTRIES
+    )
 
+
+def _has_only_ignored_runtime_state(materialized_path: Path) -> bool:
+    """Return true when only conductor runtime state is hidden from porcelain."""
     status_result = run_git(
-        ["git", "status", "--porcelain"],
-        cwd=materialization.path,
+        ["git", "status", "--porcelain", "--ignored"],
+        cwd=materialized_path,
     )
     status_lines: list[str] = [
         line
         for line in status_result.stdout.splitlines()
         if line
     ]
-    if not status_lines:
-        return False
-    if any(_status_path_from_porcelain_line(line) != ".gitignore" for line in status_lines):
-        return False
-
-    try:
-        current_gitignore: str = (materialization.path / ".gitignore").read_text(
-            encoding="utf-8"
-        )
-    except FileNotFoundError:
-        return False
-    return current_gitignore == materialization.runtime_ignore_snapshot
+    return all(
+        line[:2] == "!!" and _is_runtime_state_path(_status_path_from_porcelain_line(line))
+        for line in status_lines
+    )
 
 
 class WorkspaceHandler:
@@ -253,7 +259,7 @@ class WorkspaceHandler:
                 log_path=log_path,
             )
 
-        runtime_ignore_snapshot: str | None = _ensure_runtime_state_ignored(materialized_path)
+        _ensure_runtime_state_ignored(materialized_path)
 
         workspace = Workspace(
             id=workspace_id,
@@ -267,7 +273,6 @@ class WorkspaceHandler:
             workspace=workspace,
             path=materialized_path,
             base_commit=get_current_commit(materialized_path),
-            runtime_ignore_snapshot=runtime_ignore_snapshot,
         )
         return workspace
 
@@ -366,8 +371,8 @@ class WorkspaceHandler:
             return False
 
         args: list[str] = ["git", "worktree", "remove"]
-        force_remove: bool = effect.force or _has_only_recorded_runtime_ignore_changes(
-            materialization
+        force_remove: bool = effect.force or _has_only_ignored_runtime_state(
+            materialization.path
         )
         if force_remove:
             args.append("--force")

--- a/packages/doeff-conductor/tests/test_workspace_handler.py
+++ b/packages/doeff-conductor/tests/test_workspace_handler.py
@@ -55,6 +55,20 @@ def _branches(repo_path: Path) -> set[str]:
     return {line for line in result.stdout.splitlines() if line}
 
 
+def _git_exclude_path(worktree_path: Path) -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-path", "info/exclude"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    exclude_path = Path(result.stdout.strip())
+    if exclude_path.is_absolute():
+        return exclude_path
+    return worktree_path / exclude_path
+
+
 class TestWorkspaceHandler:
     @pytest.fixture
     def git_repo(self, tmp_path: Path) -> Path:
@@ -87,7 +101,7 @@ class TestWorkspaceHandler:
         assert "path" not in workspace.to_dict()
         assert handler.resolve_path(workspace).exists()
 
-    def test_create_workspace_installs_runtime_state_gitignore(
+    def test_create_workspace_installs_runtime_state_exclude_idempotently(
         self,
         handler: WorkspaceHandler,
     ) -> None:
@@ -96,8 +110,26 @@ class TestWorkspaceHandler:
         )
         materialized_path: Path = handler.resolve_path(workspace)
 
-        gitignore_lines: list[str] = (materialized_path / ".gitignore").read_text().splitlines()
-        assert ".agent-home/" in gitignore_lines
+        status_before_runtime_state: subprocess.CompletedProcess[str] = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=materialized_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert status_before_runtime_state.stdout == ""
+        assert not (materialized_path / ".gitignore").exists()
+
+        exclude_path: Path = _git_exclude_path(materialized_path)
+        exclude_lines: list[str] = exclude_path.read_text().splitlines()
+        assert exclude_lines.count(".agent-home/") == 1
+
+        same_workspace: Workspace = handler.handle_create_workspace(
+            CreateWorkspace(workspace_id="ws-ignore")
+        )
+        assert handler.resolve_path(same_workspace) == materialized_path
+        exclude_lines_after_second_init: list[str] = exclude_path.read_text().splitlines()
+        assert exclude_lines_after_second_init.count(".agent-home/") == 1
 
         agent_state_path: Path = materialized_path / ".agent-home" / "session.json"
         agent_state_path.parent.mkdir()
@@ -144,6 +176,7 @@ class TestWorkspaceHandler:
         )
         committed_paths: list[str] = show_result.stdout.splitlines()
         assert "feature.txt" in committed_paths
+        assert ".gitignore" not in committed_paths
         assert ".agent-home/session.json" not in committed_paths
 
     def test_create_workspace_requires_identity(self, handler: WorkspaceHandler) -> None:


### PR DESCRIPTION
## Summary

- Stop mutating tracked workspace `.gitignore` during conductor workspace materialization.
- Resolve the repository-local exclude path from the worktree with `git rev-parse --git-path info/exclude`, create parent directories, and append `.agent-home/` idempotently.
- Update workspace handler tests, docs, and add a semgrep guard that prevents this `.gitignore` write path from returning.

## Root Cause

`_ensure_runtime_state_ignored` wrote conductor runtime-state ignores into the materialized worktree's tracked `.gitignore`. Fresh workspaces were therefore dirty before any agent ran, and auto-commit could publish `.gitignore` noise into work branches and PRs.

## Acceptance Evidence

- New regression test first failed before implementation: init produced `?? .gitignore`, and auto-commit included `.gitignore` in committed paths.
- `uv run pytest packages/doeff-conductor/tests/test_workspace_handler.py::TestWorkspaceHandler::test_create_workspace_installs_runtime_state_exclude_idempotently packages/doeff-conductor/tests/test_workspace_handler.py::TestWorkspaceHandler::test_workspace_auto_commit_excludes_runtime_agent_home` -> `2 passed` after the fix.
- `uv run pytest packages/doeff-conductor/tests` -> `305 passed, 106 warnings`.
- `uv run ruff check packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py packages/doeff-conductor/tests/test_workspace_handler.py` -> `All checks passed!`.
- `uv tool run semgrep --error --config .semgrep.yaml packages/doeff-conductor/src/doeff_conductor/handlers/workspace_handler.py packages/doeff-conductor/src/doeff_conductor/handlers/git_handler.py packages/doeff-conductor/src/doeff_conductor/effects/git.py` -> `0 findings`.
- `git diff --check` -> clean.

Refs: conductor-workspace-exclude-not-gitignore