### PR TITLE
[codex] Fix conductor docs CLI drift

### DIFF
--- a/packages/doeff-conductor/README.md
+++ b/packages/doeff-conductor/README.md
@@ -9,7 +9,7 @@ doeff-conductor provides a unified orchestration layer combining:
 - **Issue-driven agent workflows**: Create issues, dispatch agents, track progress
 - **Git workspace management**: Isolated workspaces for each agent
 - **Multi-agent DAG execution**: Parallel agents with merge points
-- **Full CLI for monitoring and control**: run, ps, watch, attach, logs, stop
+- **Full CLI for monitoring and control**: run, ps, show, watch, stop, resume
 
 ## Installation
 
@@ -119,16 +119,14 @@ def multi_agent_pr(issue):
 # Workflow execution (workflow files are .hy modules in the Hy macro DSL)
 conductor run <template|file.hy> [--issue FILE] [--params JSON] [--watch]
 conductor ps [--status running|blocked|done]
-conductor show <workflow-id>
-conductor watch <workflow-id> [--agent NAME]
-conductor attach <workflow-id>[:<agent>]
-conductor send <workflow-id>:<agent> <message>
+conductor show <workflow-id> [--since SEQ] [--json]
+conductor watch <workflow-id> [--json]
 conductor stop <workflow-id> [--agent NAME]
-conductor logs <workflow-id>[:<agent>] [-f] [-n LINES]
+conductor resume <workflow-id> [--params JSON] [--json]
 
 # Issue management  
 conductor issue create <title> [--body FILE|STRING] [--labels L1,L2]
-conductor issue list [--status open|resolved|all]
+conductor issue list [--status open|in_progress|resolved|closed]
 conductor issue show <id>
 conductor issue resolve <id> [--pr URL]
 
@@ -139,7 +137,6 @@ conductor workspace cleanup [--dry-run] [--older-than DAYS]
 # Templates
 conductor template list
 conductor template show <name>
-conductor template new <name>
 ```
 
 ## Effects Catalog
@@ -194,17 +191,17 @@ Pre-built workflow templates:
 |                         doeff-conductor                              |
 +---------------------------------------------------------------------+
 |  CLI Layer                                                           |
-|  - run, ps, show, watch, attach, stop, logs                         |
+|  - run, ps, show, watch, stop, resume                              |
 |  - issue create/list/show/resolve                                   |
 |  - workspace list/cleanup                                           |
-|  - template list/show/run                                           |
+|  - template list/show                                               |
 +---------------------------------------------------------------------+
 |  Effects                                                             |
 |  +----------+ +----------+ +----------+ +----------+                |
 |  | Workspace | |  Issue   | |  Agent   | |   Git    |                |
 |  | Create   | | Create   | | Agent    | | Commit   |                |
-|  | Merge    | | List     | | Send     | | Push     |                |
-|  | Delete   | | Resolve  | | Capture  | | CreatePR |                |
+|  | Merge    | | List     | |AgentTask | | Push     |                |
+|  | Delete   | | Resolve  | |AgentEffect| |CreatePR |                |
 |  +----------+ +----------+ +----------+ +----------+                |
 +---------------------------------------------------------------------+
 |  Dependencies                                                        |

--- a/packages/doeff-conductor/docs/api.md
+++ b/packages/doeff-conductor/docs/api.md
@@ -545,11 +545,7 @@ from doeff_conductor import AgentHandler
 handler = AgentHandler()
 
 # Methods
-handler.handle_run_agent(effect)
-handler.handle_spawn_agent(effect)
-handler.handle_send_message(effect)
-handler.handle_wait_for_status(effect)
-handler.handle_capture_output(effect)
+handler.handle_agent(effect)
 ```
 
 #### `GitHandler`

--- a/packages/doeff-conductor/docs/migration-from-orch.md
+++ b/packages/doeff-conductor/docs/migration-from-orch.md
@@ -23,9 +23,9 @@ This guide helps users of the Go `orch` CLI migrate to `doeff-conductor`.
 | `orch ps` | `conductor ps` | Same syntax |
 | `orch show <id>` | `conductor show <id>` | Same syntax |
 | `orch watch <id>` | `conductor watch <id>` | Same syntax |
-| `orch attach <id>` | `conductor attach <id>` | Same syntax |
+| `orch attach <id>` | `conductor watch <id>` | No interactive attach command; watch is the workflow-level progress view |
 | `orch stop <id>` | `conductor stop <id>` | Same syntax |
-| `orch logs <id>` | `conductor logs <id>` | Same syntax |
+| `orch logs <id>` | `conductor show <id> --since N` | No logs command; show/watch expose workflow progress |
 
 ### Issue Management
 
@@ -62,7 +62,7 @@ This guide helps users of the Go `orch` CLI migrate to `doeff-conductor`.
 | Type checking | Runtime | Static (pyright) |
 | Parallel agents | Supported | Supported via Gather |
 | Human-in-loop | Supported | Supported |
-| JSON output | `--json` | `--json` |
+| JSON output | `--json` | Available on selected commands such as `ps`, `show`, `watch`, and `issue list` |
 | State storage | `~/.local/state/orch/` | `~/.local/state/doeff-conductor/` |
 
 ## Migration Steps
@@ -121,7 +121,7 @@ AGENT_SCHEMA = {
 
 @do
 def my_workflow(issue):
-    env = yield CreateWorkspace(issue=issue)
+    env = yield CreateWorkspace(issue=issue, workspace_id=f"{issue.id.lower()}-impl")
     yield Agent(AgentTask(
         run_id=issue.id,
         node_id="implement",
@@ -207,12 +207,12 @@ def my_workflow():
 
 ```python
 from doeff import do, EffectGenerator
-from doeff_conductor import Issue, PRHandle
+from doeff_conductor import CreatePR, CreateWorkspace, Issue, PRHandle
 
 @do
 def typed_workflow(issue: Issue) -> EffectGenerator[PRHandle]:
     # Type checker knows env is Workspace
-    env = yield CreateWorkspace(issue=issue)
+    env = yield CreateWorkspace(issue=issue, workspace_id=f"{issue.id.lower()}-typed")
     # Type checker knows pr is PRHandle
     pr = yield CreatePR(workspace=env, title=issue.title)
     return pr

--- a/packages/doeff-conductor/docs/tutorial.md
+++ b/packages/doeff-conductor/docs/tutorial.md
@@ -136,8 +136,8 @@ conductor template show basic_pr
 ### Using a Template Programmatically
 
 ```python
-from doeff import production_handlers, run
 from doeff_conductor import Issue, IssueStatus, basic_pr
+from doeff_conductor.handlers import mock_handlers, run_sync
 
 # Create an issue
 issue = Issue(
@@ -147,16 +147,10 @@ issue = Issue(
     status=IssueStatus.OPEN,
 )
 
-# Use the template
-program = basic_pr(issue)
-
-# Run with handlers (see full handler setup in examples)
-# workflow_handler = ...  # @do handler with isinstance branches
-# preset_handler = preset_handlers()
-result = run(
-    program,
-    handlers=[preset_handler, workflow_handler, *production_handlers()],
-)
+# Run with mock handlers (see examples for production handler setup)
+result = run_sync(basic_pr(issue), scheduled_handlers=mock_handlers())
+if result.is_err:
+    raise result.error
 print(f"Created PR: {result.value.url}")
 ```
 
@@ -204,8 +198,8 @@ conductor show abc123
 # Watch real-time progress
 conductor watch abc123
 
-# View logs
-conductor logs abc123
+# Show progress events after a known sequence number
+conductor show abc123 --since 10
 ```
 
 ### Manage Issues
@@ -224,7 +218,7 @@ conductor issue resolve ISSUE-001 --pr https://github.com/.../pull/42
 ### JSON Output for Scripting
 
 ```bash
-# All commands support --json
+# JSON-capable commands include ps, show, watch, issue list, and template list
 conductor ps --json | jq '.[] | select(.status == "running")'
 conductor issue list --json | jq 'length'
 ```

--- a/packages/doeff-conductor/docs/validation-2026-06-11.md
+++ b/packages/doeff-conductor/docs/validation-2026-06-11.md
@@ -16,7 +16,7 @@ state dirs, pane captures, or plan/validate outputs. ✅ = validated live,
 | `run` end-to-end real workers | ✅ | sample-hardening (run 6), effort-axis-review3 |
 | Profile semantic names → adapter binding | ✅ | frontier→claude, cheap→codex observed |
 | model=None → CLI default | ✅ | Fable 5 via baked agent-home settings |
-| effort = profile axis → fingerprint | ✅ | effort-axis merge c37f5534; live argv pending daemon rebuild |
+| effort = profile axis → fingerprint | 🧪 | effort-axis merge c37f5534; live argv delivery was pending for this §1 check |
 | Routing discipline (frontier for invariants) | ✅ | A/B evidence + tonight's runs |
 
 ## §4 DSL + loader
@@ -83,7 +83,8 @@ state dirs, pane captures, or plan/validate outputs. ✅ = validated live,
 
 | Layer | Tool | Status |
 |---|---|---|
-| L3 workflows | `conductor ps / show [--since] / watch / stop / resume` | ✅ works (live-tested ps, show, show --json) |
+| L3 workflows (live-tested) | `conductor ps / show / show --json` | ✅ works (live-tested ps, show, show --json) |
+| L3 workflows (implemented; live probe pending) | `conductor show --since / watch / stop / resume` | ⬜ CLI surface exists; no live workflow probe recorded in this matrix |
 | L2 sessions | `doeff-agents ps / watch / output / send / attach` | ❌→✅ now query `doeff-agentd` RPC (`session.list/get/capture/send`) as SSOT; daemon-down path is explicit fail-fast |
 | L1 daemon | `doeff-agentd` | serve only — no client subcommands; session table reachable only via sqlite |
 


### PR DESCRIPTION
## Summary

- Align conductor README/tutorial/migration CLI examples with the current `uv run conductor --help` surface.
- Remove or replace stale docs references to nonexistent `conductor attach`, `conductor send`, `conductor logs`, `conductor template new`, and `issue list --status all`.
- Update API docs/snippets for current conductor APIs: `AgentHandler.handle_agent`, `CreateWorkspace(..., workspace_id=...)`, and `run_sync(..., scheduled_handlers=...)`.
- Downgrade/scope validation-matrix claims where the recorded evidence did not support a broad ✅.

References: `conductor-docs-current-cli-sweep`.

## Verification

CLI/API authority checks run:

- `uv run conductor --help`
- `uv run conductor run --help`
- `uv run conductor ps --help`
- `uv run conductor show --help`
- `uv run conductor watch --help`
- `uv run conductor stop --help`
- `uv run conductor resume --help`
- `uv run conductor issue --help`
- `uv run conductor issue create --help`
- `uv run conductor issue list --help`
- `uv run conductor issue show --help`
- `uv run conductor issue resolve --help`
- `uv run conductor workspace --help`
- `uv run conductor workspace list --help`
- `uv run conductor workspace cleanup --help`
- `uv run conductor template --help`
- `uv run conductor template list --help`
- `uv run conductor template show --help`
- `uv run conductor env describe --help`
- `uv run conductor gate list --help`
- `uv run conductor gates --help`
- `uv run conductor answer --help`
- `uv run conductor plan --help`
- `uv run conductor validate --help`
- `uv run conductor template list --json`

Snippet/import checks run:

- Tutorial `basic_pr` snippet with `mock_handlers()` executed and produced `https://github.com/mock/repo/pull/1`.
- Migration guide workflow snippets import-checked and constructed successfully.
- `AgentHandler().handle_agent` existence checked.

Search/diff checks run:

- Target-file `rg` check for removed stale patterns: no matches.
- `git diff --check origin/main..HEAD`.

Tests run:

- `uv run pytest packages/doeff-conductor/tests/test_cli.py` — 41 passed.
- `uv run pytest packages/doeff-conductor/tests/test_templates.py` — 35 passed, 24 existing deprecation warnings.

Known unrelated result:

- `uv run pytest tests/test_docs_withhandler_contract.py` still fails on existing `docs/crystallization/algebra-draft.md` `WithHandler(` references outside this issue's target files. Those files were not modified because the issue excludes unrelated docs work.