### PR TITLE
[codex] Fix race waiter registration

### DIFF
--- a/packages/doeff-core-effects/doeff_core_effects/scheduler.py
+++ b/packages/doeff-core-effects/doeff_core_effects/scheduler.py
@@ -230,7 +230,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
     tasks = {}           # tid → {status, result, program, priority}
     promises = {}        # pid → {status, result}
     semaphores = {}      # sid → {permits, max_permits, waiters: deque of k}
-    waiters = {}         # waitable_key → [(type, k, ...)] or gather-state refs
+    waiters = {}         # waitable_key → [(type, k, ...)] or gather/race-state refs
     ready = []           # heapq: (-priority, seq, entry)
     external_queue = queue_mod.Queue()  # thread-safe, blocking get()
 
@@ -423,6 +423,39 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             results = [waitable_status(wk)[1] for wk in gather_state["keys"]]
             enqueue(("resume", gather_state["waiter_k"], results))
 
+    def remove_race_waiters(race_state):
+        """Remove unresolved sibling waiter refs after Race has a winner."""
+        for wk in set(race_state["pending_keys"]):
+            entries = waiters.get(wk)
+            if not entries:
+                continue
+            remaining_entries = [
+                entry
+                for entry in entries
+                if not (entry[0] == "race" and entry[1] is race_state)
+            ]
+            if remaining_entries:
+                waiters[wk] = remaining_entries
+            else:
+                waiters.pop(wk, None)
+
+    def wake_race_waiter(race_state, completed_key):
+        if race_state["resolved"]:
+            return
+
+        status, result = waitable_status(completed_key)
+        if status not in terminal_statuses:
+            return
+
+        race_state["resolved"] = True
+        remove_race_waiters(race_state)
+        if status == "completed":
+            enqueue(("resume", race_state["waiter_k"], result))
+        elif status == "failed":
+            enqueue(("raise", race_state["waiter_k"], result))
+        elif status == "cancelled":
+            enqueue(("raise", race_state["waiter_k"], TaskCancelledError()))
+
     def wake_waiters(completed_key):
         ws = waiters.pop(completed_key, [])
         for w in ws:
@@ -433,8 +466,8 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                 _, gather_state = w
                 wake_gather_waiter(gather_state, completed_key)
             elif w[0] == "race":
-                _, waiter_k, _race_waitables = w
-                resume_with_waitable_result(waiter_k, completed_key)
+                _, race_state = w
+                wake_race_waiter(race_state, completed_key)
 
     def drain():
         """Drain all pending external completions into promise state."""
@@ -562,11 +595,19 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                     err = result if status == "failed" else TaskCancelledError()
                     return (yield ResumeThrow(k, err))
             # All pending
+            pending_wks = []
             for t in effect.tasks:
                 wk = waitable_key(t)
                 if waitable_status(wk)[0] not in terminal_statuses:
-                    waiters.setdefault(wk, []).append(("race", k, effect.tasks))
-                    break
+                    pending_wks.append(wk)
+            if pending_wks:
+                race_state = {
+                    "waiter_k": k,
+                    "pending_keys": pending_wks,
+                    "resolved": False,
+                }
+                for wk in pending_wks:
+                    waiters.setdefault(wk, []).append(("race", race_state))
             yield TailEval(pick_next())
 
         elif isinstance(effect, Cancel):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,7 @@
 """Tests for the cooperative scheduler."""
 
 import sys
+import threading
 from types import FrameType
 from typing import Any
 
@@ -8,8 +9,10 @@ from doeff_core_effects.scheduler import (
     PRIORITY_IDLE,
     Cancel,
     CompletePromise,
+    CreateExternalPromise,
     CreatePromise,
     Gather,
+    Race,
     Spawn,
     Task,
     TaskCancelledError,
@@ -19,6 +22,29 @@ from doeff_core_effects.scheduler import (
 
 from doeff import EffectBase, Pass, Resume, do
 from doeff import run as doeff_run
+
+RACE_TIMEOUT_SECONDS = 2
+
+
+def _run_race_with_timeout(program: Any) -> Any:
+    result: dict[str, Any] = {}
+    error: dict[str, BaseException] = {}
+
+    def _worker() -> None:
+        try:
+            result["value"] = doeff_run(scheduled(program))
+        except BaseException as exc:  # pragma: no cover - test helper
+            error["value"] = exc
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    thread.join(timeout=RACE_TIMEOUT_SECONDS)
+    assert not thread.is_alive(), f"Race did not complete within {RACE_TIMEOUT_SECONDS}s"
+
+    if "value" in error:
+        raise error["value"]
+
+    return result["value"]
 
 
 def _count_waitable_status_calls_for_gather(total: int) -> int:
@@ -212,6 +238,157 @@ class TestGather:
                 return "cancelled"
 
         assert doeff_run(scheduled(body())) == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Race
+# ---------------------------------------------------------------------------
+
+class TestRace:
+    def test_race_wakes_when_second_pending_task_completes(self):
+        """Race wakes on the winning pending task even when it is not first."""
+        @do
+        def blocked(gate: Any):
+            return (yield Wait(gate.future))
+
+        @do
+        def worker(gate: Any, value: str):
+            _ = yield Wait(gate.future)
+            return value
+
+        @do
+        def release_fast(gate: Any):
+            yield CompletePromise(gate, None)
+
+        @do
+        def body():
+            blocked_gate = yield CreatePromise()
+            fast_gate = yield CreatePromise()
+            blocked_task = yield Spawn(blocked(blocked_gate))
+            fast_task = yield Spawn(worker(fast_gate, "fast"))
+            _ = yield Spawn(release_fast(fast_gate), priority=PRIORITY_IDLE)
+            return (yield Race(blocked_task, fast_task))
+
+        assert _run_race_with_timeout(body()) == "fast"
+
+    def test_race_wakes_when_third_pending_task_completes(self):
+        @do
+        def blocked(gate: Any):
+            return (yield Wait(gate.future))
+
+        @do
+        def worker(gate: Any, value: str):
+            _ = yield Wait(gate.future)
+            return value
+
+        @do
+        def release_winner(gate: Any):
+            yield CompletePromise(gate, None)
+
+        @do
+        def body():
+            first_gate = yield CreatePromise()
+            second_gate = yield CreatePromise()
+            third_gate = yield CreatePromise()
+            first_task = yield Spawn(blocked(first_gate))
+            second_task = yield Spawn(blocked(second_gate))
+            third_task = yield Spawn(worker(third_gate, "third"))
+            _ = yield Spawn(release_winner(third_gate), priority=PRIORITY_IDLE)
+            return (yield Race(first_task, second_task, third_task))
+
+        assert _run_race_with_timeout(body()) == "third"
+
+    def test_race_raises_when_pending_winner_fails(self):
+        @do
+        def blocked(gate: Any):
+            return (yield Wait(gate.future))
+
+        @do
+        def failing(gate: Any):
+            _ = yield Wait(gate.future)
+            raise RuntimeError("race failure")
+            yield
+
+        @do
+        def release_failure(gate: Any):
+            yield CompletePromise(gate, None)
+
+        @do
+        def body():
+            blocked_gate = yield CreatePromise()
+            failure_gate = yield CreatePromise()
+            blocked_task = yield Spawn(blocked(blocked_gate))
+            failing_task = yield Spawn(failing(failure_gate))
+            _ = yield Spawn(release_failure(failure_gate), priority=PRIORITY_IDLE)
+            try:
+                yield Race(blocked_task, failing_task)
+                return "should not reach"
+            except RuntimeError as error:
+                return str(error)
+
+        assert _run_race_with_timeout(body()) == "race failure"
+
+    def test_race_raises_when_pending_winner_is_cancelled(self):
+        @do
+        def blocked(gate: Any):
+            return (yield Wait(gate.future))
+
+        @do
+        def cancel_task(task: Any):
+            yield Cancel(task)
+
+        @do
+        def body():
+            blocked_gate = yield CreatePromise()
+            cancelled_gate = yield CreatePromise()
+            blocked_task = yield Spawn(blocked(blocked_gate))
+            cancelled_task = yield Spawn(blocked(cancelled_gate))
+            _ = yield Spawn(cancel_task(cancelled_task), priority=PRIORITY_IDLE)
+            try:
+                yield Race(blocked_task, cancelled_task)
+                return "should not reach"
+            except TaskCancelledError:
+                return "cancelled"
+
+        assert _run_race_with_timeout(body()) == "cancelled"
+
+    def test_race_duplicate_waitable_resolves_once(self):
+        @do
+        def worker(gate: Any):
+            _ = yield Wait(gate.future)
+            return "duplicate"
+
+        @do
+        def release_gate(gate: Any):
+            yield CompletePromise(gate, None)
+
+        @do
+        def body():
+            gate = yield CreatePromise()
+            task = yield Spawn(worker(gate))
+            _ = yield Spawn(release_gate(gate), priority=PRIORITY_IDLE)
+            return (yield Race(task, task))
+
+        assert _run_race_with_timeout(body()) == "duplicate"
+
+    def test_race_resolves_once_when_waitables_complete_back_to_back(self):
+        events: list[str] = []
+
+        @do
+        def complete_both(first: Any, second: Any):
+            first.complete("first")
+            second.complete("second")
+
+        @do
+        def body():
+            first = yield CreateExternalPromise()
+            second = yield CreateExternalPromise()
+            _ = yield Spawn(complete_both(first, second), priority=PRIORITY_IDLE)
+            winner = yield Race(first.future, second.future)
+            events.append(f"winner:{winner}")
+            return list(events)
+
+        assert _run_race_with_timeout(body()) == ["winner:first"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `scheduler-race-waiter-registration`.

`Race` now registers one shared waiter state on every pending waitable instead of only the first pending waitable. The first terminal wake flips a `resolved` guard, resumes or raises with the winning result, and removes sibling Race waiter entries by identity.

## Root Cause

The pending `Race` path appended a waiter only to the first non-terminal waitable and then stopped. If another raced waitable completed first, the parent continuation had no waiter registered on that winner and could hang permanently.

## Changes

- Added Race regression tests for second/third pending winners, failure, cancellation, duplicate waitables, and back-to-back external completions.
- Added Race shared state handling in `scheduler.py`, mirroring the fixed Gather state pattern.
- Added identity-based cleanup for unresolved sibling Race waiters.

## Verification

- Red first: `uv run pytest tests/test_scheduler.py::TestRace::test_race_wakes_when_second_pending_task_completes` failed before the fix with `AssertionError: Race did not complete within 2s`.
- `uv run pytest tests/test_scheduler.py` passed: `34 passed`.
- `uv run ruff check packages/doeff-core-effects/doeff_core_effects/scheduler.py tests/test_scheduler.py` passed.
- `uv run pytest tests/` currently does not complete collection on this checkout because `tests/effects/test_traverse.py` cannot import `doeff_traverse` (`ModuleNotFoundError`). This is outside the touched files.
- With `PYTHONPATH=packages/doeff-traverse`, `uv run pytest tests/` reached the full suite and failed only the existing docs contract test `tests/test_docs_withhandler_contract.py::test_current_docs_do_not_show_deprecated_withhandler_call_snippets` due `docs/crystallization/algebra-draft.md` containing deprecated `WithHandler(` text. Result: `1 failed, 870 passed, 90 skipped`.