### PR TITLE
[codex] Fail fast on agent protocol corruption

### DIFF
--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -126,6 +126,64 @@ rules:
         - /packages/doeff-agents/src/doeff_agents/monitor.py
         - /packages/doeff-agents/src/doeff_agents/session.py
 
+  - id: doeff-agents-agentd-request-requires-result-key
+    languages: [python]
+    severity: ERROR
+    message: >
+      agents-fail-fast-protocol: successful doeff-agentd responses must validate
+      that the result key exists. Do not use response.get("result"), which turns
+      malformed ok=true payloads into None.
+    patterns:
+      - pattern-inside: |
+          def request(...):
+              ...
+      - pattern: return $RESPONSE.get("result")
+    paths:
+      include:
+        - /packages/doeff-agents/src/doeff_agents/agentd_client.py
+
+  - id: doeff-agents-await-result-requires-protocol-fields
+    languages: [python]
+    severity: ERROR
+    message: >
+      agents-fail-fast-protocol: session.await_result must validate required
+      payload fields explicitly. Do not use dict.get() for session or result,
+      because missing or malformed daemon fields must raise AgentdProtocolError.
+    patterns:
+      - pattern-inside: |
+          def _await_outcome_from_result(...):
+              ...
+      - pattern-either:
+          - pattern: $RESULT.get("session")
+          - pattern: $RESULT.get("result")
+    paths:
+      include:
+        - /packages/doeff-agents/src/doeff_agents/agentd_client.py
+
+  - id: doeff-agents-ready-promise-fail-fast
+    languages: [generic]
+    severity: ERROR
+    message: >
+      agents-fail-fast-protocol: MCP server startup must abort if ready_promise
+      completion fails. Logging and continuing into serve_forever leaves callers
+      waiting forever for readiness.
+    pattern-regex: 'except\s+Exception:\s*\n\s+log\.exception\("Failed to complete ready_promise"\)\s*\n\s*self\.serve_forever\(\)'
+    paths:
+      include:
+        - /packages/doeff-agents/src/doeff_agents/mcp_server.py
+
+  - id: doeff-agents-mcp-loop-catches-only-queue-empty
+    languages: [generic]
+    severity: ERROR
+    message: >
+      agents-fail-fast-protocol: mcp-server-loop may catch only queue.Empty when
+      draining request_queue. Catching Exception drops poisoned requests without
+      an error response.
+    pattern-regex: '\(except\s+\[[^\]]*\bException\b[^\]]*\]\s*\(setv\s+req\s+None\)\)'
+    paths:
+      include:
+        - /packages/doeff-agents/src/doeff_agents/handlers/mcp_server_loop.hy
+
   - id: adr0001-d1-agentd-only-worker-route
     languages: [python]
     severity: ERROR

--- a/packages/doeff-agents/src/doeff_agents/agentd_client.py
+++ b/packages/doeff-agents/src/doeff_agents/agentd_client.py
@@ -1,7 +1,5 @@
 """JSON-line client for the doeff-agentd Unix socket API."""
 
-from __future__ import annotations
-
 import json
 import os
 import shlex
@@ -250,7 +248,12 @@ class AgentdClient:
             if error_code is not None and not isinstance(error_code, int):
                 raise AgentdProtocolError("doeff-agentd error_code was not an integer")
             raise AgentdClientError(error, error_code=error_code)
-        return response.get("result")
+        if "result" not in response:
+            raise AgentdProtocolError(
+                f"{method} response is missing result "
+                f"(response shape: {_mapping_shape(response)})"
+            )
+        return response["result"]
 
     def _next_request_id(self) -> int:
         with self._request_lock:
@@ -478,10 +481,29 @@ def _snapshot_from_result(result: Any) -> AgentSessionSnapshot:
 
 
 def _await_outcome_from_result(result: Mapping[str, Any]) -> AwaitOutcome:
-    session = result.get("session")
-    status = "exited"
-    if isinstance(session, Mapping):
-        status = str(session.get("status", "exited"))
+    if "session" not in result:
+        raise AgentdProtocolError(
+            "session.await_result payload is missing session "
+            f"(payload shape: {_mapping_shape(result)})"
+        )
+    session = result["session"]
+    if not isinstance(session, Mapping):
+        raise AgentdProtocolError(
+            "session.await_result session was non-object "
+            f"(session type: {type(session).__name__})"
+        )
+    if "status" not in session:
+        raise AgentdProtocolError(
+            "session.await_result session is missing status "
+            f"(session shape: {_mapping_shape(session)})"
+        )
+    status_value = session["status"]
+    if not isinstance(status_value, str):
+        raise AgentdProtocolError(
+            "session.await_result session status was not a string "
+            f"(status type: {type(status_value).__name__})"
+        )
+    status = status_value
     validation_error = result.get("validation_error")
     if validation_error is not None and not isinstance(validation_error, str):
         raise AgentdProtocolError("session.await_result validation_error was not a string")
@@ -496,10 +518,23 @@ def _await_outcome_from_result(result: Mapping[str, Any]) -> AwaitOutcome:
             continuable=False,
         )
 
-    payload = None
-    response_result = result.get("result")
-    if isinstance(response_result, Mapping):
-        payload = response_result.get("payload")
+    if "result" not in result:
+        raise AgentdProtocolError(
+            "session.await_result payload is missing result "
+            f"(payload shape: {_mapping_shape(result)})"
+        )
+    response_result = result["result"]
+    if not isinstance(response_result, Mapping):
+        raise AgentdProtocolError(
+            "session.await_result result was non-object "
+            f"(result type: {type(response_result).__name__})"
+        )
+    if "payload" not in response_result:
+        raise AgentdProtocolError(
+            "session.await_result result is missing payload "
+            f"(result shape: {_mapping_shape(response_result)})"
+        )
+    payload = response_result["payload"]
 
     return AwaitOutcome(
         status=AwaitStatus.EXITED,
@@ -507,6 +542,11 @@ def _await_outcome_from_result(result: Mapping[str, Any]) -> AwaitOutcome:
         validation_error=validation_error,
         continuable=False,
     )
+
+
+def _mapping_shape(mapping: Mapping[str, Any]) -> str:
+    fields = ", ".join(f"{key}: {type(value).__name__}" for key, value in mapping.items())
+    return f"{{{fields}}}"
 
 
 __all__ = [

--- a/packages/doeff-agents/src/doeff_agents/handlers/mcp_server_loop.hy
+++ b/packages/doeff-agents/src/doeff_agents/handlers/mcp_server_loop.hy
@@ -23,6 +23,7 @@
 (import doeff [WithHandler])
 (import doeff_core_effects.scheduler [CreateExternalPromise Wait Spawn PRIORITY_IDLE])
 (import doeff_agents.mcp-server [McpToolServer McpToolRequest])
+(import queue [Empty])
 
 
 (defk run-tool-with-stack [server full-stack req]
@@ -84,7 +85,7 @@
       (setv req None)
       (try
         (setv req (.get-nowait server.request-queue))
-        (except [_ Exception]
+        (except [_ Empty]
           (setv req None)))
       (when (is-not req None)
         (<- _ (Spawn (run-tool-with-stack server full-stack req))))))

--- a/packages/doeff-agents/src/doeff_agents/mcp_server.py
+++ b/packages/doeff-agents/src/doeff_agents/mcp_server.py
@@ -28,8 +28,6 @@ Usage (legacy):
     server.start()
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import queue
@@ -83,7 +81,7 @@ class _SseSession:
 class _McpHandler(BaseHTTPRequestHandler):
     """HTTP request handler for MCP SSE transport."""
 
-    server: McpToolServer  # type narrowing
+    server: Any
 
     # Suppress per-request logging
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A002 - public API parameter name is intentionally stable
@@ -232,7 +230,8 @@ class McpToolServer(_ThreadingHTTPServer):
     @property
     def url(self) -> str:
         """SSE endpoint URL for .mcp.json configuration."""
-        host, port = self.server_address
+        host = str(self.server_address[0])
+        port = int(self.server_address[1])
         return f"http://{host}:{port}/sse"
 
     @property
@@ -265,6 +264,7 @@ class McpToolServer(_ThreadingHTTPServer):
                 self._ready_promise.complete(None)
             except Exception:
                 log.exception("Failed to complete ready_promise")
+                raise
         self.serve_forever()
 
     def shutdown(self) -> None:

--- a/packages/doeff-agents/tests/test_agentd_client.py
+++ b/packages/doeff-agents/tests/test_agentd_client.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from doeff_agents import (
     AgentdClient,
     AgentdClientError,
+    AgentdProtocolError,
     AgentdUnavailableError,
     AgentSessionLifecycle,
     AgentType,
@@ -143,6 +144,21 @@ def test_agentd_client_raises_daemon_error() -> None:
     ):
         client = AgentdClient(server.socket_path, timeout=2.0)
         with pytest.raises(AgentdClientError, match="boom"):
+            client.status()
+
+    assert server.requests[0]["method"] == "daemon.status"
+
+
+def test_agentd_client_success_response_requires_result_key() -> None:
+    def handle(request: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {"id": request["id"], "ok": True}
+
+    with (
+        tempfile.TemporaryDirectory(prefix="agentd-", dir="/tmp") as temp_dir,
+        OneShotAgentdServer(Path(temp_dir) / "agentd.sock", handle) as server,
+    ):
+        client = AgentdClient(server.socket_path, timeout=2.0)
+        with pytest.raises(AgentdProtocolError, match="daemon.status.*missing result"):
             client.status()
 
     assert server.requests[0]["method"] == "daemon.status"
@@ -339,9 +355,47 @@ def _spy_client(captured: dict) -> AgentdClient:
             captured["read_timeout"] = read_timeout
             if method == "session.launch":
                 return _snapshot_payload()
-            return {"session": _snapshot_payload(), "result": None, "validation_error": None}
+            return {
+                "session": _snapshot_payload(),
+                "result": {"payload": None},
+                "validation_error": None,
+            }
 
     return _Spy("/tmp/unused.sock")
+
+
+class _StaticAwaitResultClient(AgentdClient):
+    def __init__(self, result: Mapping[str, Any]) -> None:
+        super().__init__("/tmp/unused.sock")
+        self.result = result
+
+    def request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None = None,
+        *,
+        read_timeout: float | None = None,
+    ) -> Any:
+        assert method == "session.await_result"
+        return self.result
+
+
+def test_await_result_rejects_missing_session() -> None:
+    client = _StaticAwaitResultClient(
+        {"result": {"payload": {"ok": True}}, "validation_error": None}
+    )
+
+    with pytest.raises(AgentdProtocolError, match="session.await_result.*missing session"):
+        client.await_result("s1", timeout_seconds=1.0)
+
+
+def test_await_result_rejects_non_object_result_payload() -> None:
+    client = _StaticAwaitResultClient(
+        {"session": _snapshot_payload(), "result": "not an object", "validation_error": None}
+    )
+
+    with pytest.raises(AgentdProtocolError, match="session.await_result result.*non-object"):
+        client.await_result("s1", timeout_seconds=1.0)
 
 
 def test_launch_read_timeout_covers_daemon_launch_budget() -> None:

--- a/packages/doeff-agents/tests/test_agentd_client.py
+++ b/packages/doeff-agents/tests/test_agentd_client.py
@@ -158,7 +158,7 @@ def test_agentd_client_success_response_requires_result_key() -> None:
         OneShotAgentdServer(Path(temp_dir) / "agentd.sock", handle) as server,
     ):
         client = AgentdClient(server.socket_path, timeout=2.0)
-        with pytest.raises(AgentdProtocolError, match="daemon.status.*missing result"):
+        with pytest.raises(AgentdProtocolError, match=r"daemon.status.*missing result"):
             client.status()
 
     assert server.requests[0]["method"] == "daemon.status"
@@ -385,7 +385,7 @@ def test_await_result_rejects_missing_session() -> None:
         {"result": {"payload": {"ok": True}}, "validation_error": None}
     )
 
-    with pytest.raises(AgentdProtocolError, match="session.await_result.*missing session"):
+    with pytest.raises(AgentdProtocolError, match=r"session.await_result.*missing session"):
         client.await_result("s1", timeout_seconds=1.0)
 
 
@@ -394,7 +394,7 @@ def test_await_result_rejects_non_object_result_payload() -> None:
         {"session": _snapshot_payload(), "result": "not an object", "validation_error": None}
     )
 
-    with pytest.raises(AgentdProtocolError, match="session.await_result result.*non-object"):
+    with pytest.raises(AgentdProtocolError, match=r"session.await_result result.*non-object"):
         client.await_result("s1", timeout_seconds=1.0)
 
 

--- a/packages/doeff-agents/tests/test_mcp_server.py
+++ b/packages/doeff-agents/tests/test_mcp_server.py
@@ -4,7 +4,6 @@ import http.client
 import json
 
 import pytest
-
 from doeff_agents.handlers import _make_run_tool
 from doeff_agents.mcp_server import McpToolServer
 
@@ -137,7 +136,7 @@ class TestServerLifecycle:
         assert server.port > 0
         server.shutdown()
 
-    def test_ready_signal_completion_failure_aborts_startup(self):
+    def test_ready_signal_completion_failure_aborts_startup(self, monkeypatch):
         class FailingReadyPromise:
             def complete(self, _value):
                 raise RuntimeError("ready already completed")
@@ -145,10 +144,10 @@ class TestServerLifecycle:
         server = McpToolServer(tools=(), run_tool=_simple_run_tool, port=0)
         server._ready_promise = FailingReadyPromise()
 
-        def serve_forever():
+        def serve_forever(_poll_interval=0.5):
             raise AssertionError("serve_forever should not start after ready failure")
 
-        server.serve_forever = serve_forever
+        monkeypatch.setattr(server, "serve_forever", serve_forever)
         try:
             with pytest.raises(RuntimeError, match="ready already completed"):
                 server._serve_with_ready_signal()

--- a/packages/doeff-agents/tests/test_mcp_server.py
+++ b/packages/doeff-agents/tests/test_mcp_server.py
@@ -3,6 +3,8 @@
 import http.client
 import json
 
+import pytest
+
 from doeff_agents.handlers import _make_run_tool
 from doeff_agents.mcp_server import McpToolServer
 
@@ -134,6 +136,24 @@ class TestServerLifecycle:
         server.start()
         assert server.port > 0
         server.shutdown()
+
+    def test_ready_signal_completion_failure_aborts_startup(self):
+        class FailingReadyPromise:
+            def complete(self, _value):
+                raise RuntimeError("ready already completed")
+
+        server = McpToolServer(tools=(), run_tool=_simple_run_tool, port=0)
+        server._ready_promise = FailingReadyPromise()
+
+        def serve_forever():
+            raise AssertionError("serve_forever should not start after ready failure")
+
+        server.serve_forever = serve_forever
+        try:
+            with pytest.raises(RuntimeError, match="ready already completed"):
+                server._serve_with_ready_signal()
+        finally:
+            server.server_close()
 
 
 # -- SSE HTTP transport tests ------------------------------------------------

--- a/packages/doeff-agents/tests/test_mcp_server_loop.py
+++ b/packages/doeff-agents/tests/test_mcp_server_loop.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import threading
 
 import hy  # noqa: F401  (enable .hy imports)
+import pytest
 from doeff_agents.handlers.mcp_server_loop import mcp_server_loop
 from doeff_agents.mcp_server import McpToolRequest, McpToolServer
 from doeff_core_effects.scheduler import scheduled
@@ -251,3 +252,36 @@ class TestMcpServerLoopMultiple:
             yield mcp_server_loop(server, [])
 
         run(scheduled(main()))  # should return, not hang
+
+
+class TestMcpServerLoopProtocolFailures:
+    def test_request_queue_unexpected_error_propagates(self):
+        """Only queue.Empty is a benign drain race; other queue errors are fatal."""
+        server = McpToolServer(tools=(_echo_tool(),))
+
+        class PoisonedQueue:
+            def __init__(self) -> None:
+                self.raised = False
+
+            def empty(self) -> bool:
+                return self.raised
+
+            def get_nowait(self):
+                self.raised = True
+                server.shutting_down = True
+                raise RuntimeError("request queue poisoned")
+
+        server.request_queue = PoisonedQueue()
+
+        def driver():
+            ep = server.wakeup_mailbox.get(timeout=5.0)
+            ep.complete(None)
+
+        threading.Thread(target=driver, daemon=True).start()
+
+        @do
+        def main():
+            yield mcp_server_loop(server, [])
+
+        with pytest.raises(RuntimeError, match="request queue poisoned"):
+            run(scheduled(main()))

--- a/packages/doeff-agents/tests/test_mcp_server_loop.py
+++ b/packages/doeff-agents/tests/test_mcp_server_loop.py
@@ -10,6 +10,7 @@ scheduler state, and Ask-resolution shared across pipeline + tool calls.
 from __future__ import annotations
 
 import threading
+from typing import Any, cast
 
 import hy  # noqa: F401  (enable .hy imports)
 import pytest
@@ -271,7 +272,7 @@ class TestMcpServerLoopProtocolFailures:
                 server.shutting_down = True
                 raise RuntimeError("request queue poisoned")
 
-        server.request_queue = PoisonedQueue()
+        server.request_queue = cast(Any, PoisonedQueue())
 
         def driver():
             ep = server.wakeup_mailbox.get(timeout=5.0)


### PR DESCRIPTION
## Summary

Fixes `agents-fail-fast-protocol`.

- Validate successful doeff-agentd responses require an explicit `result` key instead of coercing missing values to `None`.
- Validate `session.await_result` payload shape for required `session`, `session.status`, `result`, and `result.payload` fields, raising `AgentdProtocolError` on malformed daemon payloads.
- Abort MCP server startup when `ready_promise.complete(None)` fails instead of logging and continuing into `serve_forever()`.
- In the Hy MCP server loop, catch only `queue.Empty` during queue drain races; unexpected queue errors now propagate.
- Add permanent semgrep guards for the old fail-open patterns.

## TDD Evidence

Before implementation:

- Added 5 regression tests covering missing JSON-RPC `result`, malformed `await_result` payloads, ready-promise completion failure, and a poisoned MCP request queue.
- `uv run pytest ...` for the new tests failed with 5 failures, proving the tests exercised the old behavior.
- Targeted semgrep found the newly banned patterns in the old implementation.

After implementation:

- `uv run pytest packages/doeff-agents` -> `127 passed, 1 skipped`.
- `uv tool run semgrep --config .semgrep.yaml packages/doeff-agents/src/doeff_agents/agentd_client.py packages/doeff-agents/src/doeff_agents/mcp_server.py packages/doeff-agents/src/doeff_agents/handlers/mcp_server_loop.hy --error` -> 0 findings.
- `uv run ruff check packages/doeff-agents/src/doeff_agents/agentd_client.py packages/doeff-agents/src/doeff_agents/mcp_server.py packages/doeff-agents/tests/test_agentd_client.py packages/doeff-agents/tests/test_mcp_server.py packages/doeff-agents/tests/test_mcp_server_loop.py` -> passed.
- `uv run pyright packages/doeff-agents/src/doeff_agents/agentd_client.py packages/doeff-agents/src/doeff_agents/mcp_server.py` -> 0 errors.
- `PATH="$HOME/.local/bin:$PATH" make lint` -> ruff passed, pyright passed, then stopped in repository-wide semgrep on 83 pre-existing baseline findings outside this change.
- `PATH="$HOME/.local/bin:$PATH" make lint-doeff` -> doeff-linter is not installed in this environment; Makefile emitted its documented warning.

## Risk

Behavior intentionally changes malformed daemon/protocol payloads from plausible normal outcomes to typed protocol failures. Well-formed daemon responses are unchanged.