### PR TITLE
[codex] Fix VM spec API status drift

### DIFF
--- a/specs/vm/SPEC-008-rust-vm.md
+++ b/specs/vm/SPEC-008-rust-vm.md
@@ -1,6 +1,17 @@
 # SPEC-008: Rust VM for Algebraic Effects
 
-## Status: Draft (Revision 18)
+## Status: Draft (Revision 18); mixed implementation status
+
+Current implementation status as of 2026-06-12:
+
+| Area | Status | Current implementation |
+|------|--------|------------------------|
+| Core VM wrapper | Implemented | `doeff_vm.PyVM().run(doexpr)` is the exposed VM entrypoint. |
+| Top-level Python entrypoint | Implemented | `doeff.run(doexpr)` creates `PyVM` and returns the plain program value or raises. |
+| Module-level `doeff_vm.run` / `doeff_vm.async_run` | Design, never shipped | Not exported by `doeff_vm/__init__.py` or `__init__.pyi`. |
+| `RunResult` / `PyRunResult` public return | Design, never shipped | Not exported by `doeff_vm`; `run()` returns the plain value. |
+| `handlers=`, `env=`, `store=` kwargs on `run()` | Superseded by explicit composition | Compose handlers around the program before calling `run(doexpr)`. Core handler factories are `Program -> Program` installers such as `state(initial=...)(program)` and `reader(env=...)(program)`. |
+| Async entrypoint | Superseded by `scheduled()` | Top-level `doeff.async_run` is a removed placeholder: use `run()` with `scheduled()`. |
 
 ### Revision 18 Changelog
 
@@ -233,36 +244,45 @@ path (one vtable call + one match arm).
 
 **Handler Installation** (all handlers are explicit, no defaults):
 ```python
-from doeff import run, WithHandler
-from doeff.handlers import state, reader, writer
+from doeff import Ask, Get, Put, do, run
+from doeff_core_effects.handlers import reader, state, writer
 
-# Standard handlers are just handlers — no special treatment
-result = run(
-    my_program(),
-    handlers=[state, reader, writer],
-    store={"x": 0},
-)
-
-# User can replace any standard handler with custom implementation
-result = run(
-    my_program(),
-    handlers=[my_persistent_state, reader, writer],
-)
-
-# Handlers composable via WithHandler anywhere
 @do
 def my_program():
-    result = yield WithHandler(
-        handler=cache_handler,
-        expr=sub_program(),
-    )
-    return result
+    current = yield Get("x")
+    greeting = yield Ask("greeting")
+    yield Put("x", current + 1)
+    return f"{greeting}: {current + 1}"
+
+
+program = my_program()
+program = writer()(program)
+program = state(initial={"x": 0})(program)
+program = reader(env={"greeting": "hello"})(program)
+result = run(program)
+assert result == "hello: 1"
 ```
 
 **Built-in Scheduler (Explicit, see SPEC-SCHED-001)**:
 ```python
-from doeff.handlers import scheduler
-result = run(my_program(), handlers=[scheduler, state, reader, writer])
+from doeff import Gather, Pure, Spawn, do, run
+from doeff_core_effects.scheduler import scheduled
+
+
+@do
+def child(value):
+    return (yield Pure(value))
+
+
+@do
+def main():
+    left = yield Spawn(child(1))
+    right = yield Spawn(child(2))
+    return (yield Gather(left, right))
+
+
+result = run(scheduled(main()))
+assert result == [1, 2]
 ```
 
 ### ADR-3: GIL Release Strategy
@@ -291,7 +311,12 @@ Python runtime layer.
 - Rust `async` would complicate lifetime management with PyO3
 - Can add async Rust later if needed
 
-### ADR-4a: Asyncio Integration (Reference)
+### ADR-4a: Asyncio Integration (Historical Reference)
+
+**Status: Design, never shipped as public API; superseded by `run(scheduled(...))`.**
+The current top-level `doeff.async_run` export is a removed placeholder whose
+replacement message is "use run() with scheduled()". `doeff_vm` does not expose
+module-level `async_run` or `PyVM.run_async`.
 
 **Decision**: Provide a Python-level async driver (`async_run` / `VM.run_async`) and the
 `PythonAsyncSyntaxEscape` DoCtrl for handlers that need `await`.
@@ -402,6 +427,11 @@ to `run()` or `WithHandler`, at `id()` level.
 
 ### ADR-11: Store/Env Initialization and Extraction [R8-E]
 
+**Status: Design, never shipped.** Current `PyVM` does not expose these
+lifecycle helpers, and current `doeff.run()` does not accept `env=` or
+`store=`. Seed reader/state data by composing handler factories before calling
+`run(doexpr)`, for example `reader(env={...})(state(initial={...})(program))`.
+
 **Decision**: PyVM exposes `put_state()`, `put_env()`, `env_items()` for the
 `run()` function to seed initial state and read back results.
 
@@ -414,10 +444,10 @@ to `run()` or `WithHandler`, at `id()` level.
 - `state_items() -> dict` — returns `RustStore.state` as Python dict
 - `logs() -> list` — returns `RustStore.log` as Python list
 
-**Rationale**:
-- The `run()` function (SPEC-009) takes `env={}` and `store={}` parameters
-- It needs to seed the VM before running and extract results after
-- These methods are implementation details — users never call them directly
+**Historical rationale**:
+- The old SPEC-009 design had `run(..., env={}, store={})` parameters.
+- It needed to seed the VM before running and extract results after.
+- These methods would have been implementation details.
 
 ### ADR-15: Explicit Perform Boundary (EffectValue vs DoExpr) [R14-A, R14-B]
 
@@ -1030,7 +1060,7 @@ They subclass `EffectBase` (Python) and flow through dispatch as `Py<PyAny>`
 like everything else. Python handlers receive them and read attributes
 with normal Python attribute access.
 
-```python
+```text
 class MyDatabaseQuery(EffectBase):
     def __init__(self, sql: str):
         self.sql = sql
@@ -1223,8 +1253,8 @@ unsafe fn read_do_expr_tag(obj: &Py<PyAny>) -> DoExprTag {
 
 Python user-defined types extend the same bases:
 
-```python
-from doeff_vm import EffectBase, DoCtrlBase
+```text
+from doeff_vm import EffectBase
 
 # User effect — isinstance(obj, EffectBase) works
 class MyDatabaseQuery(EffectBase):
@@ -1714,44 +1744,36 @@ implementation details are defined in SPEC-SCHED-001.
 
 ### Python API for Standard Handlers [R8-H]
 
-Users install standard handlers via `run()` or `WithHandler` (see SPEC-009):
+**Status: Implemented with explicit handler factory composition.** Users install
+standard handlers by wrapping the program before calling `run(doexpr)`.
+High-level handler factories from `doeff_core_effects.handlers` are
+`Program -> Program` installers.
 
 ```python
-from doeff import run, WithHandler
-from doeff.handlers import state, reader, writer
+from doeff import Ask, Get, Put, do, run
+from doeff_core_effects.handlers import reader, state, writer
 
-# Install standard handlers explicitly
-result = run(
-    user_program(),
-    handlers=[state, reader, writer],
-    store={"x": 0},
-    env={"key": "val"},
-)
 
-# Observe state after execution
-print(result.raw_store)    # Dict of state key-value pairs
-
-# Users can replace standard handlers with custom ones
 @do
-def my_persistent_state(effect, k):
-    if isinstance(effect, Get):
-        value = db.get(effect.key)
-        result = yield Resume(k, value)
-        return result
-    elif isinstance(effect, Put):
-        db.put(effect.key, effect.value)
-        result = yield Resume(k, None)
-        return result
-    else:
-        yield Pass()
+def user_program():
+    value = yield Get("x")
+    prefix = yield Ask("prefix")
+    yield Put("x", value + 1)
+    return f"{prefix}:{value + 1}"
 
-# Custom handler intercepts state effects instead of standard state handler
-result = run(
-    user_program(),
-    handlers=[my_persistent_state, reader, writer],
-    env={"key": "val"},
-)
+
+program = user_program()
+program = writer()(program)
+program = state(initial={"x": 0})(program)
+program = reader(env={"prefix": "count"})(program)
+
+result = run(program)
+assert result == "count:1"
 ```
+
+Custom handlers replace standard handlers by exposing the same installer shape:
+a callable that accepts a program and returns a wrapped program. At VM level the
+underlying composition primitive is still `WithHandler`.
 
 ### PythonCall and PendingPython (Purpose-Tagged Calls)
 
@@ -2270,7 +2292,7 @@ pub struct DebugConfig {
 
 ### Python API for Debug
 
-```python
+```text
 vm = doeff.VM(debug=True)  # Steps level
 vm.set_debug(DebugConfig(level="trace", show_frames=True, show_dispatch=True))
 result = vm.run(program)
@@ -2982,7 +3004,7 @@ Notes:
 
 **Pass/Delegate/Resume Pseudocode** [R15-A]:
 
-```python
+```text
 @do
 def user():
     x = yield SomeEffect()
@@ -3269,7 +3291,11 @@ impl PyVM {
 
 ---
 
-## Asyncio Integration (Reference)
+## Asyncio Integration (Historical Reference)
+
+**Status: Design, never shipped as public API; superseded by
+`run(scheduled(program))`.** Current `doeff_vm` exposes only synchronous
+`PyVM.run()`, and top-level `doeff.async_run` raises a removed-API error.
 
 This section mirrors legacy SPEC-006's asyncio bridge [Deprecated], adapted to the Rust VM.
 The VM core remains synchronous; async integration is implemented by a driver
@@ -3280,7 +3306,7 @@ wrapper and a handler that yields `PythonAsyncSyntaxEscape`.
 `async_run` uses the same step loop but awaits `PythonCall::CallAsync` events.
 All other PythonCall variants are handled synchronously via `execute_python_call`.
 
-```python
+```text
 async def async_run(vm, program):
     # [R13-A] classify_program_input extracts the generator (lazy AST) from program
     vm_input = vm.classify_program_input(program)
@@ -3303,7 +3329,7 @@ async def async_run(vm, program):
 
 `execute_python_call_async` is a thin wrapper:
 
-```python
+```text
 async def execute_python_call_async(call):
     py_args = to_py_args(call.args)
     awaitable = call.func(*py_args)
@@ -3324,7 +3350,7 @@ Two reference handlers are provided:
 - `async_await_handler`: yields `PythonAsyncSyntaxEscape` so
   `async_run` can await in the event loop.
 
-```python
+```text
 @do
 def sync_await_handler(effect, k):
     if isinstance(effect, Await):
@@ -3334,7 +3360,7 @@ def sync_await_handler(effect, k):
     yield Pass(effect)
 ```
 
-```python
+```text
 @do
 def async_await_handler(effect, k):
     if isinstance(effect, Await):
@@ -3352,81 +3378,98 @@ def async_await_handler(effect, k):
     yield Pass(effect)
 ```
 
-`async_await_handler` must only be used with `async_run`;
-the sync driver raises `TypeError` if it sees `CallAsync`.
+Historical design: `async_await_handler` would only be used with `async_run`;
+the sync driver would raise `TypeError` if it saw `CallAsync`.
 
-`run()` and `async_run()` must pass handler lists through unchanged. Handler
-selection is user responsibility; no handler swapping or thread-offload
-detection is allowed in VM wrappers.
+Current replacement: compose concurrency with `scheduled(program)` and call
+`run()` on the scheduled program. Handler selection remains user responsibility.
 
 **Usage**:
-- Sync: `vm.run(with_handler(sync_await_handler, program))`
-- Async: `await vm.run_async(with_handler(async_await_handler, program))`
+- Current: `run(scheduled(program))`
+- Historical async design: `await vm.run_async(with_handler(async_await_handler, program))`
 
 ---
 
 ## Public API Contract (SPEC-009 Support) [R8-J]
 
-This section specifies the user-facing types and contracts that the VM must
-expose to satisfy SPEC-009. Everything in this section is part of the
-**public boundary** — the layer between user code and VM internals.
+**Status: Partially implemented; stale contract superseded.** This section was
+originally written for an older SPEC-009 API that included `RunResult`,
+`async_run`, and `run(..., handlers=..., env=..., store=...)`. Those APIs were
+not shipped in the current package. The implemented public boundary is:
 
-### run() and async_run() — Entrypoint Contract
+- `doeff.run(doexpr) -> Any`
+- `doeff_vm.PyVM().run(doexpr) -> Any`
+- explicit handler composition before `run(doexpr)`
+- concurrency via `doeff_core_effects.scheduler.scheduled(program)`
+
+### Current Entrypoint Contract
 
 ```python
-def run(
-    program: Program[T],
-    handlers: list[Handler] = [],
-    env: dict[str, Any] = {},
-    store: dict[str, Any] = {},
-) -> RunResult[T]: ...
+from typing import Any
 
-async def async_run(
-    program: Program[T],
-    handlers: list[Handler] = [],
-    env: dict[str, Any] = {},
-    store: dict[str, Any] = {},
-) -> RunResult[T]: ...
+
+def run(doexpr: Any) -> Any: ...
 ```
 
-These are **Python-side** functions that wrap `PyVM`. They are NOT methods on
-PyVM — they create and configure a PyVM internally.
+`doeff.run()` is a Python-side wrapper that creates `PyVM` internally and
+returns the plain program value. On error it enriches the exception with
+`__doeff_traceback__`, prints a formatted doeff traceback to stderr when
+available, and re-raises.
 
-#### Implementation Contract
+#### Current Implementation Contract
 
-`run(program, handlers, env, store)` does the following in order:
+`run(doexpr)` does the following:
 
 ```
 1. Create PyVM instance
        vm = PyVM::new()
 
-2. Initialize store (SPEC-009 API-6)
-       for key, value in store.items():
-           vm.put_state(key, Value::from_pyobject(value))
+2. Execute via driver loop
+       value = vm.run(doexpr)
 
-3. Initialize environment (SPEC-009 API-5)
-       for key, value in env.items():
-           vm.put_env(key, Value::from_pyobject(value))
-
-4. Wrap program with handlers (nesting order — see below)
-       wrapped = program
-       for h in reversed(handlers):
-           wrapped = WithHandler(handler=h, expr=wrapped)
-
-5. Execute via driver loop
-       final_value_or_error = vm.run(wrapped)   # driver loop from §Driver Loop
-
-6. Extract results into RunResult
-       raw_store = {k: v.to_pyobject() for k, v in vm.state_items()}
-       result = Ok(final_value) or Err(exception)
-       return RunResult(result=result, raw_store=raw_store)
+3. Return plain value or re-raise enriched exception
 ```
 
-`async_run` is identical except step 5 uses the async driver loop (§Async Driver).
+There is no public `async_run` in the current API. Use `run(scheduled(program))`
+for cooperative concurrency.
 
-#### Handler Nesting Order
+#### Current Handler Composition
 
-`handlers=[h0, h1, h2]` produces:
+Handlers are composed before calling `run(doexpr)`. High-level core handlers are
+`Program -> Program` installers:
+
+```python
+from doeff import Get, Put, do, run
+from doeff_core_effects.handlers import state
+
+
+@do
+def increment():
+    value = yield Get("x")
+    yield Put("x", value + 1)
+    return value + 1
+
+
+program = state(initial={"x": 0})(increment())
+assert run(program) == 1
+```
+
+At VM level the underlying composition primitive remains `WithHandler`. The
+current reader-facing handler factories call that primitive for callers.
+
+**No default handlers.** If the program yields an effect with no matching
+handler in scope, the VM raises `UnhandledEffect`.
+
+#### Historical `handlers=` Design
+
+The following older contract did not ship:
+
+```text
+run(program, handlers=[h0, h1, h2], env={...}, store={...}) -> RunResult
+async_run(program, handlers=[...]) -> RunResult
+```
+
+Historical nesting order for that design was:
 
 ```
 WithHandler(h0,           ← outermost, sees effects LAST
@@ -3435,30 +3478,11 @@ WithHandler(h0,           ← outermost, sees effects LAST
       program)))
 ```
 
-`h2` is closest to the program — it sees effects first. `h0` is outermost —
-it sees effects that `h1` and `h2` delegate. This matches `reversed(handlers)`.
+### RunResult — Historical Design [R8-J]
 
-**No default handlers** (SPEC-009 API-1). If `handlers=[]`, the program runs
-with zero handlers. Yielding any effect raises `UnhandledEffect`.
-
-#### NestingStep / NestingGenerator (ADR-13) [Q7]
-
-The `WithHandler(h0, WithHandler(h1, WithHandler(h2, program)))` nesting is
-implemented via a synthetic generator (`NestingGenerator`) that yields one
-`WithHandler` DoCtrl at a time. The driver steps this generator through:
-
-1. `run(program, handlers=[h0, h1, h2])` creates a `NestingGenerator` that
-   will yield `WithHandler(h2, program)`, then `WithHandler(h1, ...)`,
-   then `WithHandler(h0, ...)`.
-2. Each `WithHandler` yield installs the handler and creates a new prompt
-   segment. The NestingGenerator resumes with the next handler.
-3. Once all handlers are installed, the innermost body (the user program)
-   starts executing.
-
-This avoids recursion or special-case nesting in the VM — the handler
-installation loop is just normal generator stepping.
-
-### RunResult — Execution Output [R8-J]
+**Status: Design, never shipped.** `RunResult` and `PyRunResult` are not
+exported by `doeff_vm` or `doeff`. The current `run()` returns the plain value
+and raises exceptions on failure.
 
 ```rust
 /// The public result of a run()/async_run() call.
@@ -3559,7 +3583,7 @@ in the `doeff` Python package. SPEC-008 defines how the VM processes its output.
 
 #### What @do Does [R13-E]
 
-```python
+```text
 def do(fn):
     """Convert a generator function into a DoExpr factory.
 

--- a/specs/vm/SPEC-009-rust-vm-migration.md
+++ b/specs/vm/SPEC-009-rust-vm-migration.md
@@ -1,6 +1,65 @@
 # SPEC-009: Rust VM Public API
 
-## Status: Draft (Revision 8)
+## Status: Superseded draft; current implemented API documented below
+
+This file is retained as migration/design history. The current package does not
+ship the original Revision 8/9 public API exactly as written. When the
+historical sections below disagree with this status block, this block is the
+source of truth for the implementation as of 2026-06-12.
+
+| API or concept | Status | Current replacement |
+|----------------|--------|---------------------|
+| `run(program, handlers=..., env=..., store=...) -> RunResult` | Superseded | `run(doexpr) -> Any`; compose handlers before calling `run`. |
+| `async_run(...)` | Removed | `run(scheduled(program))`. The `_Removed` placeholder says "use run() with scheduled()". |
+| `default_handlers()` | Removed | Compose handlers by calling each handler installer with the program. |
+| `doeff.presets` | Removed | Compose the handler stack explicitly in application/test helpers. |
+| `RunResult` / `PyRunResult` | Design, never shipped | `run()` returns the plain value and raises exceptions on failure. Use `Ok`/`Err` explicitly only where a handler or helper returns them. |
+| `Modify` | Removed | Use `Get` plus `Put`. |
+| `Delegate` | Removed from top-level `doeff` | Re-perform/pass through effects with the current handler protocol (`Pass(effect, k)` in implemented handlers). |
+
+## Current Implemented Contract
+
+```python
+from doeff import Ask, Get, Put, do, run
+from doeff_core_effects.handlers import reader, state
+
+
+@do
+def program():
+    value = yield Get("x")
+    label = yield Ask("label")
+    yield Put("x", value + 1)
+    return f"{label}:{value + 1}"
+
+
+wrapped = state(initial={"x": 0})(program())
+wrapped = reader(env={"label": "count"})(wrapped)
+assert run(wrapped) == "count:1"
+```
+
+Concurrency is explicit handler composition too:
+
+```python
+from doeff import Gather, Pure, Spawn, do, run
+from doeff_core_effects.scheduler import scheduled
+
+
+@do
+def child(value):
+    return (yield Pure(value))
+
+
+@do
+def main():
+    left = yield Spawn(child(1))
+    right = yield Spawn(child(2))
+    return (yield Gather(left, right))
+
+
+assert run(scheduled(main())) == [1, 2]
+```
+
+## Historical Revision Notes
 
 ### Revision 8 Changelog
 
@@ -66,12 +125,14 @@
 | **R3-C** | §6 WithHandler | Strengthened: `run()` is defined in terms of WithHandler (not independent). |
 | **R3-D** | §11 Invariants | Added API-9 through API-12: structural equivalence, sentinel handlers, classify completeness, async semantics. |
 
-## Summary
+## Historical Summary (Superseded)
 
 Define the public API that the Rust VM (SPEC-008) must expose so that
 doeff subpackages can migrate from the legacy Python v3 interpreter [Deprecated].
 
-This spec defines **what users import and call** — not VM internals.
+This historical section defined **what users would import and call** under the
+unshipped `RunResult`/`async_run`/`handlers=` API. Use the current implemented
+contract at the top of this file for shipped behavior.
 
 ```
 ┌───────────────────────────────────────────────────────┐
@@ -175,7 +236,7 @@ will silently break.
 
 ### run
 
-```python
+```text
 def run(
     program: DoExpr[T] | EffectValue[T],
     handlers: list[Handler] = [],
@@ -213,7 +274,7 @@ body segments with correct `scope_chain`, and deterministic handler ordering.
 
 ### async_run
 
-```python
+```text
 async def async_run(
     program: DoExpr[T] | EffectValue[T],
     handlers: list[Handler] = [],
@@ -252,7 +313,7 @@ an informative message that includes:
 2. What types are accepted (DoExpr control or EffectValue)
 3. A hint if the input looks like a common mistake
 
-```python
+```text
 # GOOD — accepted inputs:
 run(my_do_func(1))                  # Call DoCtrl [R9-A: __call__() returns Call directly]
 run(Ask("key"))                      # EffectValue, boundary-normalized to Perform
@@ -275,7 +336,7 @@ passthrough except for one normalization rule: raw effect values are wrapped as
 and raises `TypeError` for unsupported inputs. The Rust VM evaluates DoExpr
 control nodes directly.
 
-```python
+```text
 # Python run() implementation (conceptual):
 def run(program, handlers=(), env=None, store=None):
     if isinstance(program, EffectValue):
@@ -292,7 +353,7 @@ def run(program, handlers=(), env=None, store=None):
 
 ## 2. RunResult
 
-```python
+```text
 class RunResult(Protocol[T_co]):
     @property
     def result(self) -> Result[T_co]:
@@ -307,7 +368,7 @@ class RunResult(Protocol[T_co]):
 
 Convenience accessors:
 
-```python
+```text
     @property
     def value(self) -> T_co:
         """Unwrap Ok or raise the Err."""
@@ -328,7 +389,7 @@ Convenience accessors:
 
 `Result[T]` is a sum type from `doeff`:
 
-```python
+```text
 from doeff import Ok, Err
 
 result.result  # Ok(1) or Err(ValueError("..."))
@@ -344,7 +405,7 @@ This is the doeff `Result` type, not a Rust `Result`.
 `raw_store` contains **only state entries** — the key-value pairs managed by
 the `state` handler via `Get`/`Put`/`Modify`.
 
-```python
+```text
 result = run(program, handlers=[state, reader, writer],
              store={"x": 0}, env={"key": "val"})
 
@@ -367,7 +428,7 @@ A `Program[T]` is a value that, when executed, yields effects and returns `T`.
 
 ### Writing a Program
 
-```python
+```text
 @do
 def counter():
     x = yield Get("count")
@@ -385,7 +446,7 @@ def counter():
 `@do` converts a generator function into a `Program` factory. Calling the
 factory does NOT execute the body — it creates a deferred program descriptor:
 
-```python
+```text
 @do
 def my_func(a: int, b: str):
     ...
@@ -422,7 +483,7 @@ execution. See SPEC-KPC-001.
 `@do` requires a **generator function** (`def` with `yield`). Applying `@do` to
 an `async def` is **always a bug** — there is no "async kleisli" concept.
 
-```python
+```text
 # CORRECT — generator function, uses yield for effects and Await for async I/O:
 @do
 def fetch_data(url: str):
@@ -500,7 +561,7 @@ the corresponding handler is installed.
 
 Any class can be an effect:
 
-```python
+```text
 @dataclass
 class MyEffect:
     payload: str
@@ -520,7 +581,7 @@ it.  If no handler handles it → `UnhandledEffect` error.
 
 ### Protocol
 
-```python
+```text
 Handler = Callable[[EffectValue, K], DoExpr[T]]
 ```
 
@@ -581,7 +642,7 @@ Transfer(k, value)     Resume caller with value.      NO — handler is done.
 Both resume the caller's continuation with a value. The difference is what
 happens to the handler afterward:
 
-```python
+```text
 # Resume: handler CONTINUES after the continuation completes
 @do
 def my_handler(effect, k):
@@ -618,7 +679,7 @@ swap. See SPEC-VM-010 for the full mechanism.
 
 ### Example: Custom Handler
 
-```python
+```text
 @do
 def cache_handler(effect, k):
     if isinstance(effect, CacheGet):
@@ -673,7 +734,7 @@ Source-level effect yields (`yield Tell(...)`) are lowered to
 Effects yielded by a handler are dispatched to handlers **outside** the
 current handler's scope — never to the handler itself.
 
-```python
+```text
 @do
 def logging_handler(effect, k):
     if isinstance(effect, MyEffect):
@@ -689,7 +750,7 @@ def logging_handler(effect, k):
 Since `WithHandler` is a composition primitive (not a dispatch primitive),
 handlers can install sub-handlers:
 
-```python
+```text
 @do
 def outer_handler(effect, k):
     if isinstance(effect, ComplexEffect):
@@ -707,7 +768,7 @@ def outer_handler(effect, k):
 
 ## 6. Composition: WithHandler
 
-```python
+```text
 WithHandler(handler: Handler, expr: DoExpr[T])
 ```
 
@@ -720,7 +781,7 @@ Usable from **any** `Program`:
 - Inside handlers
 - Arbitrarily nested
 
-```python
+```text
 @do
 def my_program():
     # Install a handler around a sub-program
@@ -765,7 +826,7 @@ Handles: `Get`, `Put`, `Modify`
 
 Provides mutable key-value state.
 
-```python
+```text
 from doeff.handlers import state
 
 result = run(my_program(), handlers=[state], store={"x": 0})
@@ -786,7 +847,7 @@ Handles: `Ask`
 
 Provides read-only environment.
 
-```python
+```text
 from doeff.handlers import reader
 
 result = run(my_program(), handlers=[reader], env={"key": "value"})
@@ -802,7 +863,7 @@ Handles: `Tell`
 
 Provides append-only log.
 
-```python
+```text
 from doeff.handlers import writer
 
 result = run(my_program(), handlers=[state, writer], store={"x": 0})
@@ -830,7 +891,7 @@ Note: `Await` is a Python-level asyncio bridge effect (see SPEC-EFF-005), NOT a
 scheduler effect. It is handled by the `sync_await_handler` or
 `python_async_syntax_escape_handler`, not by the scheduler.
 
-```python
+```text
 from doeff.handlers import scheduler
 ```
 
@@ -849,7 +910,7 @@ is removed. Programs using `@do` no longer require a KPC handler — the VM eval
 
 Convenience bundles for common configurations:
 
-```python
+```text
 from doeff.presets import sync_preset, async_preset
 
 # sync_preset = [state, reader, writer]  [R9-A: kpc removed]
@@ -864,7 +925,7 @@ Public convenience function returning the standard handler bundle
 `[state, reader, writer]`. Available as `from doeff import default_handlers`.
 [R9-A: `kpc` removed — KPC is a call-time macro, no handler needed.]
 
-```python
+```text
 from doeff import run, default_handlers
 
 # Explicit handler installation (required — run() defaults to handlers=[])
@@ -880,7 +941,7 @@ pass `default_handlers()` or construct their own handler list.
 
 ### User Code
 
-```python
+```text
 # Entrypoints
 from doeff import run, async_run
 
@@ -910,7 +971,7 @@ from doeff import RunResult
 
 ### Handler Authors
 
-```python
+```text
 # Everything above, plus dispatch primitives:
 from doeff import Resume, Delegate, Pass, Transfer
 ```
@@ -975,7 +1036,7 @@ framework-internal.
 
 The handler protocol changes:
 
-```python
+```text
 # BEFORE (Legacy Python interpreter [Deprecated]):
 # Handler = Callable[[EffectBase, HandlerContext], Program[LegacyState | ResumeK]]
 

--- a/specs/vm/SPEC-VM-PROTOCOL.md
+++ b/specs/vm/SPEC-VM-PROTOCOL.md
@@ -1,8 +1,19 @@
 # SPEC-VM-PROTOCOL: VM↔Python Typed Protocol
 
-## Status: Implemented
+## Status: Partially implemented; historical design sections marked inline
 
 Implementation plan: [IMPL-VM-PROTOCOL.md](IMPL-VM-PROTOCOL.md)
+
+Current implementation status as of 2026-06-12:
+
+| Section | Status | Current implementation |
+|---------|--------|------------------------|
+| §1 DoCtrl as VM vocabulary | Implemented | `PyVM.run()` classifies `DoExpr` pyclasses and `EffectBase` values through `classify_python_object`. |
+| §2 Design constraints | Partially implemented | The VM still uses selected Python object/attribute access at the bridge boundary; see the notes below rather than treating every C-rule as satisfied. |
+| §3 `DoeffGenerator` typed wrapper | Design, never shipped | `doeff_vm` does not export `DoeffGenerator`. The current bridge steps `IRStream`/generator objects and reads `gi_code`, `gi_frame.f_lineno`, and related generator attributes in `python_generator_stream.rs`. |
+| §4 `DoeffTracebackData` via `RunResult` | Superseded by exception attribute mechanism | `doeff_vm` does not export `DoeffTracebackData`, `PyRunResult`, or `RunResult`. Traceback data is attached to Python exceptions as `__doeff_traceback__` in `pyvm.rs` and enriched by `doeff.run`. |
+| §5 Call metadata protocol | Partially implemented | Frame/source metadata exists, but the `DoeffGenerator` source-of-truth design did not ship. |
+| §7 Protocol surface summary | Partially implemented | The actual public VM package exports `PyVM`, DoExpr pyclasses, `EffectBase`, `Ok`, `Err`, `K`, `Callable`, `IRStream`, `UnhandledEffect`, and `vm_live_counts`. |
 
 ---
 
@@ -40,17 +51,21 @@ These are the exhaustive list of things the VM makes decisions on:
 |------|---------------|-------------|
 | **DoCtrl variant** | `classify_yielded()` reads tag from `PyDoCtrlBase` | Branch on variant (Pure, Call, Perform, Resume, Transfer, WithHandler, Delegate, Pass, etc.) |
 | **Generator stepping** | `step_generator()` calls `send()`/`__next__()` on the generator object | Branch on outcome (yield / return / error) |
-| **Generator location** | `DoeffGenerator.get_frame` callback (see §3.4) | Used in trace assembly to supplement frame line numbers |
+| **Generator location** | Current bridge reads generator attributes (`gi_code`, `gi_frame.f_lineno`) in `python_generator_stream.rs`; §3 records a never-shipped typed-wrapper design | Used in trace assembly to supplement frame line numbers |
 | **Call metadata** | `CallMetadata` on `DoCtrl::Call` (already typed) | Stored on `Frame::PythonGenerator`, emitted in trace events |
 | **Exception propagation** | `pyerr_to_exception()` converts `PyErr` → internal `PyException` | Stack unwinding, dispatch completion |
-| **Traceback data attachment** | `DoeffTracebackData` PyClass on `RunResult` (see §4) | Output enrichment before returning to Python |
+| **Traceback data attachment** | `__doeff_traceback__` attribute on Python exceptions (see §4 current status) | Error enrichment before re-raising to Python |
 | **Handler chain matching** | `can_handle()` on `Handler::RustProgram` / `Handler::Python` | Finding which handler to dispatch to |
 | **Continuation state** | `Continuation` struct (already typed) | Resume, Transfer, dispatch completion |
 
 **Key protocol mechanisms for the two non-trivial items:**
 
-1. **Generator location** — user-provided `get_frame` callback on `DoeffGenerator` (§3). VM never touches generator internals.
-2. **Traceback data** — `DoeffTracebackData` PyClass delivered via `RunResult` (§4). VM never sets attributes on exception objects.
+1. **Generator location** — implemented by direct generator attribute reads in
+   `python_generator_stream.rs`. The `DoeffGenerator.get_frame` design in §3
+   was never shipped.
+2. **Traceback data** — implemented by attaching `__doeff_traceback__` to
+   exception objects in `pyvm.rs`. The `DoeffTracebackData`/`RunResult` design
+   in §4 was never shipped.
 
 All other items are already typed: DoCtrl arrives via tagged PyClasses, CallMetadata is a typed Rust struct, continuations are typed, handler matching uses `can_handle()`.
 
@@ -62,7 +77,10 @@ These are non-negotiable invariants for all VM↔Python communication:
 
 ### C1: Zero Dunder Attributes
 
-No `__doeff_*` attributes shall be read from or written to Python objects by the VM. See [IMPL-VM-PROTOCOL.md §1.1](IMPL-VM-PROTOCOL.md#11-dunder-attribute-violations-spec-c1) for current violations.
+**Status: Design invariant, not current behavior.** The shipped VM writes
+`__doeff_traceback__` onto exception objects when surfacing VM trace data.
+Treat this constraint as historical design intent until the typed traceback
+surface is implemented.
 
 ### C2: All VM↔Python Data-Bearing Types Are Rust PyClasses
 
@@ -105,13 +123,36 @@ See [IMPL-VM-PROTOCOL.md §1.4](IMPL-VM-PROTOCOL.md#14-silent-fallback-violation
 
 ### C8: VM Entry Accepts DoExpr
 
-The VM's `run()` / `async_run()` interface accepts all `DoExpr` types (Pure, Call, Map, FlatMap, Perform, WithHandler, etc.). `DoeffGenerator` is not an entry-point type — it is the typed wrapper for generators that appear during DoExpr evaluation.
+**Status: Partially implemented.** The shipped entrypoints are
+`doeff.run(doexpr)` and `doeff_vm.PyVM().run(doexpr)`. There is no public
+module-level `doeff_vm.run()` or `doeff_vm.async_run()`, and top-level
+`doeff.async_run` is a removed placeholder whose replacement message is
+"use run() with scheduled()".
 
-When a DoExpr evaluates to a Python generator (via `to_generator_strict`, `Call` result, handler invocation), that generator must be a `DoeffGenerator`. The VM does not accept raw Python generators at any frame push site.
+The VM accepts current `DoExpr` pyclasses and `EffectBase` values. The
+`DoeffGenerator` wrapper described below is not an entry-point type because it
+was never shipped.
+
+Historical design: when a DoExpr evaluated to a Python generator, that generator
+would have been required to be a `DoeffGenerator`. The shipped bridge instead
+uses `IRStream`/generator objects and classifies yielded `DoExpr` or
+`EffectBase` values directly.
 
 ---
 
 ## 3. DoeffGenerator: Typed Generator Wrapper
+
+**Status: Design, never shipped.** `packages/doeff-vm/doeff_vm/__init__.pyi`
+does not expose `DoeffGenerator`, and the Rust extension does not register a
+`DoeffGenerator` pyclass. The current implementation uses `IRStream` and reads
+generator attributes directly:
+
+- `gi_code.co_qualname` / `gi_code.co_name`
+- `gi_code.co_filename`
+- `gi_frame.f_lineno`, falling back to `co_firstlineno` when no live frame is available
+
+The remainder of this section is retained as historical design context and must
+not be read as implemented behavior.
 
 ### 3.1 Problem
 
@@ -157,7 +198,7 @@ There is no generic "detect-and-wrap" function. Each construction site knows its
 
 #### Default callback (plain generators, no bridge):
 
-```python
+```text
 def _default_get_frame(gen):
     """Return the generator's own frame."""
     return gen.gi_frame  # None if exhausted
@@ -167,7 +208,7 @@ def _default_get_frame(gen):
 
 The `@do` bridge generator holds the user's generator as a local variable (`gen`). The callback navigates from the bridge's frame to find the user generator's frame:
 
-```python
+```text
 def _do_get_frame(bridge_gen):
     """Navigate bridge locals to return user generator's frame."""
     if bridge_gen.gi_frame is not None:
@@ -179,7 +220,7 @@ def _do_get_frame(bridge_gen):
 
 No structural changes to `generator_wrapper` are needed. The callback runs at probe time, when the bridge has already started and the user gen exists in its locals.
 
-```python
+```text
 DoeffGenerator(
     generator=bridge_gen,
     function_name=func.__name__,
@@ -191,7 +232,7 @@ DoeffGenerator(
 
 #### `WithHandler` wrapping — single generator (no bridge):
 
-```python
+```text
 DoeffGenerator(
     generator=handler_gen,
     function_name=handler_fn.__code__.co_name,
@@ -203,7 +244,7 @@ DoeffGenerator(
 
 #### `ProgramBase.to_generator()` — implementor's responsibility:
 
-```python
+```text
 DoeffGenerator(
     generator=gen,
     function_name=...,
@@ -231,7 +272,7 @@ See §3.8 for the complete list of construction sites and their responsibilities
 
 ### 3.4 VM Behavior
 
-When the VM receives a `DoeffGenerator`, it:
+Historical design: when the VM received a `DoeffGenerator`, it would have:
 
 1. **Extracts `generator`** for stepping (`send()` / `__next__()` / `throw()`)
 2. **Stores `get_frame`** callback on the frame for later invocation
@@ -247,7 +288,8 @@ if let Some(f) = frame {
 }
 ```
 
-The VM never reads `gi_frame` directly from the generator. The callback encapsulates all generator-structure knowledge. This replaces the current `generator_current_line()` function entirely.
+This design was not implemented. The current bridge does read `gi_frame`
+directly from generator objects to recover live line numbers.
 
 The frame object is opaque to the VM — it reads standard Python frame attributes (`f_lineno`, `f_code`). The VM doesn't need to know whether the frame came from a bridge generator, a user generator, or something else entirely.
 
@@ -368,7 +410,16 @@ See [IMPL-VM-PROTOCOL.md §3.2](IMPL-VM-PROTOCOL.md#32-effect-created_at--effect
 
 When the VM encounters an uncaught exception, it assembles trace data (`Vec<TraceEntry>`) and needs to deliver it to Python. The delivery mechanism must not use dunder attributes on exception objects.
 
-### 4.2 Solution: `DoeffTracebackData` PyClass via RunResult
+### 4.2 Current Solution: `__doeff_traceback__` on Exceptions
+
+**Status: Superseded implementation.** The shipped VM attaches traceback data
+to raised Python exceptions as `__doeff_traceback__`. `doeff.run` preserves and
+enriches that attribute before re-raising and rendering.
+
+The typed `DoeffTracebackData`/`RunResult.traceback_data` design below never
+shipped and remains historical design context.
+
+### 4.3 Historical Design: `DoeffTracebackData` PyClass via RunResult
 
 **`DoeffTracebackData`** is a frozen Rust PyClass that carries the trace entries as a typed object:
 
@@ -376,11 +427,12 @@ When the VM encounters an uncaught exception, it assembles trace data (`Vec<Trac
 |-------|------|---------|
 | `entries` | `Py<PyAny>` (Python list of trace entry tuples) | The assembled active-chain trace data |
 
-The VM delivers `DoeffTracebackData` as a field on `PyRunResult`, not as an attribute on the exception object.
+Historical design: the VM would deliver `DoeffTracebackData` as a field on
+`PyRunResult`, not as an attribute on the exception object.
 
-### 4.3 RunResult Shape
+### 4.4 Historical RunResult Shape
 
-`PyRunResult` gains a `traceback_data` field:
+Historical design: `PyRunResult` would gain a `traceback_data` field:
 
 | Field | Type | Purpose |
 |-------|------|---------|
@@ -389,15 +441,20 @@ The VM delivers `DoeffTracebackData` as a field on `PyRunResult`, not as an attr
 | `trace` | `Option<Py<PyAny>>` | Full chronological trace (when `trace=True`) |
 | `traceback_data` | `Option<Py<PyAny>>` | `DoeffTracebackData` for error cases |
 
-### 4.4 Invariants
+### 4.5 Historical Invariants
 
-- The VM never sets attributes on exception objects. Trace data is delivered via `RunResult.traceback_data`.
+- Superseded by current behavior: the VM does set `__doeff_traceback__` on
+  exception objects. The `RunResult.traceback_data` surface was never shipped.
 - The VM never imports `doeff.traceback`. Traceback projection (building `DoeffTraceback` from raw data) is a Python-side concern performed by the `RunResult` consumer.
 - The VM never reads `__doeff_traceback__` from exceptions. Display/rendering is Python-side.
 
 ---
 
 ## 5. Call Metadata Protocol
+
+**Status: Partially implemented; `DoeffGenerator` references are historical.**
+The shipped bridge records source locations from direct generator attributes,
+not from a `DoeffGenerator` wrapper.
 
 ### 5.1 CallMetadata Fields
 
@@ -493,19 +550,19 @@ The `__doeff_scheduler_*` class attributes on effect PyClasses (in effect.rs) ar
 
 | Data | Type | Delivery |
 |------|------|----------|
-| Run result | `PyRunResult` PyClass | `run()` / `async_run()` return value |
-| Trace data | `DoeffTracebackData` PyClass | Field on `PyRunResult` |
+| Run result | Plain Python value | `doeff.run(doexpr)` / `PyVM.run(doexpr)` return value |
+| Trace data | Python exception attribute | `__doeff_traceback__` attached before re-raising |
 | DoCtrl primitives | `PyDoCtrlBase` subclasses | Yielded by Python generators |
 | Continuations | `PyContinuation` PyClass | Passed to handlers |
-| Ok/Err wrappers | `PyResultOk` / `PyResultErr` PyClasses | On `PyRunResult.result` |
+| Ok/Err wrappers | `Ok` / `Err` PyClasses | Public result helpers and handler-level result values |
 
 ### Python → VM (typed inputs)
 
 | Data | Type | Delivery |
 |------|------|----------|
-| Program (entry) | Any `DoExpr` | Entry to `run()` / `async_run()` |
-| Generator (any frame push) | `DoeffGenerator` PyClass | Result of DoExpr evaluation, handler calls, `to_generator()` |
-| `get_frame` callback | `Callable[[generator], Optional[FrameType]]` | Field on `DoeffGenerator`; VM invokes on cold paths (trace assembly, error) to get live location |
+| Program (entry) | Any current `DoExpr` pyclass or `EffectBase` value | Entry to `doeff.run(doexpr)` / `PyVM.run(doexpr)` |
+| Generator stream | `IRStream` / generator object | Result of `@do` expansion and handler calls |
+| Generator location | Direct generator attribute reads | `python_generator_stream.rs` reads `gi_code` and `gi_frame.f_lineno` |
 | DoCtrl instructions | `PyDoCtrlBase` subclasses | Yielded from generators |
 | Effects | `PyEffectBase` subclasses | Yielded via `DoCtrl::Perform` |
 | Handlers | `PyRustHandlerSentinel` or raw Python callable | In `WithHandler` / handler list |
@@ -587,25 +644,34 @@ None of the handler/decorator-level `__doeff_*` dunders are read by the VM. They
 
 All silent fallbacks in VM runtime paths are prohibited. See C7. `PyCall.meta` is mandatory. `CallMetadata::anonymous()` is not used in user-facing runtime paths.
 
-### Q4: VM entry interface — RESOLVED
+### Q4: VM entry interface — CURRENT
 
-`run()` / `async_run()` accepts DoExpr, not DoeffGenerator. See C8. DoeffGenerator is the wrapper for generators produced during DoExpr evaluation, not an entry-point type.
+`doeff.run(doexpr)` and `PyVM.run(doexpr)` accept current DoExpr pyclasses and
+`EffectBase` values. `async_run` was removed; use `run(scheduled(program))`.
+`DoeffGenerator` was never shipped.
 
-### Q5: Handler generators need DoeffGenerator — RESOLVED
+### Q5: Handler generators need DoeffGenerator — HISTORICAL DESIGN, NEVER SHIPPED
 
-Handler generators must be wrapped in DoeffGenerator because they appear in the active-chain traceback. Wrapping happens at `WithHandler` registration time — the handler function is wrapped so its generator result is automatically a DoeffGenerator. See §3.8.
+Historical design: handler generators would have been wrapped in
+`DoeffGenerator` because they appear in active-chain tracebacks. The shipped
+bridge does not expose or require `DoeffGenerator`.
 
 ---
 
 ## 10. Resolved Design Questions
 
-### D1: Handler generator wrapping mechanism — RESOLVED
+### D1: Handler generator wrapping mechanism — HISTORICAL DESIGN, NEVER SHIPPED
 
-`WithHandler` wraps handler functions at registration time. When the VM calls the wrapped handler with `(effect, k)`, it receives `DoeffGenerator` directly. The VM never sees raw handler generators. See §3.8.
+Historical design: `WithHandler` would wrap handler functions at registration
+time so the VM received `DoeffGenerator` directly. The shipped bridge invokes
+handler callables and processes their `IRStream`/generator results without a
+public `DoeffGenerator` wrapper.
 
-### D2: `to_generator_strict` accepted types — RESOLVED
+### D2: `to_generator_strict` accepted types — HISTORICAL DESIGN, NEVER SHIPPED
 
-`to_generator()` is a Python-side method. It is the responsibility of `ProgramBase` implementations to return `DoeffGenerator`. The VM's `to_generator_strict` checks that the result is `DoeffGenerator`; if not, it raises an error. See §3.7 (no silent fallbacks).
+Historical design: Python-side `to_generator()` implementations would return
+`DoeffGenerator`. Current `@do` code produces `Expand(Apply(...))` with
+`IRStream`, and the VM classifies yielded values through the current bridge.
 
 ### D3: Continuation frame snapshots with `get_frame` — RESOLVED
 


### PR DESCRIPTION
## Summary

Reference: `specs-vm-status-drift`

Updates the VM specs to stop presenting removed or never-shipped APIs as implemented:

- Marks `SPEC-VM-PROTOCOL` as partially implemented, with `DoeffGenerator` and `DoeffTracebackData`/`RunResult` documented as never-shipped or superseded by the current exception attribute mechanism.
- Updates `SPEC-008` current-status notes and Python examples to use `run(doexpr)`, explicit handler factory composition, and `scheduled()` for concurrency.
- Marks `SPEC-009` as a superseded draft, adds the current implemented public contract, and moves old Python examples to historical text blocks so only current snippets are treated as executable examples.

## Validation

- `uv run python` extraction/execution of all remaining Python fenced snippets in the three touched specs: `executed 7 python snippets`.
- `rg -n '\b(PyVM|K|Callable|IRStream|EffectBase|Ok|Err|Pure|Perform|Resume|Transfer|Apply|Expand|Pass|WithHandler|ResumeThrow|TransferThrow|WithObserve|GetTraceback|GetExecutionContext|GetHandlers|GetOuterHandlers|RunResult|PyRunResult|DoeffGenerator|DoeffTracebackData|async_run|def run)\b' packages/doeff-vm/doeff_vm/__init__.pyi` to confirm the still-public stub names.
- `rg` negative check for removed/never-shipped VM names in `packages/doeff-vm/doeff_vm/__init__.pyi`: `absent in pyi: DoeffGenerator DoeffTracebackData PyRunResult RunResult async_run`.
- Runtime public/removed API check: confirmed `doeff_vm` exposes the documented current names and does not expose `DoeffGenerator`, `DoeffTracebackData`, `PyRunResult`, `RunResult`, `run`, or `async_run`; confirmed `_Removed` messages for `async_run`, `default_handlers`, `Modify`, `Delegate`, and `presets`.
- `git diff --check` passed.

## Known Existing Failure

- `uv run pytest tests/test_docs_withhandler_contract.py` currently fails on pre-existing, untouched files: `docs/crystallization/algebra-draft.md` and `docs/crystallization/constraint-graph-conductor.md` still contain current-doc `WithHandler(` mentions. The second test in that file passed. This PR does not modify those docs because they are outside `specs-vm-status-drift` scope.