### PR TITLE
[codex] Fix scheduler cancel lifecycle

### DIFF
--- a/docs/crystallization/algebra-draft.md
+++ b/docs/crystallization/algebra-draft.md
@@ -87,7 +87,7 @@ OCaml 5から輸入: `perform` / `match_with`(WithHandler) / `resume`(non-tail) 
 ### 導出物(ライブラリ)の導出経路
 
 - `Try` = エラーチャネル(コア)上のハンドラ
-- `Local(e, p)` = `WithHandler(reader(e ⊕ outer_env), p)` + 内側ハンドラ再設置
+- `Local(e, p)` = `reader(e ⊕ outer_env)(p)` + 内側ハンドラ再設置
 - `Listen(p, T)` = ローカルWithHandlerで型Tを横取り+Pass
 - `Gather(ts)` = `traverse Wait ts`(scheduler内部で導出済み)
 - `Race/Cancel/Promise/Semaphore` = Spawn/Wait+キュー状態(scheduler.pyで実証)

--- a/docs/crystallization/constraint-graph-conductor.md
+++ b/docs/crystallization/constraint-graph-conductor.md
@@ -48,7 +48,7 @@ workspace識別(C8) <──同型── 「識別は式座標の純関数」 ─
 
 ### 核K4: await×並行性核 — C6 ⇔ C1 ⇔ 本体B10(スケジューラ=ハンドラ)
 
-- D1が「並行性は構造的」と宣言し(C6)、D1/D6がワーカー待ちをagentd RPCにし(C1)、スケジューラは協調的ハンドラである(本体B10)。**3つの選択は個々に正しいが、「RPC待ちは協調スケジューラとどう合成するか」だけが決められなかった**: `DaemonAgentHandler.handle_await_result`(doeff-agents handlers/daemon.py:298)→ `AgentdClient.await_result`(agentd_client.py:135)が同期ブロックし、`run(scheduled(WithHandler(conductor_handler, program)))`(api.py:152)のループごと止める
+- D1が「並行性は構造的」と宣言し(C6)、D1/D6がワーカー待ちをagentd RPCにし(C1)、スケジューラは協調的ハンドラである(本体B10)。**3つの選択は個々に正しいが、「RPC待ちは協調スケジューラとどう合成するか」だけが決められなかった**: `DaemonAgentHandler.handle_await_result`(doeff-agents handlers/daemon.py:298)→ `AgentdClient.await_result`(agentd_client.py:135)が同期ブロックし、`run(scheduled(conductor_handler(program)))`(api.py:152)のループごと止める
 - 帰結: **parallelは形だけで実行は直列** — live実証 2026-06-12、run `doeff-review-20260612-1`(6-branch parallel、起動5分後もセッション1個。兄弟branchはlaunchすら起きない=スケジューラ飢餓)。conductor srcに`Await`/スレッド退避は0箇所(唯一の言及はutils.py:51の深層皮肉「use Await effects in programs」)
 - **law候補**:
   - **L-K4-1(非ブロックハンドラ)**: エフェクトハンドラは無制限ブロッキングI/Oを同期実行しない。無制限待ちはスケジューラのAwait/external completion経路(scheduler.pyのexternal_queueが既に受け皿)からのみ入る

--- a/doeff/__init__.py
+++ b/doeff/__init__.py
@@ -69,9 +69,11 @@ from doeff_core_effects.scheduler import Gather as Gather
 from doeff_core_effects.scheduler import Promise as Promise
 from doeff_core_effects.scheduler import Race as Race
 from doeff_core_effects.scheduler import ReleaseSemaphore as ReleaseSemaphore
+from doeff_core_effects.scheduler import SchedulerDeadlockError as SchedulerDeadlockError
 from doeff_core_effects.scheduler import Semaphore as Semaphore
 from doeff_core_effects.scheduler import Spawn as Spawn
 from doeff_core_effects.scheduler import Task as Task
+from doeff_core_effects.scheduler import TaskCancelledError as TaskCancelledError
 from doeff_core_effects.scheduler import Wait as Wait
 
 

--- a/packages/doeff-conductor/src/doeff_conductor/handlers/utils.py
+++ b/packages/doeff-conductor/src/doeff_conductor/handlers/utils.py
@@ -4,8 +4,9 @@ import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from doeff import Effect, Pass, Resume, do
 from doeff_core_effects.scheduler import CreateExternalPromise, Wait
+
+from doeff import Effect, Pass, Resume, do
 
 if TYPE_CHECKING:
     from doeff_conductor.handlers.agent_handler import AgentHandler

--- a/packages/doeff-conductor/tests/test_k4_parallel_overlap.py
+++ b/packages/doeff-conductor/tests/test_k4_parallel_overlap.py
@@ -18,8 +18,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from doeff import Effect, Pass, Resume, Spawn, WithHandler, do, run
-from doeff_core_effects.scheduler import Gather, scheduled
 from doeff_conductor.effects.agent import AgentEffect, AgentTask
 from doeff_conductor.effects.workspace import CreateWorkspace
 from doeff_conductor.handlers.testing import MockConductorRuntime
@@ -27,7 +25,9 @@ from doeff_conductor.handlers.utils import (
     make_offloaded_scheduled_handler,
     make_scheduled_handler,
 )
+from doeff_core_effects.scheduler import Gather, scheduled
 
+from doeff import Effect, Pass, Resume, Spawn, WithHandler, do, run
 
 SIMPLE_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -226,7 +226,7 @@ class TestK4ParallelOverlap:
             conductor_handler = _build_handler_with_real_scheduler(runtime, timed)
 
             @do
-            def workflow():
+            def workflow(iteration: int = iteration):
                 workspace = yield CreateWorkspace(workspace_id=f"ws-k4r{iteration}")
                 task_a = _make_agent_task(
                     f"run-k4r{iteration}", "branch-a", workspace
@@ -274,15 +274,11 @@ class TestK4ParallelOverlap:
 
         timed = _TimedAgentHandler(runtime, delay=self.BRANCH_DELAY)
 
-        # Use the OLD blocking handler (pre-fix behaviour)
-        from doeff_conductor.effects.agent import AgentEffect as AE
-        from doeff_conductor.effects.workspace import CreateWorkspace as CW
-
         @do
         def blocking_handler(effect: Effect, k: Any):
-            if isinstance(effect, AE):
+            if isinstance(effect, AgentEffect):
                 return (yield Resume(k, timed.handle_agent(effect)))
-            if isinstance(effect, CW):
+            if isinstance(effect, CreateWorkspace):
                 return (yield Resume(k, runtime.handle_create_workspace(effect)))
             yield Pass(effect, k)
 
@@ -297,7 +293,7 @@ class TestK4ParallelOverlap:
             return results
 
         wall_start = time.monotonic()
-        result = run(scheduled(WithHandler(blocking_handler, workflow())))
+        run(scheduled(WithHandler(blocking_handler, workflow())))
         wall_elapsed = time.monotonic() - wall_start
 
         # The blocking handler should take >= sum of branch delays

--- a/packages/doeff-core-effects/doeff_core_effects/__init__.py
+++ b/packages/doeff-core-effects/doeff_core_effects/__init__.py
@@ -56,6 +56,7 @@ from doeff_core_effects.scheduler import (  # noqa: F401
     Promise,
     Race,
     ReleaseSemaphore,
+    SchedulerDeadlockError,
     Semaphore,
     Spawn,
     Task,

--- a/packages/doeff-core-effects/doeff_core_effects/scheduler.py
+++ b/packages/doeff-core-effects/doeff_core_effects/scheduler.py
@@ -105,6 +105,27 @@ class TaskCancelledError(Exception):
     """Raised when waiting on a cancelled task."""
 
 
+class SchedulerDeadlockError(RuntimeError):
+    """Raised when the scheduler has parked work that cannot make progress."""
+
+    def __init__(self, semaphore_waiters):
+        self.semaphore_waiters = {
+            sem_id: list(task_ids)
+            for sem_id, task_ids in semaphore_waiters.items()
+        }
+        details = []
+        for sem_id, task_ids in self.semaphore_waiters.items():
+            if task_ids:
+                task_list = ", ".join(str(task_id) for task_id in task_ids)
+                details.append(f"semaphore {sem_id}: tasks {task_list}")
+            else:
+                details.append(f"semaphore {sem_id}: root continuation")
+        super().__init__(
+            "scheduler deadlock: semaphore waiters remain with no runnable tasks "
+            f"({'; '.join(details)})"
+        )
+
+
 class Race(EffectBase):
     def __init__(self, *tasks):
         super().__init__()
@@ -229,8 +250,8 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
     insertion_seq = [0]  # tie-breaker for priority queue (FIFO within same priority)
     tasks = {}           # tid → {status, result, program, priority}
     promises = {}        # pid → {status, result}
-    semaphores = {}      # sid → {permits, max_permits, waiters: deque of k}
-    waiters = {}         # waitable_key → [(type, k, ...)] or gather/race-state refs
+    semaphores = {}      # sid → {permits, max_permits, waiters: deque of (owner_tid, k)}
+    waiters = {}         # waitable_key → [(type, owner_tid, k/state, ...)]
     ready = []           # heapq: (-priority, seq, entry)
     external_queue = queue_mod.Queue()  # thread-safe, blocking get()
 
@@ -267,6 +288,18 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             _, _, entry = heapq.heappop(ready)
             return entry
         return None
+
+    def is_owner_cancelled(owner_tid):
+        return (
+            owner_tid is not None
+            and tasks.get(owner_tid, {}).get("status") == "cancelled"
+        )
+
+    def enqueue_resume(owner_tid, cont, value, priority=PRIORITY_NORMAL):
+        enqueue(("resume", owner_tid, cont, value), priority)
+
+    def enqueue_raise(owner_tid, cont, error, priority=PRIORITY_NORMAL):
+        enqueue(("raise", owner_tid, cont, error), priority)
 
     def alloc_task(program, priority=PRIORITY_NORMAL, inner_handlers=None):
         tid = fresh_id()
@@ -309,7 +342,41 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             promises[pid]["result"] = value
             wake_waiters(("promise", pid))
 
-    def pick_next():
+    def live_semaphore_waiters():
+        """Return live semaphore waiters, pruning cancelled task continuations."""
+        blocked = {}
+        for sid, sem in semaphores.items():
+            original_waiters = list(sem["waiters"])
+            live_waiters = [
+                waiter
+                for waiter in original_waiters
+                if not is_owner_cancelled(waiter[0])
+            ]
+            if len(live_waiters) != len(original_waiters):
+                sem["waiters"].clear()
+                sem["waiters"].extend(live_waiters)
+            if live_waiters:
+                blocked[sid] = [
+                    owner_tid
+                    for owner_tid, _waiter_k in live_waiters
+                    if owner_tid is not None
+                ]
+        return blocked
+
+    def has_pending_external_waiters():
+        for key, entries in waiters.items():
+            kind, wid = key
+            if kind != "promise":
+                continue
+            promise = promises.get(wid, {})
+            if not promise.get("external") or promise.get("status") in terminal_statuses:
+                continue
+            for entry in entries:
+                if len(entry) >= 2 and not is_owner_cancelled(entry[1]):
+                    return True
+        return False
+
+    def pick_next():  # noqa: PLR0912 - scheduler dispatch loop has one branch per ready entry
         from doeff.program import ResumeThrow
         while True:
             drain()
@@ -324,28 +391,37 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                     # Re-wrap task with inner handlers captured at spawn site
                     for h in tasks[tid].pop("inner_handlers", []):
                         prog = WithHandler(h, prog)
-                    return WithHandler(handler, wrap_task(tid, prog))
+                    return WithHandler(make_handler(tid), wrap_task(tid, prog))
                 if entry[0] == "resume":
-                    _, cont, value = entry
+                    _, owner_tid, cont, value = entry
+                    if is_owner_cancelled(owner_tid):
+                        continue
                     return Transfer(cont, value)
                 if entry[0] == "raise":
-                    _, cont, error = entry
+                    _, owner_tid, cont, error = entry
+                    if is_owner_cancelled(owner_tid):
+                        continue
                     return ResumeThrow(cont, error)
                 if entry[0] == "wait_external":
                     # Task waiting for external promise at NORMAL priority.
                     # Keeps IDLE tasks (clock driver) from running.
-                    _, cont, wk = entry
+                    _, owner_tid, cont, wk = entry
+                    if is_owner_cancelled(owner_tid):
+                        continue
                     if waitable_status(wk)[0] in terminal_statuses:
-                        resume_with_waitable_result(cont, wk)
+                        resume_with_waitable_result(owner_tid, cont, wk)
                         continue
                     # Not yet resolved — block for one completion, drain rest
                     _drain_one_external()
                     drain()
                     if waitable_status(wk)[0] in terminal_statuses:
-                        resume_with_waitable_result(cont, wk)
+                        resume_with_waitable_result(owner_tid, cont, wk)
                     else:
                         enqueue(entry, PRIORITY_EXTERNAL_WAIT)
                     continue
+            blocked_semaphore_waiters = live_semaphore_waiters()
+            if blocked_semaphore_waiters and not has_pending_external_waiters():
+                raise SchedulerDeadlockError(blocked_semaphore_waiters)
             if not waiters:
                 return Pure(None)
             # All tasks blocked — block for one external completion
@@ -367,16 +443,16 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
         t.pop("inner_handlers", None)
         t.pop("spawn_site", None)
 
-    def resume_with_waitable_result(waiter_k, key):
+    def resume_with_waitable_result(owner_tid, waiter_k, key):
         """Add a ready entry that resumes waiter with the waitable's result.
         For failed/cancelled, uses ("raise", k, error) so handler can throw."""
         status, result = waitable_status(key)
         if status == "completed":
-            enqueue(("resume", waiter_k, result))
+            enqueue_resume(owner_tid, waiter_k, result)
         elif status == "failed":
-            enqueue(("raise", waiter_k, result))
+            enqueue_raise(owner_tid, waiter_k, result)
         elif status == "cancelled":
-            enqueue(("raise", waiter_k, TaskCancelledError()))
+            enqueue_raise(owner_tid, waiter_k, TaskCancelledError())
 
     def remove_gather_waiters(gather_state):
         """Remove unresolved waiter refs for a fail-fast Gather resolution."""
@@ -387,7 +463,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             remaining_entries = [
                 entry
                 for entry in entries
-                if not (entry[0] == "gather" and entry[1] is gather_state)
+                if not (entry[0] == "gather" and entry[2] is gather_state)
             ]
             if remaining_entries:
                 waiters[wk] = remaining_entries
@@ -400,7 +476,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
         gather_state["resolved"] = True
         gather_state["failure"] = error
         remove_gather_waiters(gather_state)
-        enqueue(("raise", gather_state["waiter_k"], error))
+        enqueue_raise(gather_state["owner_tid"], gather_state["waiter_k"], error)
 
     def wake_gather_waiter(gather_state, completed_key):
         if gather_state["resolved"]:
@@ -421,7 +497,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
         if gather_state["remaining"] == 0:
             gather_state["resolved"] = True
             results = [waitable_status(wk)[1] for wk in gather_state["keys"]]
-            enqueue(("resume", gather_state["waiter_k"], results))
+            enqueue_resume(gather_state["owner_tid"], gather_state["waiter_k"], results)
 
     def remove_race_waiters(race_state):
         """Remove unresolved sibling waiter refs after Race has a winner."""
@@ -432,7 +508,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             remaining_entries = [
                 entry
                 for entry in entries
-                if not (entry[0] == "race" and entry[1] is race_state)
+                if not (entry[0] == "race" and entry[2] is race_state)
             ]
             if remaining_entries:
                 waiters[wk] = remaining_entries
@@ -450,23 +526,23 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
         race_state["resolved"] = True
         remove_race_waiters(race_state)
         if status == "completed":
-            enqueue(("resume", race_state["waiter_k"], result))
+            enqueue_resume(race_state["owner_tid"], race_state["waiter_k"], result)
         elif status == "failed":
-            enqueue(("raise", race_state["waiter_k"], result))
+            enqueue_raise(race_state["owner_tid"], race_state["waiter_k"], result)
         elif status == "cancelled":
-            enqueue(("raise", race_state["waiter_k"], TaskCancelledError()))
+            enqueue_raise(race_state["owner_tid"], race_state["waiter_k"], TaskCancelledError())
 
     def wake_waiters(completed_key):
         ws = waiters.pop(completed_key, [])
         for w in ws:
             if w[0] == "wait":
-                _, waiter_k = w
-                resume_with_waitable_result(waiter_k, completed_key)
+                _, owner_tid, waiter_k = w
+                resume_with_waitable_result(owner_tid, waiter_k, completed_key)
             elif w[0] == "gather":
-                _, gather_state = w
+                _, _owner_tid, gather_state = w
                 wake_gather_waiter(gather_state, completed_key)
             elif w[0] == "race":
-                _, race_state = w
+                _, _owner_tid, race_state = w
                 wake_race_waiter(race_state, completed_key)
 
     def drain():
@@ -478,8 +554,22 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                 promises[pid]["result"] = value
                 wake_waiters(("promise", pid))
 
+    def pop_live_semaphore_waiter(sem):
+        while sem["waiters"]:
+            owner_tid, waiter_k = sem["waiters"].popleft()
+            if is_owner_cancelled(owner_tid):
+                continue
+            return owner_tid, waiter_k
+        return None
+
+    def make_handler(current_tid):
+        @do
+        def handler(effect, k):
+            return (yield TailEval(handle_scheduler_effect(current_tid, effect, k)))
+        return handler
+
     @do
-    def handler(effect, k):  # noqa: PLR0911, PLR0912, PLR0915 - baseline cleanup keeps existing control flow unchanged
+    def handle_scheduler_effect(current_tid, effect, k):  # noqa: PLR0911, PLR0912, PLR0915 - baseline cleanup keeps existing control flow unchanged
         drain()
         if isinstance(effect, Spawn):
             # Capture inner handlers from continuation (between yield site and scheduler).
@@ -497,28 +587,31 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             tid = alloc_task(effect.program, effect.priority, inner_handlers=inner_handlers)
             tasks[tid]["spawn_site"] = spawn_site
             enqueue(("new", tid), effect.priority)
-            enqueue(("resume", k, Task(tid)))  # spawner resumes at normal priority
+            enqueue_resume(current_tid, k, Task(tid))  # spawner resumes at normal priority
             yield TailEval(pick_next())
 
         elif isinstance(effect, TaskCompleted):
             tid = effect.task_id
             r = effect.result
-            if hasattr(r, "is_ok") and r.is_ok():
-                tasks[tid]["status"] = "completed"
-                tasks[tid]["result"] = r.value
+            if tasks[tid]["status"] == "cancelled":
+                _release_task_refs(tid)
             else:
-                tasks[tid]["status"] = "failed"
-                error = r.error if hasattr(r, "error") else r
-                # Add spawn boundary to traceback
-                if isinstance(error, BaseException) and hasattr(error, "__doeff_traceback__"):
-                    error.__doeff_traceback__.insert(0, {
-                        "kind": "spawn_boundary",
-                        "task_id": tid,
-                        "spawn_site": tasks[tid].get("spawn_site", ""),
-                    })
-                tasks[tid]["result"] = error
-            wake_waiters(("task", tid))
-            _release_task_refs(tid)
+                if hasattr(r, "is_ok") and r.is_ok():
+                    tasks[tid]["status"] = "completed"
+                    tasks[tid]["result"] = r.value
+                else:
+                    tasks[tid]["status"] = "failed"
+                    error = r.error if hasattr(r, "error") else r
+                    # Add spawn boundary to traceback
+                    if isinstance(error, BaseException) and hasattr(error, "__doeff_traceback__"):
+                        error.__doeff_traceback__.insert(0, {
+                            "kind": "spawn_boundary",
+                            "task_id": tid,
+                            "spawn_site": tasks[tid].get("spawn_site", ""),
+                        })
+                    tasks[tid]["result"] = error
+                wake_waiters(("task", tid))
+                _release_task_refs(tid)
             yield TailEval(pick_next())
 
         elif isinstance(effect, Wait):
@@ -544,12 +637,12 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                     # promise — drain() wakes it when the promise resolves,
                     # and the clock driver is free to advance sim time.
                     if effect.priority == PRIORITY_IDLE:
-                        waiters.setdefault(wk, []).append(("wait", k))
+                        waiters.setdefault(wk, []).append(("wait", current_tid, k))
                     else:
-                        enqueue(("wait_external", k, wk), PRIORITY_EXTERNAL_WAIT)
+                        enqueue(("wait_external", current_tid, k, wk), PRIORITY_EXTERNAL_WAIT)
                 else:
                     # Internal promise: use waiters (resolved by other tasks)
-                    waiters.setdefault(wk, []).append(("wait", k))
+                    waiters.setdefault(wk, []).append(("wait", current_tid, k))
                 yield TailEval(pick_next())
 
         elif isinstance(effect, Gather):
@@ -572,6 +665,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                 return r
 
             gather_state = {
+                "owner_tid": current_tid,
                 "waiter_k": k,
                 "keys": wks,
                 "pending_keys": pending_wks,
@@ -580,7 +674,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                 "resolved": False,
             }
             for wk in pending_wks:
-                waiters.setdefault(wk, []).append(("gather", gather_state))
+                waiters.setdefault(wk, []).append(("gather", current_tid, gather_state))
             yield TailEval(pick_next())
 
         elif isinstance(effect, Race):
@@ -602,12 +696,13 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                     pending_wks.append(wk)
             if pending_wks:
                 race_state = {
+                    "owner_tid": current_tid,
                     "waiter_k": k,
                     "pending_keys": pending_wks,
                     "resolved": False,
                 }
                 for wk in pending_wks:
-                    waiters.setdefault(wk, []).append(("race", race_state))
+                    waiters.setdefault(wk, []).append(("race", current_tid, race_state))
             yield TailEval(pick_next())
 
         elif isinstance(effect, Cancel):
@@ -635,7 +730,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             # run first.  The main user is the sim clock driver which is
             # Spawned at IDLE — without this it would be promoted to
             # NORMAL and race with the tasks it just woke.
-            enqueue(("resume", k, None), PRIORITY_IDLE)
+            enqueue_resume(current_tid, k, None, PRIORITY_IDLE)
             yield TailEval(pick_next())
 
         elif isinstance(effect, FailPromise):
@@ -643,7 +738,7 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
             promises[pid]["status"] = "failed"
             promises[pid]["result"] = effect.error
             wake_waiters(("promise", pid))
-            enqueue(("resume", k, None), PRIORITY_IDLE)
+            enqueue_resume(current_tid, k, None, PRIORITY_IDLE)
             yield TailEval(pick_next())
 
         elif isinstance(effect, CreateExternalPromise):
@@ -676,16 +771,17 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
                 return r
             else:
                 # Park — FIFO queue
-                sem["waiters"].append(k)
+                sem["waiters"].append((current_tid, k))
                 yield TailEval(pick_next())
 
         elif isinstance(effect, ReleaseSemaphore):
             sid = effect.semaphore.sem_id
             sem = semaphores[sid]
-            if sem["waiters"]:
+            waiter = pop_live_semaphore_waiter(sem)
+            if waiter is not None:
                 # Transfer permit directly to first waiter
-                waiter_k = sem["waiters"].popleft()
-                enqueue(("resume", waiter_k, None))
+                owner_tid, waiter_k = waiter
+                enqueue_resume(owner_tid, waiter_k, None)
             else:
                 if sem["permits"] >= sem["max_permits"]:
                     from doeff.program import ResumeThrow
@@ -697,4 +793,4 @@ def scheduled(body_program):  # noqa: PLR0915 - baseline cleanup keeps existing 
         else:
             yield Pass(effect, k)
 
-    return WithHandler(handler, body_program)
+    return WithHandler(make_handler(None), body_program)

--- a/tests/laws/test_generator_laws.py
+++ b/tests/laws/test_generator_laws.py
@@ -9,7 +9,7 @@ Law IDs map to algebra-draft.md. Negative tests (assert_not_equiv) lock in
 refutations discovered in the 2026-06-12 adversarial-attack session — they are
 executable documentation that a tempting rewrite is ILLEGAL.
 
-S6 (state×continuation sharing) is covered by the existing
+S6 (state-continuation sharing) is covered by the existing
 tests/effects/test_effect_combinations.py::TestSafeNonRollbackLaw.
 """
 
@@ -33,7 +33,6 @@ from doeff import (
     do,
 )
 from tests._run_helpers import run_with_defaults
-
 
 # ============================================================================
 # Harness
@@ -66,7 +65,8 @@ def assert_not_equiv(lhs_thunk, rhs_thunk, *, env=None, store=None):
     """Refutation lock: the two sides MUST differ (both Ok, different values)."""
     lhs = run1(lhs_thunk, env=env, store=store)
     rhs = run1(rhs_thunk, env=env, store=store)
-    assert lhs.is_ok() and rhs.is_ok(), f"expected Ok/Ok: LHS={lhs!r} RHS={rhs!r}"
+    assert lhs.is_ok(), f"expected Ok LHS={lhs!r}"
+    assert rhs.is_ok(), f"expected Ok RHS={rhs!r}"
     assert lhs.value != rhs.value, (
         f"refutation vanished — sides now agree on {lhs.value!r}; "
         "either the law became unconditional (update algebra-draft) or "
@@ -284,7 +284,6 @@ class TestWriterLaws:
 def _tell_seq(messages):
     for m in messages:
         yield Tell(m)
-    return None
 
 
 # ============================================================================
@@ -334,7 +333,7 @@ class TestAwaitLaws:
         assert_equiv(lhs, rhs)
 
     @pytest.mark.skip(
-        reason="AW2 counterexample (async × multi-task: yield-point count is "
+        reason="AW2 counterexample (async x multi-task: yield-point count is "
         "observable) needs the deterministic sim driver to be reproducible — "
         "real-clock schedules are flaky. Blocked on strategy priority 3 "
         "(deterministic simulator). See algebra-draft.md §3 G4 / D17."
@@ -500,7 +499,8 @@ class TestConcurrencyLaws:
 
         first = run1(main, store={})
         second = run1(main, store={})
-        assert first.is_ok() and second.is_ok()
+        assert first.is_ok()
+        assert second.is_ok()
         assert first.value == second.value, (
             f"scheduler nondeterminism detected:\n{first.value}\n{second.value}"
         )
@@ -529,4 +529,3 @@ def _noop():
 @do
 def _completer(promise):
     yield CompletePromise(promise, "done")
-    return None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,12 +5,15 @@ import threading
 from types import FrameType
 from typing import Any
 
+import pytest
 from doeff_core_effects.scheduler import (
     PRIORITY_IDLE,
+    AcquireSemaphore,
     Cancel,
     CompletePromise,
     CreateExternalPromise,
     CreatePromise,
+    CreateSemaphore,
     Gather,
     Race,
     Spawn,
@@ -90,6 +93,27 @@ def _count_waitable_status_calls_for_gather(total: int) -> int:
 
     assert result == list(range(total))
     return calls
+
+
+def _run_scheduled_with_timeout(program: Any, timeout: float = 0.5) -> Any:
+    result: dict[str, Any] = {}
+    error: dict[str, BaseException] = {}
+
+    def worker() -> None:
+        try:
+            result["value"] = doeff_run(scheduled(program))
+        except BaseException as exc:  # pragma: no cover - helper re-raises in caller
+            error["value"] = exc
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+    assert not thread.is_alive(), "scheduler blocked after cancelled external wait"
+
+    if "value" in error:
+        raise error["value"]
+
+    return result["value"]
 
 
 # ---------------------------------------------------------------------------
@@ -737,6 +761,66 @@ class TestCancel:
 
         assert doeff_run(scheduled(body())) == "cancelled"
 
+    def test_cancelled_promise_waiter_does_not_resume_when_promise_completes(self):
+        """Cancelled tasks parked on a promise must not resume later."""
+        events: list[str] = []
+
+        @do
+        def blocked_task(gate: Any):
+            events.append("waiting")
+            _ = yield Wait(gate.future)
+            events.append("resumed")
+            return "resumed"
+
+        @do
+        def body():
+            gate = yield CreatePromise()
+            task = yield Spawn(blocked_task(gate))
+
+            yield Cancel(task)
+            yield CompletePromise(gate, "late")
+
+            try:
+                yield Wait(task)
+                return ("completed", list(events))
+            except TaskCancelledError:
+                return ("cancelled", list(events))
+
+        assert doeff_run(scheduled(body())) == ("cancelled", ["waiting"])
+
+    def test_cancelled_external_waiter_does_not_block_scheduler(self):
+        """A cancelled external wait entry must not block later scheduler progress."""
+        events: list[str] = []
+
+        @do
+        def blocked_task(external_promise: Any):
+            events.append("waiting")
+            _ = yield Wait(external_promise.future)
+            events.append("resumed")
+            return "resumed"
+
+        @do
+        def release_gate(gate: Any):
+            yield CompletePromise(gate, "released")
+
+        @do
+        def body():
+            external_promise = yield CreateExternalPromise()
+            gate = yield CreatePromise()
+            task = yield Spawn(blocked_task(external_promise))
+
+            yield Cancel(task)
+            _ = yield Spawn(release_gate(gate), priority=PRIORITY_IDLE)
+            gate_value = yield Wait(gate.future)
+
+            try:
+                yield Wait(task)
+                return ("completed", gate_value, list(events))
+            except TaskCancelledError:
+                return ("cancelled", gate_value, list(events))
+
+        assert _run_scheduled_with_timeout(body()) == ("cancelled", "released", ["waiting"])
+
     def test_cancel_does_not_affect_completed(self):
         """Cancelling an already-completed task is a no-op."""
         from doeff_core_effects.scheduler import Cancel
@@ -885,3 +969,29 @@ class TestSemaphore:
                 return str(e)
 
         assert "too many" in doeff_run(scheduled(body()))
+
+    def test_semaphore_only_deadlock_raises_scheduler_deadlock_error(self):
+        """Semaphore waiters must keep the scheduler from silently returning None."""
+        from doeff_core_effects.scheduler import SchedulerDeadlockError
+
+        @do
+        def waiter(sem: Any):
+            yield AcquireSemaphore(sem)
+            return "acquired"
+
+        @do
+        def body():
+            sem = yield CreateSemaphore(1)
+            yield AcquireSemaphore(sem)
+            _ = yield Spawn(waiter(sem))
+            _ = yield Spawn(waiter(sem))
+            yield AcquireSemaphore(sem)
+            return "should not reach"
+
+        with pytest.raises(SchedulerDeadlockError) as exc_info:
+            doeff_run(scheduled(body()))
+
+        error = exc_info.value
+        assert error.semaphore_waiters == {0: [1, 2]}
+        assert "semaphore 0" in str(error)
+        assert "tasks 1, 2" in str(error)


### PR DESCRIPTION
Reference: scheduler-cancel-lifecycle

## Summary
- Enforce cancellation at scheduler resume boundaries by carrying owner task ids on parked continuations and skipping continuations owned by cancelled tasks.
- Preserve terminal cancelled status so TaskCompleted/TaskFailed cannot overwrite cancelled tasks.
- Drop cancelled external wait entries before blocking on external queues.
- Add SchedulerDeadlockError for semaphore-only deadlocks, including parked semaphore/task details.
- Integrate latest Race waiter registration behavior with owner-aware race waiter state.
- Clean up newly merged law/conductor lint issues and update stale crystallization docs WithHandler snippets.

## Acceptance Evidence
- Added and red-checked focused repros for zombie promise waiter resume, cancelled external waits, and semaphore-only deadlock behavior before implementing the fix.
- `uv run ruff check doeff/ tests/ packages/` -> All checks passed.
- `uv run pyright doeff/` -> 0 errors, 0 warnings, 0 informations.
- `uv run pytest tests/` -> 874 passed, 90 skipped, 55108 warnings in 48.71s.

## Notes
- Full-suite setup required installing the editable `packages/doeff-traverse` dependency after `make sync` could not rebuild the Rust VM extension because `maturin` is unavailable in this environment.